### PR TITLE
Integrate de-async branch of aptos-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "proc-macro2 1.0.81",
  "quote 1.0.36",
@@ -210,7 +210,7 @@ checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -223,7 +223,7 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -233,7 +233,7 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -248,7 +248,7 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -294,7 +294,7 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -324,7 +324,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "hex",
@@ -333,7 +333,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -342,7 +342,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -378,7 +378,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "futures",
  "rustversion",
@@ -410,7 +410,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "shadow-rs",
 ]
@@ -418,7 +418,7 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -433,7 +433,7 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -445,7 +445,7 @@ dependencies = [
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -457,7 +457,7 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -503,20 +503,18 @@ dependencies = [
  "aptos-short-hex-str",
  "aptos-types",
  "bcs 0.1.4",
- "futures",
  "itertools 0.10.5",
  "mirai-annotations",
  "once_cell",
  "rand 0.7.3",
  "rayon",
  "serde",
- "tokio",
 ]
 
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-crypto-derive",
@@ -562,7 +560,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "proc-macro2 1.0.81",
  "quote 1.0.36",
@@ -572,7 +570,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-config",
  "aptos-crypto",
@@ -603,7 +601,7 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
@@ -651,7 +649,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -678,12 +676,11 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-crypto",
  "aptos-crypto-derive",
- "aptos-runtimes",
  "bcs 0.1.4",
  "bellman",
  "blst",
@@ -711,7 +708,7 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-experimental-runtimes",
  "aptos-infallible",
@@ -723,7 +720,7 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -740,7 +737,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-block-partitioner",
@@ -774,7 +771,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-block-partitioner",
@@ -811,7 +808,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -834,7 +831,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-block-partitioner",
@@ -856,7 +853,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-runtimes",
  "core_affinity",
@@ -864,13 +861,12 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "rayon",
- "tokio",
 ]
 
 [[package]]
 name = "aptos-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -904,7 +900,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -919,7 +915,7 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -994,7 +990,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "either",
  "move-core-types",
@@ -1003,7 +999,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -1019,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1042,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
@@ -1057,7 +1053,7 @@ dependencies = [
 [[package]]
 name = "aptos-genesis"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -1082,22 +1078,22 @@ dependencies = [
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1125,7 +1121,7 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1135,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
@@ -1182,7 +1178,7 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1196,7 +1192,7 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "proc-macro2 1.0.81",
  "quote 1.0.36",
@@ -1206,7 +1202,7 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-infallible",
  "aptos-log-derive",
@@ -1230,7 +1226,7 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
@@ -1244,7 +1240,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -1284,7 +1280,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-runtimes",
  "aptos-types",
@@ -1298,7 +1294,7 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-infallible",
  "bytes",
@@ -1309,7 +1305,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -1318,7 +1314,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-gas-schedule",
@@ -1344,7 +1340,7 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -1367,7 +1363,7 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -1384,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
@@ -1401,7 +1397,7 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1449,7 +1445,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -1461,7 +1457,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-build-info",
  "aptos-infallible",
@@ -1477,7 +1473,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "proc-macro2 1.0.81",
  "quote 1.0.36",
@@ -1487,7 +1483,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -1500,7 +1496,7 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1513,7 +1509,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-config",
  "aptos-types",
@@ -1526,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -1536,7 +1532,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -1549,7 +1545,7 @@ dependencies = [
 [[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "ipnet",
 ]
@@ -1557,7 +1553,7 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -1568,7 +1564,7 @@ dependencies = [
 [[package]]
 name = "aptos-rate-limiter"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-infallible",
  "aptos-logger",
@@ -1582,7 +1578,7 @@ dependencies = [
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -1608,7 +1604,7 @@ dependencies = [
 [[package]]
 name = "aptos-retrier"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-logger",
  "tokio",
@@ -1617,7 +1613,7 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-config",
  "rocksdb",
@@ -1626,7 +1622,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "rayon",
  "tokio",
@@ -1635,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -1652,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-crypto",
  "aptos-drop-helper",
@@ -1672,7 +1668,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -1693,7 +1689,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -1712,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -1731,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1753,7 +1749,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -1764,7 +1760,7 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -1776,7 +1772,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1808,7 +1804,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -1822,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-compression",
  "aptos-config",
@@ -1838,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-gas-schedule",
@@ -1859,7 +1855,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -1868,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -1881,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1932,12 +1928,12 @@ dependencies = [
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
@@ -1953,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -1987,7 +1983,6 @@ dependencies = [
  "dashmap",
  "derive_more",
  "fail 0.5.1",
- "futures",
  "hex",
  "jsonwebtoken",
  "move-binary-format",
@@ -2010,7 +2005,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -2032,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -2047,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2068,7 +2063,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "aptos-event-notifications",
@@ -6390,7 +6385,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6407,7 +6402,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -6422,12 +6417,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6442,7 +6437,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6454,7 +6449,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -6469,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "clap 4.5.4",
@@ -6486,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6532,7 +6527,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "difference",
@@ -6549,7 +6544,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6578,7 +6573,7 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -6611,7 +6606,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6636,7 +6631,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6656,7 +6651,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "clap 4.5.4",
@@ -6674,7 +6669,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6693,7 +6688,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6707,7 +6702,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6726,7 +6721,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6745,7 +6740,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "hex",
@@ -6758,7 +6753,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "hex",
@@ -6772,7 +6767,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6800,7 +6795,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6837,7 +6832,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6876,7 +6871,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6906,7 +6901,7 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -6937,7 +6932,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6965,7 +6960,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "abstract-domain-derive",
  "codespan",
@@ -6992,7 +6987,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "hex",
@@ -7015,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "once_cell",
  "serde",
@@ -7024,7 +7019,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7042,7 +7037,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "better_any",
@@ -7073,7 +7068,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "better_any",
  "bytes",
@@ -7098,7 +7093,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7113,7 +7108,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=8319a2b3647452dabe624ac5b7e3de650b8bad45#8319a2b3647452dabe624ac5b7e3de650b8bad45"
 dependencies = [
  "bcs 0.1.4",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,30 +131,30 @@ ethers-middleware = { version = "=2.0.10", default-features = false }
 # Aptos dependencies
 # We use a forked version so that we can override dependency versions. This is required
 # to be avoid depenedency conflicts with other Sovereign Labs crates.
-aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", branch = "monza" }
-aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", branch = "monza" }
-aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
-aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", branch = "monza" }
+aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
+aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "8319a2b3647452dabe624ac5b7e3de650b8bad45" }
 
 move-binary-format = { git = "https://github.com/diem/move" }
 move-table-extension = { git = "https://github.com/diem/move" }


### PR DESCRIPTION
Removing async from `aptos-consensus-types` and `aptos-vm` as per https://github.com/movementlabsxyz/aptos-core/pull/7.