### PR TITLE
Executor API cleanup and simplification

### DIFF
--- a/networks/monza/monza-full-node/src/partial.rs
+++ b/networks/monza/monza-full-node/src/partial.rs
@@ -41,16 +41,18 @@ impl <T : MonzaExecutor + Send + Sync + Clone>MonzaPartialNode<T> {
         }
     }
 
-    pub async fn bind_transaction_channel(&mut self) -> Result<(), anyhow::Error> {
-        self.executor.set_tx_channel(self.transaction_sender.clone()).await?;
-        Ok(())
-    }
+	fn bind_transaction_channel(&mut self) {
+		self.executor.set_tx_channel(self.transaction_sender.clone());
+	}
 
-    pub async fn bound(executor : T, light_node_client: LightNodeServiceClient<tonic::transport::Channel>) -> Result<Self, anyhow::Error> {
-        let mut node = Self::new(executor, light_node_client);
-        node.bind_transaction_channel().await?;
-        Ok(node)
-    }
+	pub fn bound(
+		executor: T,
+		light_node_client: LightNodeServiceClient<tonic::transport::Channel>,
+	) -> Result<Self, anyhow::Error> {
+		let mut node = Self::new(executor, light_node_client);
+		node.bind_transaction_channel();
+		Ok(node)
+	}
 
     pub async fn tick_write_transactions_to_da(&self) -> Result<(), anyhow::Error> {
         
@@ -225,7 +227,7 @@ impl MonzaPartialNode<MonzaExecutorV1> {
         let executor = MonzaExecutorV1::try_from_env(tx).await.context(
             "Failed to get executor from environment"
         )?;
-        Self::bound(executor, light_node_client).await
+        Self::bound(executor, light_node_client)
     }
 
 }

--- a/networks/monza/monza-full-node/src/partial.rs
+++ b/networks/monza/monza-full-node/src/partial.rs
@@ -166,7 +166,7 @@ impl <T : MonzaExecutor + Send + Sync + Clone>MonzaPartialNode<T> {
             );
             let block_id = executable_block.block_id;
             self.executor.execute_block(
-                &FinalityMode::Opt,
+                FinalityMode::Opt,
                 executable_block
             ).await?;
 

--- a/networks/suzuka/suzuka-full-node/src/partial.rs
+++ b/networks/suzuka/suzuka-full-node/src/partial.rs
@@ -41,16 +41,18 @@ impl <T : SuzukaExecutor + Send + Sync + Clone>SuzukaPartialNode<T> {
         }
     }
 
-    pub async fn bind_transaction_channel(&mut self) -> Result<(), anyhow::Error> {
-        self.executor.set_tx_channel(self.transaction_sender.clone()).await?;
-        Ok(())
-    }
+	fn bind_transaction_channel(&mut self) {
+		self.executor.set_tx_channel(self.transaction_sender.clone());
+	}
 
-    pub async fn bound(executor : T, light_node_client: LightNodeServiceClient<tonic::transport::Channel>) -> Result<Self, anyhow::Error> {
-        let mut node = Self::new(executor, light_node_client);
-        node.bind_transaction_channel().await?;
-        Ok(node)
-    }
+	pub fn bound(
+		executor: T,
+		light_node_client: LightNodeServiceClient<tonic::transport::Channel>,
+	) -> Result<Self, anyhow::Error> {
+		let mut node = Self::new(executor, light_node_client);
+		node.bind_transaction_channel();
+		Ok(node)
+	}
 
     pub async fn tick_write_transactions_to_da(&self) -> Result<(), anyhow::Error> {
         
@@ -225,7 +227,7 @@ impl SuzukaPartialNode<SuzukaExecutorV1> {
         let executor = SuzukaExecutorV1::try_from_env(tx).await.context(
             "Failed to get executor from environment"
         )?;
-        Self::bound(executor, light_node_client).await
+        Self::bound(executor, light_node_client)
     }
 
 }

--- a/networks/suzuka/suzuka-full-node/src/partial.rs
+++ b/networks/suzuka/suzuka-full-node/src/partial.rs
@@ -166,7 +166,7 @@ impl <T : SuzukaExecutor + Send + Sync + Clone>SuzukaPartialNode<T> {
             );
             let block_id = executable_block.block_id;
             self.executor.execute_block(
-                &FinalityMode::Opt,
+                FinalityMode::Opt,
                 executable_block
             ).await?;
 

--- a/protocol-units/execution/maptos/util/src/finality_mode.rs
+++ b/protocol-units/execution/maptos/util/src/finality_mode.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum FinalityMode {
     Dyn,
     Opt,

--- a/protocol-units/execution/monza/executor/src/lib.rs
+++ b/protocol-units/execution/monza/executor/src/lib.rs
@@ -24,7 +24,7 @@ pub trait MonzaExecutor {
     /// Executes a block dynamically
     async fn execute_block(
         &self,
-        mode : &FinalityMode, 
+        mode: FinalityMode, 
         block: ExecutableBlock,
     ) -> Result<(), anyhow::Error>;
 

--- a/protocol-units/execution/monza/executor/src/lib.rs
+++ b/protocol-units/execution/monza/executor/src/lib.rs
@@ -28,14 +28,14 @@ pub trait MonzaExecutor {
         block: ExecutableBlock,
     ) -> Result<(), anyhow::Error>;
 
-    /// Sets the transaction channel.
-    async fn set_tx_channel(&mut self, tx_channel: Sender<SignedTransaction>) -> Result<(), anyhow::Error>;
+	/// Sets the transaction channel.
+	fn set_tx_channel(
+		&mut self,
+		tx_channel: Sender<SignedTransaction>,
+	);
 
-    /// Gets the dyn API.
-    async fn get_api(
-        &self,
-        mode : &FinalityMode, 
-    ) -> Result<Apis, anyhow::Error>;
+	/// Gets the dyn API.
+	fn get_api(&self, mode: FinalityMode) -> Apis;
 
     /// Get block head height.
     async fn get_block_head_height(&self) -> Result<u64, anyhow::Error>;

--- a/protocol-units/execution/monza/executor/src/v1.rs
+++ b/protocol-units/execution/monza/executor/src/v1.rs
@@ -43,7 +43,7 @@ impl MonzaExecutor for MonzaExecutorV1 {
 	/// Executes a block dynamically
 	async fn execute_block(
 		&self,
-		mode: &FinalityMode,
+		mode: FinalityMode,
 		block: ExecutableBlock,
 	) -> Result<(), anyhow::Error> {
 		match mode {
@@ -131,15 +131,15 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_execute_opt_block() -> Result<(), anyhow::Error> {
-		let (tx, rx) = async_channel::unbounded();
-		let mut executor = MonzaExecutorV1::try_from_env(tx).await?;
+		let (tx, _rx) = async_channel::unbounded();
+		let executor = MonzaExecutorV1::try_from_env(tx).await?;
 		let block_id = HashValue::random();
 		let tx = SignatureVerifiedTransaction::Valid(Transaction::UserTransaction(
 			create_signed_transaction(0),
 		));
 		let txs = ExecutableTransactions::Unsharded(vec![tx]);
 		let block = ExecutableBlock::new(block_id.clone(), txs);
-		executor.execute_block(&FinalityMode::Opt, block).await?;
+		executor.execute_block(FinalityMode::Opt, block).await?;
 		Ok(())
 	}
 
@@ -212,7 +212,7 @@ mod tests {
 			SignatureVerifiedTransaction::Valid(Transaction::UserTransaction(received_transaction));
 		let txs = ExecutableTransactions::Unsharded(vec![tx]);
 		let block = ExecutableBlock::new(block_id.clone(), txs);
-		executor.execute_block(&FinalityMode::Opt, block).await?;
+		executor.execute_block(FinalityMode::Opt, block).await?;
 
 		services_handle.abort();
 		background_handle.abort();
@@ -274,7 +274,7 @@ mod tests {
 			));
 			let txs = ExecutableTransactions::Unsharded(vec![tx]);
 			let block = ExecutableBlock::new(block_id.clone(), txs);
-			executor.execute_block(&FinalityMode::Opt, block).await?;
+			executor.execute_block(FinalityMode::Opt, block).await?;
 
 			blockheight += 1;
 			committed_blocks.insert(

--- a/protocol-units/execution/suzuka/executor/src/lib.rs
+++ b/protocol-units/execution/suzuka/executor/src/lib.rs
@@ -28,14 +28,14 @@ pub trait SuzukaExecutor {
         block: ExecutableBlock,
     ) -> Result<(), anyhow::Error>;
 
-    /// Sets the transaction channel.
-    async fn set_tx_channel(&mut self, tx_channel: Sender<SignedTransaction>) -> Result<(), anyhow::Error>;
+	/// Sets the transaction channel.
+	fn set_tx_channel(
+		&mut self,
+		tx_channel: Sender<SignedTransaction>,
+	);
 
-    /// Gets the dyn API.
-    async fn get_api(
-        &self,
-        mode : &FinalityMode, 
-    ) -> Result<Apis, anyhow::Error>;
+	/// Gets the dyn API.
+	fn get_api(&self, mode: FinalityMode) -> Apis;
 
     /// Get block head height.
     async fn get_block_head_height(&self) -> Result<u64, anyhow::Error>;

--- a/protocol-units/execution/suzuka/executor/src/lib.rs
+++ b/protocol-units/execution/suzuka/executor/src/lib.rs
@@ -24,7 +24,7 @@ pub trait SuzukaExecutor {
     /// Executes a block dynamically
     async fn execute_block(
         &self,
-        mode : &FinalityMode, 
+        mode: FinalityMode, 
         block: ExecutableBlock,
     ) -> Result<(), anyhow::Error>;
 

--- a/protocol-units/execution/suzuka/executor/src/v1.rs
+++ b/protocol-units/execution/suzuka/executor/src/v1.rs
@@ -48,7 +48,7 @@ impl SuzukaExecutor for SuzukaExecutorV1 {
     /// Executes a block dynamically
     async fn execute_block(
         &self,
-        mode : &FinalityMode, 
+        mode: FinalityMode, 
         block: ExecutableBlock,
     ) -> Result<(), anyhow::Error> {
 
@@ -137,15 +137,15 @@ mod opt_tests {
 
 	#[tokio::test]
 	async fn test_execute_opt_block() -> Result<(), anyhow::Error> {
-        let (tx, rx) = async_channel::unbounded();
-		let mut executor = SuzukaExecutorV1::try_from_env(tx).await?;
+        let (tx, _rx) = async_channel::unbounded();
+		let executor = SuzukaExecutorV1::try_from_env(tx).await?;
 		let block_id = HashValue::random();
 		let tx = SignatureVerifiedTransaction::Valid(Transaction::UserTransaction(
 			create_signed_transaction(0),
 		));
 		let txs = ExecutableTransactions::Unsharded(vec![tx]);
 		let block = ExecutableBlock::new(block_id.clone(), txs);
-		executor.execute_block(&FinalityMode::Opt, block).await?;
+		executor.execute_block(FinalityMode::Opt, block).await?;
 		Ok(())
 	}
 
@@ -228,7 +228,7 @@ mod opt_tests {
         ));
         let txs = ExecutableTransactions::Unsharded(vec![tx]);
         let block = ExecutableBlock::new(block_id.clone(), txs);
-        executor.execute_block(&FinalityMode::Opt, block).await?;
+        executor.execute_block(FinalityMode::Opt, block).await?;
 
         services_handle.abort();
         background_handle.abort();

--- a/protocol-units/execution/suzuka/executor/src/v1.rs
+++ b/protocol-units/execution/suzuka/executor/src/v1.rs
@@ -64,21 +64,18 @@ impl SuzukaExecutor for SuzukaExecutorV1 {
     }
 
     /// Sets the transaction channel.
-    async fn set_tx_channel(&mut self, tx_channel: Sender<SignedTransaction>) -> Result<(), anyhow::Error> {
+    fn set_tx_channel(&mut self, tx_channel: Sender<SignedTransaction>) {
         self.transaction_channel = tx_channel;
-        Ok(())
     }
 
     /// Gets the API.
-    async fn get_api(
+    fn get_api(
         &self,
-        _mode : &FinalityMode, 
-    ) -> Result<Apis, anyhow::Error> {
-        match _mode {
+        mode: FinalityMode, 
+    ) -> Apis {
+        match mode {
             FinalityMode::Dyn => unimplemented!(),
-            FinalityMode::Opt => {
-                Ok(self.executor.try_get_apis().await?)
-            },
+            FinalityMode::Opt => self.executor.get_apis(),
             FinalityMode::Fin => unimplemented!(),
         }
     }
@@ -177,7 +174,7 @@ mod opt_tests {
 		let request = SubmitTransactionPost::Bcs(
 			aptos_api::bcs_payload::Bcs(bcs_user_transaction)
 		);
-		let api = executor.get_api(&FinalityMode::Opt).await?;
+		let api = executor.get_api(FinalityMode::Opt);
 		api.transactions.submit_transaction(AcceptType::Bcs, request).await?;
 
 		services_handle.abort();
@@ -215,7 +212,7 @@ mod opt_tests {
 		let request = SubmitTransactionPost::Bcs(
 			aptos_api::bcs_payload::Bcs(bcs_user_transaction)
 		);
-		let api = executor.get_api(&FinalityMode::Opt).await?;
+		let api = executor.get_api(FinalityMode::Opt);
 		api.transactions.submit_transaction(AcceptType::Bcs, request).await?;
 
 		let received_transaction = rx.recv().await?;


### PR DESCRIPTION
Make `FinalityMode` passed by value like a simple mode selector parameter should be.
Change signatures of methods that don't need to be async
or fallible.