### PR TITLE
ENG 394 additional unit test for memseq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6230,6 +6230,7 @@ name = "memseq"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "futures",
  "mempool-util",
  "move-rocks",
  "movement-types",

--- a/protocol-units/sequencing/memseq/Cargo.toml
+++ b/protocol-units/sequencing/memseq/Cargo.toml
@@ -19,6 +19,7 @@ movement-types = { workspace = true }
 anyhow = { workspace = true }
 move-rocks = { workspace = true }
 tempfile = { workspace = true }
+futures = { workspace = true }
 
 [lints]
 workspace = true

--- a/protocol-units/sequencing/memseq/src/lib.rs
+++ b/protocol-units/sequencing/memseq/src/lib.rs
@@ -192,6 +192,18 @@ pub mod test {
 	}
 
 	#[tokio::test]
+	async fn test_wait_for_next_block_no_transactions() -> Result<(), anyhow::Error> {
+		let dir = tempdir()?;
+		let path = dir.path().to_path_buf();
+		let memseq = Memseq::try_move_rocks(path)?.with_block_size(10).with_building_time_ms(500);
+
+		let block = memseq.wait_for_next_block().await?;
+		assert!(block.is_none());
+
+		Ok(())
+	}
+
+	#[tokio::test]
 	async fn test_memseq() -> Result<(), anyhow::Error> {
 		let dir = tempdir()?;
 		let path = dir.path().to_path_buf();

--- a/protocol-units/sequencing/memseq/src/lib.rs
+++ b/protocol-units/sequencing/memseq/src/lib.rs
@@ -130,6 +130,33 @@ pub mod test {
 	}
 
 	#[tokio::test]
+	async fn test_memseq_with_methods() -> Result<(), anyhow::Error> {
+		let dir = tempdir()?;
+		let path = dir.path().to_path_buf();
+
+		let mem_pool = Arc::new(RwLock::new(RocksdbMempool::try_new(
+			path.to_str().ok_or(anyhow::anyhow!("PathBuf to str failed"))?,
+		)?));
+		let block_size = 50;
+		let building_time_ms = 2000;
+		let parent_block = Arc::new(RwLock::new(Id::default()));
+
+		let memseq = Memseq::new(mem_pool, block_size, Arc::clone(&parent_block), building_time_ms);
+
+		// Test with_block_size
+		let new_block_size = 100;
+		let memseq = memseq.with_block_size(new_block_size);
+		assert_eq!(memseq.block_size, new_block_size);
+
+		// Test with_building_time_ms
+		let new_building_time_ms = 5000;
+		let memseq = memseq.with_building_time_ms(new_building_time_ms);
+		assert_eq!(memseq.building_time_ms, new_building_time_ms);
+
+		Ok(())
+	}
+
+	#[tokio::test]
 	async fn test_memseq() -> Result<(), anyhow::Error> {
 		let dir = tempdir()?;
 		let path = dir.path().to_path_buf();

--- a/protocol-units/sequencing/memseq/src/lib.rs
+++ b/protocol-units/sequencing/memseq/src/lib.rs
@@ -109,6 +109,41 @@ pub mod test {
 	use tempfile::tempdir;
 
 	#[tokio::test]
+	async fn test_try_move_rocks() -> Result<(), anyhow::Error> {
+		let dir = tempdir()?;
+		let path = dir.path().to_path_buf();
+		let memseq = Memseq::try_move_rocks(path.clone())?;
+
+		assert_eq!(memseq.block_size, 10);
+		assert_eq!(memseq.building_time_ms, 1000);
+
+		// Test invalid path
+		let invalid_path = PathBuf::from("");
+		let result = Memseq::try_move_rocks(invalid_path);
+		assert!(result.is_err());
+
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn test_try_move_rocks_from_env() -> Result<(), anyhow::Error> {
+		let dir = tempdir()?;
+		let path = dir.path().to_path_buf();
+		std::env::set_var("MOVE_ROCKS_PATH", path.to_str().unwrap());
+
+		let memseq = Memseq::try_move_rocks_from_env()?;
+		assert_eq!(memseq.block_size, 10);
+		assert_eq!(memseq.building_time_ms, 1000);
+
+		// Test environment variable not set
+		std::env::remove_var("MOVE_ROCKS_PATH");
+		let result = Memseq::try_move_rocks_from_env();
+		assert!(result.is_err());
+
+		Ok(())
+	}
+
+	#[tokio::test]
 	async fn test_memseq_initialization() -> Result<(), anyhow::Error> {
 		let dir = tempdir()?;
 		let path = dir.path().to_path_buf();

--- a/protocol-units/sequencing/memseq/src/lib.rs
+++ b/protocol-units/sequencing/memseq/src/lib.rs
@@ -1,241 +1,217 @@
-pub use movement_types::{Block, Transaction, Id};
 use mempool_util::{MempoolBlockOperations, MempoolTransactionOperations};
+pub use move_rocks::RocksdbMempool;
+pub use movement_types::{Block, Id, Transaction};
+pub use sequencing_util::Sequencer;
 use std::{path::PathBuf, sync::Arc};
 use tokio::sync::RwLock;
-pub use move_rocks::RocksdbMempool;
-pub use sequencing_util::Sequencer;
 
 #[derive(Clone)]
-pub struct Memseq<T : MempoolBlockOperations + MempoolTransactionOperations> {
-    pub mempool : Arc<RwLock<T>>,
-    // this value should not be changed after initialization
-    block_size : u32,
-    pub parent_block : Arc<RwLock<Id>>,
-    // this value should not be changed after initialization
-    building_time_ms : u64,
+pub struct Memseq<T: MempoolBlockOperations + MempoolTransactionOperations> {
+	pub mempool: Arc<RwLock<T>>,
+	// this value should not be changed after initialization
+	block_size: u32,
+	pub parent_block: Arc<RwLock<Id>>,
+	// this value should not be changed after initialization
+	building_time_ms: u64,
 }
 
-impl <T : MempoolBlockOperations + MempoolTransactionOperations> Memseq<T> {
-    pub fn new(mempool : Arc<RwLock<T>>, block_size : u32, parent_block : Arc<RwLock<Id>>, building_time_ms : u64) -> Self {
-        Self {
-            mempool,
-            block_size,
-            parent_block,
-            building_time_ms
-        }
-    }
+impl<T: MempoolBlockOperations + MempoolTransactionOperations> Memseq<T> {
+	pub fn new(
+		mempool: Arc<RwLock<T>>,
+		block_size: u32,
+		parent_block: Arc<RwLock<Id>>,
+		building_time_ms: u64,
+	) -> Self {
+		Self { mempool, block_size, parent_block, building_time_ms }
+	}
 
-    pub fn with_block_size(mut self, block_size : u32) -> Self {
-        self.block_size = block_size;
-        self
-    }
+	pub fn with_block_size(mut self, block_size: u32) -> Self {
+		self.block_size = block_size;
+		self
+	}
 
-    pub fn with_building_time_ms(mut self, building_time_ms : u64) -> Self {
-        self.building_time_ms = building_time_ms;
-        self
-    }
-
+	pub fn with_building_time_ms(mut self, building_time_ms: u64) -> Self {
+		self.building_time_ms = building_time_ms;
+		self
+	}
 }
 
 impl Memseq<RocksdbMempool> {
+	pub fn try_move_rocks(path: PathBuf) -> Result<Self, anyhow::Error> {
+		let mempool = RocksdbMempool::try_new(
+			path.to_str().ok_or(anyhow::anyhow!("PathBuf to str failed"))?,
+		)?;
+		let mempool = Arc::new(RwLock::new(mempool));
+		let parent_block = Arc::new(RwLock::new(Id::default()));
+		Ok(Self::new(mempool, 10, parent_block, 1000))
+	}
 
-    pub fn try_move_rocks(path : PathBuf) -> Result<Self, anyhow::Error> {
-        let mempool = RocksdbMempool::try_new(path.to_str().ok_or(
-            anyhow::anyhow!("PathBuf to str failed")
-        )?)?;
-        let mempool = Arc::new(RwLock::new(mempool));
-        let parent_block = Arc::new(RwLock::new(Id::default()));
-        Ok(Self::new(mempool, 10, parent_block, 1000))
-    }
-
-    pub fn try_move_rocks_from_env() -> Result<Self, anyhow::Error> {
-        let path = std::env::var("MOVE_ROCKS_PATH").or(Err(anyhow::anyhow!("MOVE_ROCKS_PATH not found")))?;
-        Self::try_move_rocks(PathBuf::from(path))
-    }
-
+	pub fn try_move_rocks_from_env() -> Result<Self, anyhow::Error> {
+		let path = std::env::var("MOVE_ROCKS_PATH")
+			.or(Err(anyhow::anyhow!("MOVE_ROCKS_PATH not found")))?;
+		Self::try_move_rocks(PathBuf::from(path))
+	}
 }
 
-impl <T : MempoolBlockOperations + MempoolTransactionOperations> Sequencer for Memseq<T> {
+impl<T: MempoolBlockOperations + MempoolTransactionOperations> Sequencer for Memseq<T> {
+	async fn publish(&self, transaction: Transaction) -> Result<(), anyhow::Error> {
+		let mempool = self.mempool.read().await;
+		mempool.add_transaction(transaction).await?;
+		Ok(())
+	}
 
-    async fn publish(&self, transaction: Transaction) -> Result<(), anyhow::Error> {
-        let mempool = self.mempool.read().await;
-        mempool.add_transaction(transaction).await?;
-        Ok(())
-    }
+	async fn wait_for_next_block(&self) -> Result<Option<Block>, anyhow::Error> {
+		let mempool = self.mempool.read().await;
+		let mut transactions = Vec::new();
 
-    async fn wait_for_next_block(&self) -> Result<Option<Block>, anyhow::Error> {
-        
-        let mempool = self.mempool.read().await;
-        let mut transactions = Vec::new();
+		let mut now = std::time::Instant::now();
+		let finish_by = now + std::time::Duration::from_millis(self.building_time_ms);
 
-        let mut now = std::time::Instant::now();
-        let finish_by = now + std::time::Duration::from_millis(self.building_time_ms);
+		loop {
+			let current_block_size = transactions.len() as u32;
+			if current_block_size >= self.block_size {
+				break;
+			}
 
-        loop {
+			for _ in 0..self.block_size - current_block_size {
+				if let Some(transaction) = mempool.pop_transaction().await? {
+					transactions.push(transaction);
+				} else {
+					break;
+				}
+			}
 
-            let current_block_size = transactions.len() as u32;
-            if current_block_size >= self.block_size {
-                break;
-            }
+			// sleep to yield to other tasks and wait for more transactions
+			tokio::time::sleep(std::time::Duration::from_millis(1)).await;
 
-            for _ in 0..self.block_size - current_block_size {
-                if let Some(transaction) = mempool.pop_transaction().await? {
-                    transactions.push(transaction);
-                } else {
-                    break;
-                }
-            }
+			now = std::time::Instant::now();
+			if now > finish_by {
+				break;
+			}
+		}
 
-            // sleep to yield to other tasks and wait for more transactions
-            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
-
-            now = std::time::Instant::now();
-            if now > finish_by {
-                break;
-            }
-
-        }
-       
-        if transactions.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(Block::new(
-                Default::default(),
-                self.parent_block.read().await.clone().to_vec(),
-                transactions
-            )))
-        }
-
-    }
-
+		if transactions.is_empty() {
+			Ok(None)
+		} else {
+			Ok(Some(Block::new(
+				Default::default(),
+				self.parent_block.read().await.clone().to_vec(),
+				transactions,
+			)))
+		}
+	}
 }
 
 #[cfg(test)]
 pub mod test {
 
-    use super::*;
-    use tempfile::tempdir;
+	use super::*;
+	use tempfile::tempdir;
 
-    #[tokio::test]
-    async fn test_memseq() -> Result<(), anyhow::Error>{
+	#[tokio::test]
+	async fn test_memseq() -> Result<(), anyhow::Error> {
+		let dir = tempdir()?;
+		let path = dir.path().to_path_buf();
+		let memseq = Memseq::try_move_rocks(path)?;
 
-        let dir = tempdir()?;
-        let path = dir.path().to_path_buf();
-        let memseq = Memseq::try_move_rocks(path)?;
+		let transaction = Transaction::new(vec![1, 2, 3]);
+		memseq.publish(transaction.clone()).await?;
 
-        let transaction = Transaction::new(vec![1, 2, 3]);
-        memseq.publish(transaction.clone()).await?;
+		let block = memseq.wait_for_next_block().await?;
 
-        let block = memseq.wait_for_next_block().await?;
+		assert_eq!(block.ok_or(anyhow::anyhow!("Block not found"))?.transactions[0], transaction);
 
-        assert_eq!(block.ok_or(
-            anyhow::anyhow!("Block not found")
-        )?.transactions[0], transaction);
-        
-        Ok(())
-    }
+		Ok(())
+	}
 
-    #[tokio::test]
-    async fn test_respects_size() -> Result<(), anyhow::Error>{
+	#[tokio::test]
+	async fn test_respects_size() -> Result<(), anyhow::Error> {
+		let dir = tempdir()?;
+		let path = dir.path().to_path_buf();
+		let block_size = 100;
+		let memseq = Memseq::try_move_rocks(path)?.with_block_size(block_size);
 
-        let dir = tempdir()?;
-        let path = dir.path().to_path_buf();
-        let block_size = 100;
-        let memseq = Memseq::try_move_rocks(path)?.with_block_size(block_size);
+		let mut transactions = Vec::new();
+		for i in 0..block_size * 2 {
+			let transaction = Transaction::new(vec![i as u8]);
+			memseq.publish(transaction.clone()).await?;
+			transactions.push(transaction);
+		}
 
-        let mut transactions = Vec::new();
-        for i in 0..block_size * 2 {
-            let transaction = Transaction::new(vec![i as u8]);
-            memseq.publish(transaction.clone()).await?;
-            transactions.push(transaction);
-        }
+		let block = memseq.wait_for_next_block().await?;
 
-        let block = memseq.wait_for_next_block().await?;
+		assert!(block.is_some());
 
-        assert!(block.is_some());
+		let block = block.ok_or(anyhow::anyhow!("Block not found"))?;
 
-        let block = block.ok_or(
-            anyhow::anyhow!("Block not found")
-        )?;
+		assert_eq!(block.transactions.len(), block_size as usize);
 
-        assert_eq!(block.transactions.len(), block_size as usize);
+		let second_block = memseq.wait_for_next_block().await?;
 
-        let second_block = memseq.wait_for_next_block().await?;
+		assert!(second_block.is_some());
 
-        assert!(second_block.is_some());
+		let second_block = second_block.ok_or(anyhow::anyhow!("Second block not found"))?;
 
-        let second_block = second_block.ok_or(
-            anyhow::anyhow!("Second block not found")
-        )?;
+		assert_eq!(second_block.transactions.len(), block_size as usize);
 
-        assert_eq!(second_block.transactions.len(), block_size as usize);
-        
-        Ok(())
-    }
+		Ok(())
+	}
 
+	#[tokio::test]
+	async fn test_respects_time() -> Result<(), anyhow::Error> {
+		let dir = tempdir()?;
+		let path = dir.path().to_path_buf();
+		let block_size = 100;
+		let memseq = Memseq::try_move_rocks(path)?
+			.with_block_size(block_size)
+			.with_building_time_ms(500);
 
-    #[tokio::test]
-    async fn test_respects_time() -> Result<(), anyhow::Error>{
+		let building_memseq = Arc::new(memseq);
+		let waiting_memseq = Arc::clone(&building_memseq);
 
-        let dir = tempdir()?;
-        let path = dir.path().to_path_buf();
-        let block_size = 100;
-        let memseq = Memseq::try_move_rocks(path)?
-        .with_block_size(block_size)
-        .with_building_time_ms(500);
+		let building_task = async move {
+			let memseq = building_memseq;
 
-        let building_memseq = Arc::new(memseq);
-        let waiting_memseq = Arc::clone(&building_memseq);
+			// add half of the transactions
+			for i in 0..block_size / 2 {
+				let transaction = Transaction::new(vec![i as u8]);
+				memseq.publish(transaction.clone()).await?;
+			}
 
-        let building_task = async move {
-            let memseq = building_memseq;
-    
-            // add half of the transactions
-            for i in 0..block_size/2 {
-                let transaction = Transaction::new(vec![i as u8]);
-                memseq.publish(transaction.clone()).await?;
-            }
+			tokio::time::sleep(std::time::Duration::from_millis(600)).await;
 
-            tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+			// add the rest of the transactions
+			for i in block_size / 2..block_size - 2 {
+				let transaction = Transaction::new(vec![i as u8]);
+				memseq.publish(transaction.clone()).await?;
+			}
 
-            // add the rest of the transactions
-            for i in block_size/2..block_size-2 {
-                let transaction = Transaction::new(vec![i as u8]);
-                memseq.publish(transaction.clone()).await?;
-            }
+			Ok::<_, anyhow::Error>(())
+		};
 
-            Ok::<_, anyhow::Error>(())
-        };
+		let waiting_task = async move {
+			let memseq = waiting_memseq;
 
-        let waiting_task = async move {
-            let memseq = waiting_memseq;
+			// first block
+			let block = memseq.wait_for_next_block().await?;
+			assert!(block.is_some());
+			let block = block.ok_or(anyhow::anyhow!("Block not found"))?;
+			assert_eq!(block.transactions.len(), (block_size / 2) as usize);
 
-            // first block
-            let block = memseq.wait_for_next_block().await?;
-            assert!(block.is_some());
-            let block = block.ok_or(
-                anyhow::anyhow!("Block not found")
-            )?;
-            assert_eq!(block.transactions.len(), (block_size/2) as usize);
+			tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
-            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+			// second block
+			let block = memseq.wait_for_next_block().await?;
+			assert!(block.is_some());
+			let block = block.ok_or(anyhow::anyhow!("Block not found"))?;
+			assert_eq!(block.transactions.len(), ((block_size / 2) - 2) as usize);
 
-            // second block
-            let block = memseq.wait_for_next_block().await?;
-            assert!(block.is_some());
-            let block = block.ok_or(
-                anyhow::anyhow!("Block not found")
-            )?;
-            assert_eq!(block.transactions.len(), ((block_size/2) - 2) as usize);
+			Ok::<_, anyhow::Error>(())
+		};
 
-            Ok::<_, anyhow::Error>(())
-        };
+		tokio::try_join!(building_task, waiting_task)?;
 
-        tokio::try_join!(building_task, waiting_task)?;
-        
-        Ok(())
-    }
-
-
-
+		Ok(())
+	}
 }
+

--- a/protocol-units/sequencing/memseq/src/lib.rs
+++ b/protocol-units/sequencing/memseq/src/lib.rs
@@ -109,6 +109,27 @@ pub mod test {
 	use tempfile::tempdir;
 
 	#[tokio::test]
+	async fn test_memseq_initialization() -> Result<(), anyhow::Error> {
+		let dir = tempdir()?;
+		let path = dir.path().to_path_buf();
+
+		let mem_pool = Arc::new(RwLock::new(RocksdbMempool::try_new(
+			path.to_str().ok_or(anyhow::anyhow!("PathBuf to str failed"))?,
+		)?));
+		let block_size = 50;
+		let building_time_ms = 2000;
+		let parent_block = Arc::new(RwLock::new(Id::default()));
+
+		let memseq = Memseq::new(mem_pool, block_size, Arc::clone(&parent_block), building_time_ms);
+
+		assert_eq!(memseq.block_size, block_size);
+		assert_eq!(memseq.building_time_ms, building_time_ms);
+		assert_eq!(*memseq.parent_block.read().await, *parent_block.read().await);
+
+		Ok(())
+	}
+
+	#[tokio::test]
 	async fn test_memseq() -> Result<(), anyhow::Error> {
 		let dir = tempdir()?;
 		let path = dir.path().to_path_buf();
@@ -214,4 +235,3 @@ pub mod test {
 		Ok(())
 	}
 }
-


### PR DESCRIPTION
- **rustfmt**
- **test(memseq): add initialization unit test**
- **test(memseq): Add tests for with_block_size and with_building_time_ms methods**
- **test(memseq): Add new unit tests for try_move_rocks function**
- **test(memseq): Add test for waiting on next block with no transactions**
- **test(memseq): add support for concurrent access testing**
- **test(memseq): add tests for error propagation in `Memseq` operations**
- **test(memseq): add test for block building timeout**

# Summary

- **Status**: `review`
- **Categories**: `protocol-units`.

# Changelog

1. Updated the test suite to cover scenarios involving testing memseq concurrency control mechanisms.
2. Added `futures` to dev-dependencies in `Cargo.toml` and `Cargo.lock` to test asynchronous operations using FuturesUnordered.
3. Made syntax and format adjustments for better code clarity and maintainability. `rustfmt +nightly`

# Testing

The changes have been covered with tests, particularly focusing on:
- **Concurrency control**: Test the new setup under concurrent access scenarios
  using `FuturesUnordered` and ensure correct transaction handling.
- **Error Propagation**: Ensure errors are propagated appropriately when
  operations fail, using mock implementations.
- **Initialization and setup**: Verify that `Memseq` can be initialized
correctly and handle paths and environments as expected.
- **Transaction Processing**: Transactions should be correctly published and
  awaited within blocks under various configurations (e.g., block size,
  timeouts).

# Outstanding issues

- **Integration Testing**: Further end-to-end integration testing with other
  system components is essential to ensure full system compatibility and
  performance adherence.
- **Documentation Updates**: Additional documentation detailing the changes in
  system behavior and setup due to these changes should be prepared.
- **Code**: There are some techniques used, such as sleeping for 1ms to give
  control back to the runtime, which could be optimized. Furthermore, the choice
  has been made to use `anyhow::Error` in a library, which is not idiomatic. We
  could use a custom Error type using the `thiserror` crate.

