### PR TITLE
Broken Monza Executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "proc-macro2 1.0.81",
  "quote 1.0.36",
@@ -210,7 +210,7 @@ checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -223,7 +223,7 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -233,7 +233,7 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -248,7 +248,7 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -294,7 +294,7 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -324,7 +324,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "hex",
@@ -333,7 +333,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -342,7 +342,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -368,7 +368,7 @@ dependencies = [
  "move-vm-types",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "rand 0.7.3",
  "rayon",
  "scopeguard",
@@ -378,7 +378,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "futures",
  "rustversion",
@@ -410,7 +410,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "shadow-rs",
 ]
@@ -418,7 +418,7 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -433,7 +433,7 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -445,7 +445,7 @@ dependencies = [
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -457,7 +457,7 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-crypto-derive",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "proc-macro2 1.0.81",
  "quote 1.0.36",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-config",
  "aptos-crypto",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
@@ -651,7 +651,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-experimental-runtimes",
  "aptos-infallible",
@@ -723,7 +723,7 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-block-partitioner",
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-block-partitioner",
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -834,7 +834,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-block-partitioner",
@@ -856,7 +856,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-runtimes",
  "core_affinity",
@@ -870,7 +870,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -904,7 +904,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -994,7 +994,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "either",
  "move-core-types",
@@ -1003,7 +1003,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -1019,7 +1019,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1042,7 +1042,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
@@ -1057,7 +1057,7 @@ dependencies = [
 [[package]]
 name = "aptos-genesis"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -1082,22 +1082,22 @@ dependencies = [
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1125,7 +1125,7 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1135,7 +1135,7 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
@@ -1182,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1196,7 +1196,7 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "proc-macro2 1.0.81",
  "quote 1.0.36",
@@ -1206,7 +1206,7 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-infallible",
  "aptos-log-derive",
@@ -1230,7 +1230,7 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
@@ -1244,7 +1244,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -1284,7 +1284,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-runtimes",
  "aptos-types",
@@ -1298,7 +1298,7 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-infallible",
  "bytes",
@@ -1309,7 +1309,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -1318,7 +1318,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-gas-schedule",
@@ -1344,7 +1344,7 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -1367,7 +1367,7 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -1384,7 +1384,7 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
@@ -1401,7 +1401,7 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1449,7 +1449,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -1461,7 +1461,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-build-info",
  "aptos-infallible",
@@ -1477,7 +1477,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "proc-macro2 1.0.81",
  "quote 1.0.36",
@@ -1487,7 +1487,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -1500,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1513,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-config",
  "aptos-types",
@@ -1526,7 +1526,7 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -1536,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -1549,7 +1549,7 @@ dependencies = [
 [[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "ipnet",
 ]
@@ -1557,7 +1557,7 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -1568,7 +1568,7 @@ dependencies = [
 [[package]]
 name = "aptos-rate-limiter"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-infallible",
  "aptos-logger",
@@ -1582,7 +1582,7 @@ dependencies = [
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "aptos-retrier"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-logger",
  "tokio",
@@ -1617,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-config",
  "rocksdb",
@@ -1626,7 +1626,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "rayon",
  "tokio",
@@ -1635,7 +1635,7 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -1652,7 +1652,7 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-crypto",
  "aptos-drop-helper",
@@ -1672,7 +1672,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -1693,7 +1693,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -1712,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -1731,7 +1731,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1753,7 +1753,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -1764,7 +1764,7 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -1776,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1795,7 +1795,7 @@ dependencies = [
  "itertools 0.10.5",
  "move-core-types",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "proptest",
  "proptest-derive 0.4.0",
  "rayon",
@@ -1808,7 +1808,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -1822,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-compression",
  "aptos-config",
@@ -1838,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-gas-schedule",
@@ -1859,7 +1859,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -1868,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -1881,7 +1881,7 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1932,12 +1932,12 @@ dependencies = [
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
@@ -1953,7 +1953,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2010,7 +2010,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -2032,7 +2032,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -2047,7 +2047,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2068,7 +2068,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "aptos-event-notifications",
@@ -3725,7 +3725,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "signal-hook",
  "signal-hook-mio",
  "winapi 0.3.9",
@@ -3741,7 +3741,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "signal-hook",
  "signal-hook-mio",
  "winapi 0.3.9",
@@ -3952,7 +3952,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.9",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
@@ -5446,7 +5446,7 @@ dependencies = [
  "dashmap",
  "hashbrown 0.12.3",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
 ]
 
 [[package]]
@@ -5911,9 +5911,9 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -6390,7 +6390,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6407,7 +6407,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -6422,12 +6422,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6442,7 +6442,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6454,7 +6454,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -6469,7 +6469,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "clap 4.5.4",
@@ -6486,7 +6486,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6532,7 +6532,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "difference",
@@ -6549,7 +6549,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -6611,7 +6611,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6636,7 +6636,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6656,7 +6656,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "clap 4.5.4",
@@ -6674,7 +6674,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6693,7 +6693,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6707,7 +6707,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6726,7 +6726,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6745,7 +6745,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "hex",
@@ -6758,7 +6758,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "hex",
@@ -6772,7 +6772,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6800,7 +6800,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6837,7 +6837,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6876,7 +6876,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6906,7 +6906,7 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -6937,7 +6937,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6965,7 +6965,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "abstract-domain-derive",
  "codespan",
@@ -6992,7 +6992,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "hex",
@@ -7015,7 +7015,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "once_cell",
  "serde",
@@ -7024,7 +7024,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7042,7 +7042,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "better_any",
@@ -7073,7 +7073,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "better_any",
  "bytes",
@@ -7098,7 +7098,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7113,7 +7113,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#2027a153efa4fda4a2d0abe5e4ded8f95ce49ee7"
+source = "git+https://github.com/movementlabsxyz/aptos-core?branch=monza#06443b81f6b8b8742c4aa47eba9e315b5e6502ff"
 dependencies = [
  "bcs 0.1.4",
  "derivative",
@@ -7211,7 +7211,7 @@ checksum = "40a3eb6b7c682b65d1f631ec3176829d72ab450b3aacdd3f719bf220822e59ac"
 dependencies = [
  "libc",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "thiserror",
  "widestring",
  "winapi 0.3.9",
@@ -7710,12 +7710,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.9",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
@@ -7734,15 +7734,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall 0.5.1",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -8049,7 +8049,7 @@ dependencies = [
  "mime",
  "multer",
  "nix 0.27.1",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "percent-encoding",
  "pin-project-lite",
  "poem-derive",
@@ -8321,7 +8321,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "thiserror",
 ]
 
@@ -8687,6 +8687,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+dependencies = [
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -10226,7 +10235,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -11464,9 +11473,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63381fa6624bf92130a6b87c0d07380116f80b565c42cf0d754136f0238359ef"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 dependencies = [
  "zeroize_derive",
 ]

--- a/networks/monza/monza-full-node/src/partial.rs
+++ b/networks/monza/monza-full-node/src/partial.rs
@@ -163,10 +163,13 @@ impl <T : MonzaExecutor + Send + Sync + Clone>MonzaPartialFullNode<T> {
                 block_hash,
                 block
             );
+            let block_id = executable_block.block_id;
             self.executor.execute_block(
                 &FinalityMode::Opt,
                 executable_block
             ).await?;
+
+            println!("Executed block: {:?}", block_id);
 
         }
 

--- a/protocol-units/execution/monza/executor/src/lib.rs
+++ b/protocol-units/execution/monza/executor/src/lib.rs
@@ -7,7 +7,6 @@ pub use aptos_types::{
     transaction::{SignedTransaction, Transaction}
 };
 pub use aptos_crypto::hash::HashValue;
-use aptos_executor_types::state_checkpoint_output::StateCheckpointOutput;
 use async_channel::Sender;
 use aptos_api::runtime::Apis;
 pub use monza_execution_util::FinalityMode;
@@ -27,7 +26,7 @@ pub trait MonzaExecutor {
         &self,
         mode : &FinalityMode, 
         block: ExecutableBlock,
-    ) -> Result<StateCheckpointOutput, anyhow::Error>;
+    ) -> Result<(), anyhow::Error>;
 
     /// Sets the transaction channel.
     async fn set_tx_channel(&mut self, tx_channel: Sender<SignedTransaction>) -> Result<(), anyhow::Error>;

--- a/protocol-units/execution/monza/executor/src/v1.rs
+++ b/protocol-units/execution/monza/executor/src/v1.rs
@@ -57,6 +57,7 @@ impl MonzaExecutor for MonzaExecutorV1 {
         match mode {
             FinalityMode::Dyn => unimplemented!(),
             FinalityMode::Opt => {
+                println!("Executing opt block: {:?}", block.block_id);
                 self.executor.execute_block(block).await
             },
             FinalityMode::Fin => unimplemented!(),

--- a/protocol-units/execution/monza/executor/src/v1.rs
+++ b/protocol-units/execution/monza/executor/src/v1.rs
@@ -131,7 +131,7 @@ mod opt_tests {
 			0,
 			gas_unit_price,
 			0,
-			ChainId::new(10), // This is the value used in aptos testing code.
+			ChainId::test(), // This is the value used in aptos testing code.
 		);
 		SignedTransaction::new(raw_transaction, public_key, Ed25519Signature::dummy_signature())
 	}

--- a/protocol-units/execution/monza/executor/src/v1.rs
+++ b/protocol-units/execution/monza/executor/src/v1.rs
@@ -1,7 +1,5 @@
 use crate::*;
 use monza_opt_executor::Executor;
-use std::sync::Arc;
-use tokio::sync::RwLock;
 use async_channel::Sender;
 use aptos_types::transaction::SignedTransaction;
 
@@ -52,7 +50,7 @@ impl MonzaExecutor for MonzaExecutorV1 {
         &self,
         mode : &FinalityMode, 
         block: ExecutableBlock,
-    ) -> Result<StateCheckpointOutput, anyhow::Error> {
+    ) -> Result<(), anyhow::Error> {
 
         match mode {
             FinalityMode::Dyn => unimplemented!(),


### PR DESCRIPTION
# Summary
While investigating the transaction confirmation bug, I eventually discovered that our executor is actually not committing state successfully. Sorry, I should have reviewed that more closely in #30 .

It turns out the issue I was experiencing is not due to our current `monza-opt-executor` failing to move transactions from pending. But, instead, it is a result of state not being reliably committed at all. 

## Steps to Reproduce
Check out the tests in the [`monza-opt-executor` ](https://github.com/movementlabsxyz/movement/tree/partial-monza/broken-executor/protocol-units/execution/monza/opt-executor) crate. 

In particular, I've expanded **`test_execute_block_state_db`** to actually run checks of state values with the state view, and it has not passed. 

Strangely, you can successfully get transactions from the `reader.get_transaction_by_hash`. But, anything involving the `state_view` API does not work. This breaks upstream compatibility with the rest API implementation obtained from Aptos Core. 

## Recommended Approach
- Ostensibly, if you can get  **`test_execute_block_state_db`** to pass, this should fix all downstream issues.
- The `commit_block` method is responsible for actually triggering the ledger info to be committed to state. We can see from just using `db.reader` methods that this is functional. But, something appears to be off about the ledger versioning.
- This should help and is certainly more relevant for the current Aptos API: https://github.com/movementlabsxyz/aptos-core/blob/ea91067b81f9673547417bff9c70d5a2fe1b0e7b/execution/executor-test-helpers/src/integration_test_impl.rs#L53