### PR TITLE
ENG 400 replace anyhow Error in public APIs Generics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7203,10 +7203,10 @@ dependencies = [
 name = "movement-types"
 version = "0.3.0"
 dependencies = [
- "anyhow",
  "serde",
  "serde_with",
  "sha2 0.10.8",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6220,9 +6220,9 @@ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 name = "mempool-util"
 version = "0.3.0"
 dependencies = [
- "anyhow",
  "movement-types",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -7031,6 +7031,7 @@ dependencies = [
  "rocksdb",
  "serde_json",
  "tempfile",
+ "thiserror",
  "tokio",
 ]
 
@@ -9341,8 +9342,9 @@ dependencies = [
 name = "sequencing-util"
 version = "0.3.0"
 dependencies = [
- "anyhow",
+ "mempool-util",
  "movement-types",
+ "thiserror",
  "tokio",
 ]
 

--- a/protocol-units/mempool/move-rocks/Cargo.toml
+++ b/protocol-units/mempool/move-rocks/Cargo.toml
@@ -17,9 +17,11 @@ mempool-util = { workspace = true }
 movement-types = { workspace = true }
 rocksdb = { workspace = true }
 serde_json = { workspace = true }
-anyhow = { workspace = true }
+thiserror = { workspace = true }
 tempfile = { workspace = true }
 
+[dev-dependencies]
+anyhow = { workspace = true }
 
 [lints]
 workspace = true

--- a/protocol-units/mempool/move-rocks/src/lib.rs
+++ b/protocol-units/mempool/move-rocks/src/lib.rs
@@ -1,277 +1,366 @@
 use mempool_util::{
-    MempoolBlockOperations,
-    MempoolTransactionOperations,
-    MempoolTransaction
+	MempoolBlockOperations, MempoolBlockOperationsError, MempoolBlockOperationsResult,
+	MempoolTransaction, MempoolTransactionOperations, MempoolTransactionOperationsError,
+	MempoolTransactionOperationsResult,
 };
-use rocksdb::{DB, Options, ColumnFamilyDescriptor};
-use std::sync::Arc;
-use serde_json;
-use tokio::sync::RwLock;
 use movement_types::{Block, Id};
-use anyhow::Error;
+use rocksdb::{BoundColumnFamily, ColumnFamilyDescriptor, Options, DB};
+use serde_json;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+#[derive(thiserror::Error, Debug)]
+pub enum RocksdbMempoolError {
+	#[error("Underlying db error")]
+	RocksDbError(#[from] rocksdb::Error),
+	#[error("Family handle missing")]
+	FamilyHandleMissing,
+}
+
+pub type RocksdbMempoolResult<T> = Result<T, RocksdbMempoolError>;
+
+trait DBExt {
+	fn get_from_handle(
+		&self,
+		handle: &str,
+		key: impl AsRef<[u8]>,
+	) -> RocksdbMempoolResult<Option<Vec<u8>>>;
+
+	fn put_to_handle(
+		&self,
+		handle: &str,
+		key: impl AsRef<[u8]>,
+		value: impl AsRef<[u8]>,
+	) -> RocksdbMempoolResult<()>;
+
+	fn delete_from_handle(&self, handle: &str, key: impl AsRef<[u8]>) -> RocksdbMempoolResult<()>;
+
+	fn iter_from_handle(
+		&self,
+		handle: &str,
+	) -> RocksdbMempoolResult<(Arc<BoundColumnFamily>, rocksdb::DBIterator)>;
+}
+
+impl DBExt for rocksdb::DB {
+	fn get_from_handle(
+		&self,
+		handle: &str,
+		key: impl AsRef<[u8]>,
+	) -> RocksdbMempoolResult<Option<Vec<u8>>> {
+		let cf_handle = self.cf_handle(handle).ok_or(RocksdbMempoolError::FamilyHandleMissing)?;
+		self.get_cf(&cf_handle, key).map_err(RocksdbMempoolError::from)
+	}
+
+	fn put_to_handle(
+		&self,
+		handle: &str,
+		key: impl AsRef<[u8]>,
+		value: impl AsRef<[u8]>,
+	) -> RocksdbMempoolResult<()> {
+		let cf_handle = self.cf_handle(handle).ok_or(RocksdbMempoolError::FamilyHandleMissing)?;
+		self.put_cf(&cf_handle, key, value).map_err(RocksdbMempoolError::from)
+	}
+
+	fn delete_from_handle(&self, handle: &str, key: impl AsRef<[u8]>) -> RocksdbMempoolResult<()> {
+		let cf_handle = self.cf_handle(handle).ok_or(RocksdbMempoolError::FamilyHandleMissing)?;
+		self.delete_cf(&cf_handle, key).map_err(RocksdbMempoolError::from)
+	}
+
+	fn iter_from_handle(
+		&self,
+		handle: &str,
+	) -> RocksdbMempoolResult<(Arc<BoundColumnFamily>, rocksdb::DBIterator)> {
+		let cf_handle = self.cf_handle(handle).ok_or(RocksdbMempoolError::FamilyHandleMissing)?;
+		let iterator = self.iterator_cf(&cf_handle, rocksdb::IteratorMode::Start);
+		Ok((cf_handle, iterator))
+	}
+}
 
 #[derive(Debug, Clone)]
 pub struct RocksdbMempool {
-    db: Arc<RwLock<DB>>,
+	db: Arc<RwLock<DB>>,
 }
 impl RocksdbMempool {
-    pub fn try_new(path: &str) -> Result<Self, Error> {
-        let mut options = Options::default();
-        options.create_if_missing(true);
-        options.create_missing_column_families(true);
+	pub fn try_new(path: &str) -> RocksdbMempoolResult<Self> {
+		let mut options = Options::default();
+		options.create_if_missing(true);
+		options.create_missing_column_families(true);
 
-        let mempool_transactions_cf = ColumnFamilyDescriptor::new("mempool_transactions", Options::default());
-        let transaction_truths_cf = ColumnFamilyDescriptor::new("transaction_truths", Options::default());
-        let blocks_cf = ColumnFamilyDescriptor::new("blocks", Options::default());
-        let transaction_lookups_cf = ColumnFamilyDescriptor::new("transaction_lookups", Options::default());
+		let mempool_transactions_cf =
+			ColumnFamilyDescriptor::new("mempool_transactions", Options::default());
+		let transaction_truths_cf =
+			ColumnFamilyDescriptor::new("transaction_truths", Options::default());
+		let blocks_cf = ColumnFamilyDescriptor::new("blocks", Options::default());
+		let transaction_lookups_cf =
+			ColumnFamilyDescriptor::new("transaction_lookups", Options::default());
 
-        let db = DB::open_cf_descriptors(
-            &options, 
-            path, 
-            vec![mempool_transactions_cf, transaction_truths_cf, blocks_cf, transaction_lookups_cf]
-        ).map_err(|e| Error::new(e))?;
+		let db = DB::open_cf_descriptors(
+			&options,
+			path,
+			vec![mempool_transactions_cf, transaction_truths_cf, blocks_cf, transaction_lookups_cf],
+		)?;
 
-        Ok(RocksdbMempool {
-            db: Arc::new(RwLock::new(db))
-        })
-    }
+		Ok(RocksdbMempool { db: Arc::new(RwLock::new(db)) })
+	}
 
-    pub fn construct_mempool_transaction_key(transaction: &MempoolTransaction) -> String {
-      
-        // pad to 32 characters
-        let slot_seconds_str = format!("{:032}", transaction.timestamp);
-    
-        // Assuming transaction.transaction.id() returns a hex string of length 32
-        let transaction_id_hex = transaction.transaction.id(); // This should be a String of hex characters
-    
-        // Concatenate the two parts to form a 48-character hex string key
-        let key = format!("{}:{}", slot_seconds_str, transaction_id_hex);
-    
-        key
-    }
-    
-    
-    
-    
-    /// Helper function to retrieve the key for mempool transaction from the lookup table.
-    async fn get_mempool_transaction_key(&self, transaction_id: &Id) -> Result<Option<Vec<u8>>, Error> {
-        let db = self.db.read().await;
-        let cf_handle = db.cf_handle("transaction_lookups").ok_or_else(|| Error::msg("CF handle not found"))?;
-        db.get_cf(&cf_handle, transaction_id.to_vec()).map_err(|e| Error::new(e))
-    }
+	pub fn construct_mempool_transaction_key(transaction: &MempoolTransaction) -> String {
+		// pad to 32 characters
+		let slot_seconds_str = format!("{:032}", transaction.timestamp);
 
+		// Assuming transaction.transaction.id() returns a hex string of length 32
+		let transaction_id_hex = transaction.transaction.id(); // This should be a String of hex characters
+
+		// Concatenate the two parts to form a 48-character hex string key
+		let key = format!("{}:{}", slot_seconds_str, transaction_id_hex);
+
+		key
+	}
+
+	/// Helper function to retrieve the key for mempool transaction from the lookup table.
+	async fn get_mempool_transaction_key(
+		&self,
+		transaction_id: &Id,
+	) -> RocksdbMempoolResult<Option<Vec<u8>>> {
+		let db = self.db.read().await;
+		db.get_from_handle("transaction_lookups", transaction_id.to_vec())
+	}
 }
-
 
 impl MempoolTransactionOperations for RocksdbMempool {
+	async fn has_mempool_transaction(
+		&self,
+		transaction_id: Id,
+	) -> MempoolTransactionOperationsResult<bool> {
+		let key = self
+			.get_mempool_transaction_key(&transaction_id)
+			.await
+			.map_err(MempoolTransactionOperationsError::store_error)?;
+		match key {
+			Some(k) => {
+				let db = self.db.read().await;
+				db.get_from_handle("mempool_transactions", k)
+					.map_err(MempoolTransactionOperationsError::store_error)
+					.map(|v| v.is_some())
+			},
+			None => Ok(false),
+		}
+	}
 
-    async fn has_mempool_transaction(&self, transaction_id: Id) -> Result<bool, Error> {
-        let key = self.get_mempool_transaction_key(&transaction_id).await?;
-        match key {
-            Some(k) => {
-                let db = self.db.read().await;
-                let cf_handle = db.cf_handle("mempool_transactions").ok_or_else(|| Error::msg("CF handle not found"))?;
-                Ok(db.get_cf(&cf_handle, k)?.is_some())
-            },
-            None => Ok(false),
-        }
-    }
+	async fn add_mempool_transaction(
+		&self,
+		tx: MempoolTransaction,
+	) -> MempoolTransactionOperationsResult<()> {
+		let serialized_tx = serde_json::to_vec(&tx)
+			.map_err(|e| MempoolTransactionOperationsError::SerializationError(e.to_string()))?;
 
-    async fn add_mempool_transaction(&self, tx: MempoolTransaction) -> Result<(), Error> {
-        let serialized_tx = serde_json::to_vec(&tx)?;
-        let db = self.db.write().await;
-        let mempool_transactions_cf_handle = db.cf_handle("mempool_transactions").ok_or_else(|| Error::msg("CF handle not found"))?;
-        let transaction_lookups_cf_handle = db.cf_handle("transaction_lookups").ok_or_else(|| Error::msg("CF handle not found"))?;
-        
-        let key = Self::construct_mempool_transaction_key(&tx);
-        db.put_cf(&mempool_transactions_cf_handle, &key, &serialized_tx)?;
-        db.put_cf(&transaction_lookups_cf_handle, tx.transaction.id().to_vec(), &key)?;
-        
-        Ok(())
-    }
+		let db = self.db.write().await;
 
-    async fn remove_mempool_transaction(&self, transaction_id: Id) -> Result<(), Error> {
-        let key = self.get_mempool_transaction_key(&transaction_id).await?;
+		let key = Self::construct_mempool_transaction_key(&tx);
+		db.put_to_handle("mempool_transactions", &key, &serialized_tx)
+			.map_err(MempoolTransactionOperationsError::store_error)?;
+		db.put_to_handle("transaction_lookups", tx.transaction.id().to_vec(), &key)
+			.map_err(MempoolTransactionOperationsError::store_error)?;
 
-        match key {
-            Some(k) => {
-                let db = self.db.write().await;
-                let cf_handle = db.cf_handle("mempool_transactions").ok_or_else(|| Error::msg("CF handle not found"))?;
-                db.delete_cf(&cf_handle, k)?;
-                let lookups_cf_handle = db.cf_handle("transaction_lookups").ok_or_else(|| Error::msg("CF handle not found"))?;
-                db.delete_cf(&lookups_cf_handle, transaction_id.to_vec())?;
-            },
-            None => (),
-        }
-        Ok(())
-    }
+		Ok(())
+	}
 
-   // Updated method signatures and implementations go here
-   async fn get_mempool_transaction(&self, transaction_id: Id) -> Result<Option<MempoolTransaction>, Error> {
-        let key = match self.get_mempool_transaction_key(&transaction_id).await? {
-            Some(k) => k,
-            None => return Ok(None), // If no key found in lookup, return None
-        };
-        let db = self.db.read().await;
-        let cf_handle = db.cf_handle("mempool_transactions").ok_or_else(|| Error::msg("CF handle not found"))?;
-        match db.get_cf(&cf_handle, &key)? {
-            Some(serialized_tx) => {
-                let tx: MempoolTransaction = serde_json::from_slice(&serialized_tx)?;
-                Ok(Some(tx))
-            },
-            None => Ok(None),
-        }
-    }
+	async fn remove_mempool_transaction(
+		&self,
+		transaction_id: Id,
+	) -> MempoolTransactionOperationsResult<()> {
+		let key = self
+			.get_mempool_transaction_key(&transaction_id)
+			.await
+			.map_err(MempoolTransactionOperationsError::store_error)?;
 
-    async fn pop_mempool_transaction(&self) -> Result<Option<MempoolTransaction>, Error> {
-        let db = self.db.write().await;
-        let cf_handle = db.cf_handle("mempool_transactions").ok_or_else(|| Error::msg("CF handle not found"))?;
-        let mut iter = db.iterator_cf(&cf_handle, rocksdb::IteratorMode::Start);
+		match key {
+			Some(k) => {
+				let db = self.db.write().await;
+				db.delete_from_handle("mempool_transactions", k)
+					.map_err(MempoolTransactionOperationsError::store_error)?;
+				db.delete_from_handle("transaction_lookups", transaction_id.to_vec())
+					.map_err(MempoolTransactionOperationsError::store_error)?;
+			},
+			None => (),
+		}
+		Ok(())
+	}
 
-        match iter.next() {
-            None => return Ok(None), // No transactions to pop
-            Some(res) => {
-                let (key, value) = res?;
-                let tx: MempoolTransaction = serde_json::from_slice(&value)?;
-                db.delete_cf(&cf_handle, &key)?;
+	// Updated method signatures and implementations go here
+	async fn get_mempool_transaction(
+		&self,
+		transaction_id: Id,
+	) -> MempoolTransactionOperationsResult<Option<MempoolTransaction>> {
+		let key = match self
+			.get_mempool_transaction_key(&transaction_id)
+			.await
+			.map_err(MempoolTransactionOperationsError::store_error)?
+		{
+			Some(k) => k,
+			None => return Ok(None), // If no key found in lookup, return None
+		};
 
-                // Optionally, remove from the lookup table as well
-                let lookups_cf_handle = db.cf_handle("transaction_lookups").ok_or_else(|| Error::msg("CF handle not found"))?;
-                db.delete_cf(&lookups_cf_handle, tx.transaction.id().to_vec())?;
-                
-                Ok(Some(tx))
-            }
-        }
+		let db = self.db.read().await;
+		match db
+			.get_from_handle("mempool_transactions", &key)
+			.map_err(MempoolTransactionOperationsError::store_error)?
+		{
+			Some(serialized_tx) => {
+				let tx: MempoolTransaction =
+					serde_json::from_slice(&serialized_tx).map_err(|e| {
+						MempoolTransactionOperationsError::SerializationError(e.to_string())
+					})?;
+				Ok(Some(tx))
+			},
+			None => Ok(None),
+		}
+	}
 
-    }
+	async fn pop_mempool_transaction(
+		&self,
+	) -> MempoolTransactionOperationsResult<Option<MempoolTransaction>> {
+		let db = self.db.write().await;
 
+		let (cf_handle, mut iter) = db
+			.iter_from_handle("mempool_transactions")
+			.map_err(MempoolTransactionOperationsError::store_error)?;
+
+		match iter.next() {
+			None => return Ok(None), // No transactions to pop
+			Some(res) => {
+				let (key, value) = res.map_err(MempoolTransactionOperationsError::store_error)?;
+				let tx: MempoolTransaction = serde_json::from_slice(&value).map_err(|e| {
+					MempoolTransactionOperationsError::DeserializationError(e.to_string())
+				})?;
+
+				db.delete_cf(&cf_handle, &key)
+					.map_err(MempoolTransactionOperationsError::store_error)?;
+
+				db.delete_from_handle("transaction_lookups", tx.transaction.id().to_vec())
+					.map_err(MempoolTransactionOperationsError::store_error)?;
+
+				Ok(Some(tx))
+			},
+		}
+	}
 }
 
-
 impl MempoolBlockOperations for RocksdbMempool {
-    async fn has_block(&self, block_id: Id) -> Result<bool, Error> {
-        let db = self.db.read().await;
-        let cf_handle = db.cf_handle("blocks").ok_or_else(|| Error::msg("CF handle not found"))?;
-        Ok(db.get_cf(&cf_handle, block_id.to_vec())?.is_some())
-    }
+	async fn has_block(&self, block_id: Id) -> MempoolBlockOperationsResult<bool> {
+		let db = self.db.read().await;
+		Ok(db
+			.get_from_handle("blocks", block_id.to_vec())
+			.map_err(MempoolBlockOperationsError::store_error)?
+			.is_some())
+	}
 
-    async fn add_block(&self, block: Block) -> Result<(), Error> {
-        let serialized_block = serde_json::to_vec(&block)?;
-        let db = self.db.write().await;
-        let cf_handle = db.cf_handle("blocks").ok_or_else(|| Error::msg("CF handle not found"))?;
-        db.put_cf(&cf_handle, block.id().to_vec(), &serialized_block)?;
-        Ok(())
-    }
+	async fn add_block(&self, block: Block) -> MempoolBlockOperationsResult<()> {
+		let serialized_block = serde_json::to_vec(&block)
+			.map_err(|e| MempoolBlockOperationsError::SerializeError(e.to_string()))?;
 
-    async fn remove_block(&self, block_id: Id) -> Result<(), Error> {
-        let db = self.db.write().await;
-        let cf_handle = db.cf_handle("blocks").ok_or_else(|| Error::msg("CF handle not found"))?;
-        db.delete_cf(&cf_handle, block_id.to_vec())?;
-        Ok(())
-    }
+		let db = self.db.write().await;
+		db.put_to_handle("blocks", block.id().to_vec(), &serialized_block)
+			.map_err(MempoolBlockOperationsError::store_error)?;
+		Ok(())
+	}
 
-    async fn get_block(&self, block_id: Id) -> Result<Option<Block>, Error> {
-        let db = self.db.read().await;
-        let cf_handle = db.cf_handle("blocks").ok_or_else(|| Error::msg("CF handle not found"))?;
-        let serialized_block = db.get_cf(&cf_handle, block_id.to_vec())?;
-        match serialized_block {
-            Some(serialized_block) => {
-                let block: Block = serde_json::from_slice(&serialized_block)?;
-                Ok(Some(block))
-            },
-            None => Ok(None),
-        }
-    }
-    
+	async fn remove_block(&self, block_id: Id) -> MempoolBlockOperationsResult<()> {
+		let db = self.db.write().await;
+		db.delete_from_handle("blocks", block_id.to_vec())
+			.map_err(MempoolBlockOperationsError::store_error)?;
+		Ok(())
+	}
+
+	async fn get_block(&self, block_id: Id) -> MempoolBlockOperationsResult<Option<Block>> {
+		let db = self.db.read().await;
+		let serialized_block = db
+			.get_from_handle("blocks", block_id.to_vec())
+			.map_err(MempoolBlockOperationsError::store_error)?;
+		match serialized_block {
+			Some(serialized_block) => {
+				let block: Block = serde_json::from_slice(&serialized_block).map_err(|e| {
+					MempoolBlockOperationsError::DeserializationError(e.to_string())
+				})?;
+				Ok(Some(block))
+			},
+			None => Ok(None),
+		}
+	}
 }
 
 #[cfg(test)]
 pub mod test {
 
-    use super::*;
-    use movement_types::Transaction;
-    use tempfile::tempdir;
+	use super::*;
+	use movement_types::Transaction;
+	use tempfile::tempdir;
 
-    #[tokio::test]
-    async fn test_rocksdb_mempool_basic_operations() -> Result<(), Error>{
-        let temp_dir = tempdir().unwrap();
-        let path = temp_dir.path().to_str().unwrap();
-        let mempool = RocksdbMempool::try_new(path)?;
+	use anyhow::Result;
 
-        let tx = MempoolTransaction::test();
-        let tx_id = tx.id();
-        mempool.add_mempool_transaction(tx.clone()).await?;
-        assert!(mempool.has_mempool_transaction(tx_id.clone()).await?);
-        let tx2 = mempool.get_mempool_transaction(tx_id.clone()).await?;
-        assert_eq!(Some(tx), tx2);
-        mempool.remove_mempool_transaction(tx_id.clone()).await?;
-        assert!(!mempool.has_mempool_transaction(tx_id.clone()).await?);
+	#[tokio::test]
+	async fn test_rocksdb_mempool_basic_operations() -> Result<()> {
+		let temp_dir = tempdir().unwrap();
+		let path = temp_dir.path().to_str().unwrap();
+		let mempool = RocksdbMempool::try_new(path)?;
 
-        let block = Block::test();
-        let block_id = block.id();
-        mempool.add_block(block.clone()).await?;
-        assert!(mempool.has_block(block_id.clone()).await?);
-        let block2 = mempool.get_block(block_id.clone()).await?;
-        assert_eq!(Some(block), block2);
-        mempool.remove_block(block_id.clone()).await?;
-        assert!(!mempool.has_block(block_id.clone()).await?);
+		let tx = MempoolTransaction::test();
+		let tx_id = tx.id();
+		mempool.add_mempool_transaction(tx.clone()).await?;
+		assert!(mempool.has_mempool_transaction(tx_id.clone()).await?);
+		let tx2 = mempool.get_mempool_transaction(tx_id.clone()).await?;
+		assert_eq!(Some(tx), tx2);
+		mempool.remove_mempool_transaction(tx_id.clone()).await?;
+		assert!(!mempool.has_mempool_transaction(tx_id.clone()).await?);
 
-        Ok(())
-    }
+		let block = Block::test();
+		let block_id = block.id();
+		mempool.add_block(block.clone()).await?;
+		assert!(mempool.has_block(block_id.clone()).await?);
+		let block2 = mempool.get_block(block_id.clone()).await?;
+		assert_eq!(Some(block), block2);
+		mempool.remove_block(block_id.clone()).await?;
+		assert!(!mempool.has_block(block_id.clone()).await?);
 
-    #[tokio::test]
-    async fn test_rocksdb_transaction_operations() -> Result<(), Error> {
-        let temp_dir = tempdir().unwrap();
-        let path = temp_dir.path().to_str().unwrap();
-        let mempool = RocksdbMempool::try_new(path)?;
+		Ok(())
+	}
 
-        let tx = Transaction::test();
-        let tx_id = tx.id();
-        mempool.add_transaction(tx.clone()).await?;
-        assert!(mempool.has_transaction(tx_id.clone()).await?);
-        let tx2 = mempool.get_transaction(tx_id.clone()).await?;
-        assert_eq!(Some(tx), tx2);
-        mempool.remove_transaction(tx_id.clone()).await?;
-        assert!(!mempool.has_transaction(tx_id.clone()).await?);
+	#[tokio::test]
+	async fn test_rocksdb_transaction_operations() -> Result<()> {
+		let temp_dir = tempdir().unwrap();
+		let path = temp_dir.path().to_str().unwrap();
+		let mempool = RocksdbMempool::try_new(path)?;
 
-        Ok(())
-    }
+		let tx = Transaction::test();
+		let tx_id = tx.id();
+		mempool.add_transaction(tx.clone()).await?;
+		assert!(mempool.has_transaction(tx_id.clone()).await?);
+		let tx2 = mempool.get_transaction(tx_id.clone()).await?;
+		assert_eq!(Some(tx), tx2);
+		mempool.remove_transaction(tx_id.clone()).await?;
+		assert!(!mempool.has_transaction(tx_id.clone()).await?);
 
-    #[tokio::test]
-    async fn test_transaction_slot_based_ordering() -> Result<(), Error> {
-        let temp_dir = tempdir().unwrap();
-        let path = temp_dir.path().to_str().unwrap();
-        let mempool = RocksdbMempool::try_new(path)?;
+		Ok(())
+	}
 
-        let tx1 = MempoolTransaction::at_time(
-            Transaction::new(
-                vec![1],
-            ),
-            2,
-        );
-        let tx2 = MempoolTransaction::at_time(
-            Transaction::new(
-                vec![2],
-            ),
-            64,
-        );
-        let tx3 = MempoolTransaction::at_time(
-            Transaction::new(
-                vec![3],
-            ),
-            128
-        );
+	#[tokio::test]
+	async fn test_transaction_slot_based_ordering() -> Result<()> {
+		let temp_dir = tempdir().unwrap();
+		let path = temp_dir.path().to_str().unwrap();
+		let mempool = RocksdbMempool::try_new(path)?;
 
-        mempool.add_mempool_transaction(tx2.clone()).await?;
-        mempool.add_mempool_transaction(tx1.clone()).await?;
-        mempool.add_mempool_transaction(tx3.clone()).await?;
+		let tx1 = MempoolTransaction::at_time(Transaction::new(vec![1]), 2);
+		let tx2 = MempoolTransaction::at_time(Transaction::new(vec![2]), 64);
+		let tx3 = MempoolTransaction::at_time(Transaction::new(vec![3]), 128);
 
-        let txs = mempool.pop_mempool_transactions(3).await?;
-        assert_eq!(txs[0], tx1);
-        assert_eq!(txs[1], tx2);
-        assert_eq!(txs[2], tx3);
+		mempool.add_mempool_transaction(tx2.clone()).await?;
+		mempool.add_mempool_transaction(tx1.clone()).await?;
+		mempool.add_mempool_transaction(tx3.clone()).await?;
 
-        Ok(())
-    }
+		let txs = mempool.pop_mempool_transactions(3).await?;
+		assert_eq!(txs[0], tx1);
+		assert_eq!(txs[1], tx2);
+		assert_eq!(txs[2], tx3);
 
+		Ok(())
+	}
 }

--- a/protocol-units/mempool/util/Cargo.toml
+++ b/protocol-units/mempool/util/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = { workspace = true }
 [dependencies]
 serde = { workspace = true}
 movement-types = { workspace = true }
-anyhow = { workspace = true }
+thiserror = { workspace = true }
 
 [lints]
 workspace = true

--- a/protocol-units/mempool/util/src/lib.rs
+++ b/protocol-units/mempool/util/src/lib.rs
@@ -130,36 +130,36 @@ pub trait MempoolTransactionOperations {
 }
 
 #[derive(Error, Debug)]
-pub enum MempoolBlockOperationsError {
+pub enum MempoolBlockOperationsError<E> {
 	#[error("Store error: {0}")]
-	StoreError(#[from] BoxedStoreError),
+	StoreError(E),
 	#[error("Serialization error: {0}")]
 	SerializeError(String),
 	#[error("Deserialization error: {0}")]
 	DeserializationError(String),
 }
 
-impl MempoolBlockOperationsError {
-	pub fn store_error<E: std::error::Error + Send + Sync + 'static>(error: E) -> Self {
-		Self::StoreError(Box::new(error))
+impl<E: std::error::Error + Send + Sync + 'static> From<E> for MempoolBlockOperationsError<E> {
+	fn from(error: E) -> Self {
+		Self::StoreError(error)
 	}
 }
 
-pub type MempoolBlockOperationsResult<T> = Result<T, MempoolBlockOperationsError>;
+pub type MempoolBlockOperationsResult<T, E> = Result<T, MempoolBlockOperationsError<E>>;
 
 #[allow(async_fn_in_trait)]
-pub trait MempoolBlockOperations {
+pub trait MempoolBlockOperations<E> {
 	/// Checks whether a block exists in the mempool.
-	async fn has_block(&self, block_id: Id) -> MempoolBlockOperationsResult<bool>;
+	async fn has_block(&self, block_id: Id) -> MempoolBlockOperationsResult<bool, E>;
 
 	/// Adds a block to the mempool.
-	async fn add_block(&self, block: Block) -> MempoolBlockOperationsResult<()>;
+	async fn add_block(&self, block: Block) -> MempoolBlockOperationsResult<(), E>;
 
 	/// Removes a block from the mempool.
-	async fn remove_block(&self, block_id: Id) -> MempoolBlockOperationsResult<()>;
+	async fn remove_block(&self, block_id: Id) -> MempoolBlockOperationsResult<(), E>;
 
 	/// Gets a block from the mempool.
-	async fn get_block(&self, block_id: Id) -> MempoolBlockOperationsResult<Option<Block>>;
+	async fn get_block(&self, block_id: Id) -> MempoolBlockOperationsResult<Option<Block>, E>;
 }
 
 /// Wraps a transaction with a timestamp for help ordering.

--- a/protocol-units/mempool/util/src/lib.rs
+++ b/protocol-units/mempool/util/src/lib.rs
@@ -1,172 +1,224 @@
 use serde::{Deserialize, Serialize};
 
-use movement_types::{Block, Transaction, Id};
+use movement_types::{Block, Id, Transaction};
 use std::cmp::Ordering;
+use thiserror::Error;
 
-pub trait MempoolTransactionOperations {
-    
-    // todo: move mempool_transaction methods into separate trait
+pub type BoxedStoreError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-    /// Checks whether a mempool transaction exists in the mempool.
-    async fn has_mempool_transaction(&self, transaction_id :Id) -> Result<bool, anyhow::Error>;
-
-    /// Adds a mempool transaction to the mempool.
-    async fn add_mempool_transaction(&self, tx: MempoolTransaction) -> Result<(), anyhow::Error>;
-
-    /// Removes a mempool transaction from the mempool.
-    async fn remove_mempool_transaction(&self, transaction_id:Id) -> Result<(), anyhow::Error>;
-
-    /// Pops mempool transaction from the mempool.
-    async fn pop_mempool_transaction(&self) -> Result<Option<MempoolTransaction>, anyhow::Error>;
- 
-    /// Gets a mempool transaction from the mempool.
-    async fn get_mempool_transaction(&self, transaction_id:Id) -> Result<Option<MempoolTransaction>, anyhow::Error>;
-
-    /// Pops the next n mempool transactions from the mempool.
-    async fn pop_mempool_transactions(&self, n: usize) -> Result<Vec<MempoolTransaction>, anyhow::Error> {
-        let mut mempool_transactions = Vec::with_capacity(n);
-        for _ in 0..n {
-            if let Some(mempool_transaction) = self.pop_mempool_transaction().await? {
-                mempool_transactions.push(mempool_transaction);
-            } else {
-                break;
-            }
-        }
-        Ok(mempool_transactions)
-    }
-
-    /// Checks whether the mempool has the transaction.
-    async fn has_transaction(&self, transaction_id:Id) -> Result<bool, anyhow::Error> {
-        self.has_mempool_transaction(transaction_id).await
-    }
-
-    /// Adds a transaction to the mempool.
-    async fn add_transaction(&self, tx: Transaction) -> Result<(), anyhow::Error> {
-
-        if self.has_transaction(tx.id()).await? {
-            return Ok(());
-        }
-
-        let mempool_transaction = MempoolTransaction::slot_now(tx);
-        self.add_mempool_transaction(mempool_transaction).await
-
-    }
-
-    /// Removes a transaction from the mempool.
-    async fn remove_transaction(&self, transaction_id:Id) -> Result<(), anyhow::Error> {
-        self.remove_mempool_transaction(transaction_id).await
-    }
-
-    /// Pops transaction from the mempool.
-    async fn pop_transaction(&self) -> Result<Option<Transaction>, anyhow::Error> {
-        let mempool_transaction = self.pop_mempool_transaction().await?;
-        Ok(mempool_transaction.map(|mempool_transaction| mempool_transaction.transaction))
-    }
-
-    /// Gets a transaction from the mempool.
-    async fn get_transaction(&self, transaction_id:Id) -> Result<Option<Transaction>, anyhow::Error> {
-        let mempool_transaction = self.get_mempool_transaction(transaction_id).await?;
-        Ok(mempool_transaction.map(|mempool_transaction| mempool_transaction.transaction))
-    }
-
-    /// Pops the next n transactions from the mempool.
-    async fn pop_transactions(&self, n: usize) -> Result<Vec<Transaction>, anyhow::Error> {
-        let mempool_transactions = self.pop_mempool_transactions(n).await?;
-        Ok(mempool_transactions.into_iter().map(|mempool_transaction| mempool_transaction.transaction).collect())
-    }
-
+#[derive(Error, Debug)]
+pub enum MempoolTransactionOperationsError {
+	#[error("Serialization error: {0}")]
+	SerializationError(String),
+	#[error("Deserialization error: {0}")]
+	DeserializationError(String),
+	#[error("Underlying store error")]
+	StoreError(#[from] BoxedStoreError),
+	#[error("Mock error: {0}")]
+	MockError(String),
 }
 
+impl MempoolTransactionOperationsError {
+	pub fn store_error<E: std::error::Error + Send + Sync + 'static>(error: E) -> Self {
+		Self::StoreError(Box::new(error))
+	}
+}
 
+pub type MempoolTransactionOperationsResult<T> = Result<T, MempoolTransactionOperationsError>;
+
+#[allow(async_fn_in_trait)]
+pub trait MempoolTransactionOperations {
+	// todo: move mempool_transaction methods into separate trait
+
+	/// Checks whether a mempool transaction exists in the mempool.
+	async fn has_mempool_transaction(
+		&self,
+		transaction_id: Id,
+	) -> MempoolTransactionOperationsResult<bool>;
+
+	/// Adds a mempool transaction to the mempool.
+	async fn add_mempool_transaction(
+		&self,
+		tx: MempoolTransaction,
+	) -> MempoolTransactionOperationsResult<()>;
+
+	/// Removes a mempool transaction from the mempool.
+	async fn remove_mempool_transaction(
+		&self,
+		transaction_id: Id,
+	) -> MempoolTransactionOperationsResult<()>;
+
+	/// Pops mempool transaction from the mempool.
+	async fn pop_mempool_transaction(
+		&self,
+	) -> MempoolTransactionOperationsResult<Option<MempoolTransaction>>;
+
+	/// Gets a mempool transaction from the mempool.
+	async fn get_mempool_transaction(
+		&self,
+		transaction_id: Id,
+	) -> MempoolTransactionOperationsResult<Option<MempoolTransaction>>;
+
+	/// Pops the next n mempool transactions from the mempool.
+	async fn pop_mempool_transactions(
+		&self,
+		n: usize,
+	) -> MempoolTransactionOperationsResult<Vec<MempoolTransaction>> {
+		let mut mempool_transactions = Vec::with_capacity(n);
+		for _ in 0..n {
+			if let Some(mempool_transaction) = self.pop_mempool_transaction().await? {
+				mempool_transactions.push(mempool_transaction);
+			} else {
+				break;
+			}
+		}
+		Ok(mempool_transactions)
+	}
+
+	/// Checks whether the mempool has the transaction.
+	async fn has_transaction(
+		&self,
+		transaction_id: Id,
+	) -> MempoolTransactionOperationsResult<bool> {
+		self.has_mempool_transaction(transaction_id).await
+	}
+
+	/// Adds a transaction to the mempool.
+	async fn add_transaction(&self, tx: Transaction) -> MempoolTransactionOperationsResult<()> {
+		if self.has_transaction(tx.id()).await? {
+			return Ok(());
+		}
+
+		let mempool_transaction = MempoolTransaction::slot_now(tx);
+		self.add_mempool_transaction(mempool_transaction).await
+	}
+
+	/// Removes a transaction from the mempool.
+	async fn remove_transaction(
+		&self,
+		transaction_id: Id,
+	) -> MempoolTransactionOperationsResult<()> {
+		self.remove_mempool_transaction(transaction_id).await
+	}
+
+	/// Pops transaction from the mempool.
+	async fn pop_transaction(&self) -> MempoolTransactionOperationsResult<Option<Transaction>> {
+		let mempool_transaction = self.pop_mempool_transaction().await?;
+		Ok(mempool_transaction.map(|mempool_transaction| mempool_transaction.transaction))
+	}
+
+	/// Gets a transaction from the mempool.
+	async fn get_transaction(
+		&self,
+		transaction_id: Id,
+	) -> MempoolTransactionOperationsResult<Option<Transaction>> {
+		let mempool_transaction = self.get_mempool_transaction(transaction_id).await?;
+		Ok(mempool_transaction.map(|mempool_transaction| mempool_transaction.transaction))
+	}
+
+	/// Pops the next n transactions from the mempool.
+	async fn pop_transactions(
+		&self,
+		n: usize,
+	) -> MempoolTransactionOperationsResult<Vec<Transaction>> {
+		let mempool_transactions = self.pop_mempool_transactions(n).await?;
+		Ok(mempool_transactions
+			.into_iter()
+			.map(|mempool_transaction| mempool_transaction.transaction)
+			.collect())
+	}
+}
+
+#[derive(Error, Debug)]
+pub enum MempoolBlockOperationsError {
+	#[error("Store error: {0}")]
+	StoreError(#[from] BoxedStoreError),
+	#[error("Serialization error: {0}")]
+	SerializeError(String),
+	#[error("Deserialization error: {0}")]
+	DeserializationError(String),
+}
+
+impl MempoolBlockOperationsError {
+	pub fn store_error<E: std::error::Error + Send + Sync + 'static>(error: E) -> Self {
+		Self::StoreError(Box::new(error))
+	}
+}
+
+pub type MempoolBlockOperationsResult<T> = Result<T, MempoolBlockOperationsError>;
+
+#[allow(async_fn_in_trait)]
 pub trait MempoolBlockOperations {
-    
-    /// Checks whether a block exists in the mempool.
-    async fn has_block(&self, block_id :Id) -> Result<bool, anyhow::Error>;
+	/// Checks whether a block exists in the mempool.
+	async fn has_block(&self, block_id: Id) -> MempoolBlockOperationsResult<bool>;
 
-    /// Adds a block to the mempool.
-    async fn add_block(&self, block: Block) -> Result<(), anyhow::Error>;
+	/// Adds a block to the mempool.
+	async fn add_block(&self, block: Block) -> MempoolBlockOperationsResult<()>;
 
-    /// Removes a block from the mempool.
-    async fn remove_block(&self, block_id:Id) -> Result<(), anyhow::Error>;
- 
-    /// Gets a block from the mempool.
-    async fn get_block(&self, block_id:Id) -> Result<Option<Block>, anyhow::Error>;
+	/// Removes a block from the mempool.
+	async fn remove_block(&self, block_id: Id) -> MempoolBlockOperationsResult<()>;
 
+	/// Gets a block from the mempool.
+	async fn get_block(&self, block_id: Id) -> MempoolBlockOperationsResult<Option<Block>>;
 }
 
 /// Wraps a transaction with a timestamp for help ordering.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MempoolTransaction {
-    pub transaction: Transaction,
-    pub timestamp: u64,
-    pub slot_seconds : u64
+	pub transaction: Transaction,
+	pub timestamp: u64,
+	pub slot_seconds: u64,
 }
 
 impl PartialOrd for MempoolTransaction {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+		Some(self.cmp(other))
+	}
 }
 
 /// Ordered first by slot_seconds, then by transaction.
 /// This allows us to use a BTreeSet to order transactions by slot_seconds, and then by transaction and pop them off in order.
 impl Ord for MempoolTransaction {
-    fn cmp(&self, other: &Self) -> Ordering {
-        // First, compare by slot_seconds
-        match self.slot_seconds.cmp(&other.slot_seconds) {
-            Ordering::Equal => {}
-            non_equal => return non_equal,
-        }
-        // If slot_seconds are equal, then compare by transaction
-        self.transaction.cmp(&other.transaction)
-    }
+	fn cmp(&self, other: &Self) -> Ordering {
+		// First, compare by slot_seconds
+		match self.slot_seconds.cmp(&other.slot_seconds) {
+			Ordering::Equal => {},
+			non_equal => return non_equal,
+		}
+		// If slot_seconds are equal, then compare by transaction
+		self.transaction.cmp(&other.transaction)
+	}
 }
 
 impl MempoolTransaction {
+	const SLOT_SECONDS: u64 = 2;
 
-    const SLOT_SECONDS : u64 = 2;
+	/// Creates a test MempoolTransaction.
+	pub fn test() -> Self {
+		Self { transaction: Transaction::test(), timestamp: 0, slot_seconds: Self::SLOT_SECONDS }
+	}
 
-    /// Creates a test MempoolTransaction.
-    pub fn test() -> Self {
-        Self {
-            transaction: Transaction::test(),
-            timestamp: 0,
-            slot_seconds: Self::SLOT_SECONDS
-        }
-    }
+	pub fn at_time(transaction: Transaction, timestamp: u64) -> Self {
+		let floor = (timestamp / Self::SLOT_SECONDS) * Self::SLOT_SECONDS;
+		Self { transaction, timestamp: floor, slot_seconds: Self::SLOT_SECONDS }
+	}
 
-    pub fn at_time(transaction: Transaction, timestamp: u64) -> Self {
-        let floor = (
-            timestamp / Self::SLOT_SECONDS
-        ) * Self::SLOT_SECONDS;
-        Self {
-            transaction,
-            timestamp : floor,
-            slot_seconds: Self::SLOT_SECONDS
-        }
-    }
+	pub fn new(transaction: Transaction, timestamp: u64, slot_seconds: u64) -> Self {
+		Self { transaction, timestamp, slot_seconds }
+	}
 
-    pub fn new(transaction: Transaction, timestamp: u64, slot_seconds: u64) -> Self {
-        Self {
-            transaction,
-            timestamp,
-            slot_seconds
-        }
-    }
+	/// Creates a new MempoolTransaction with the current timestamp floored to the nearest slot.
+	/// todo: probably want to move this out to a factory.
+	pub fn slot_now(transaction: Transaction) -> MempoolTransaction {
+		let timestamp = std::time::SystemTime::now()
+			.duration_since(std::time::UNIX_EPOCH)
+			.unwrap()
+			.as_secs();
 
-    /// Creates a new MempoolTransaction with the current timestamp floored to the nearest slot.
-    /// todo: probably want to move this out to a factory.
-    pub fn slot_now(transaction : Transaction) -> MempoolTransaction {
-        
-        let timestamp = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
-    
-        Self::at_time(transaction, timestamp)
-        
-    }
+		Self::at_time(transaction, timestamp)
+	}
 
-    pub fn id(&self) ->Id {
-        self.transaction.id()
-    }
-    
-
+	pub fn id(&self) -> Id {
+		self.transaction.id()
+	}
 }

--- a/protocol-units/sequencing/util/Cargo.toml
+++ b/protocol-units/sequencing/util/Cargo.toml
@@ -14,7 +14,8 @@ rust-version = { workspace = true }
 [dependencies]
 tokio = { workspace = true }
 movement-types = { workspace = true }
-anyhow = { workspace = true }
+thiserror = { workspace = true }
+mempool-util = { workspace = true }
 
 [lints]
 workspace = true

--- a/protocol-units/sequencing/util/src/lib.rs
+++ b/protocol-units/sequencing/util/src/lib.rs
@@ -1,17 +1,27 @@
-use movement_types::{Block, Transaction, AtomicTransactionBundle};
+use mempool_util::{MempoolBlockOperationsError, MempoolTransactionOperationsError};
+use movement_types::{AtomicTransactionBundle, Block, Transaction};
+use thiserror::Error;
 
-pub trait Sequencer {
-
-    async fn publish(&self, atb: Transaction) -> Result<(), anyhow::Error>;
-
-    async fn wait_for_next_block(&self) -> Result<Option<Block>, anyhow::Error>;
-
+#[derive(Error, Debug)]
+pub enum SequencerError {
+	#[error("MempoolTransactionOperationsError error: {0}")]
+	MempoolTransactionOperationsError(#[from] MempoolTransactionOperationsError),
+	#[error("MempoolBlockOperationsError error: {0}")]
+	MempoolBlockOperationsError(#[from] MempoolBlockOperationsError),
 }
 
+pub type SequencerResult<T> = Result<T, SequencerError>;
+
+#[allow(async_fn_in_trait)]
+pub trait Sequencer {
+	async fn publish(&self, atb: Transaction) -> SequencerResult<()>;
+
+	async fn wait_for_next_block(&self) -> SequencerResult<Option<Block>>;
+}
+
+#[allow(async_fn_in_trait)]
 pub trait SharedSequencer {
+	async fn publish(&self, atb: AtomicTransactionBundle) -> SequencerResult<()>;
 
-    async fn publish(&self, atb: AtomicTransactionBundle) -> Result<(), anyhow::Error>;
-
-    async fn wait_for_next_block(&self) -> Result<Option<Block>, anyhow::Error>;
-
+	async fn wait_for_next_block(&self) -> SequencerResult<Option<Block>>;
 }

--- a/protocol-units/sequencing/util/src/lib.rs
+++ b/protocol-units/sequencing/util/src/lib.rs
@@ -3,25 +3,25 @@ use movement_types::{AtomicTransactionBundle, Block, Transaction};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum SequencerError {
+pub enum SequencerError<E> {
 	#[error("MempoolTransactionOperationsError error: {0}")]
 	MempoolTransactionOperationsError(#[from] MempoolTransactionOperationsError),
 	#[error("MempoolBlockOperationsError error: {0}")]
-	MempoolBlockOperationsError(#[from] MempoolBlockOperationsError),
+	MempoolBlockOperationsError(#[from] MempoolBlockOperationsError<E>),
 }
 
-pub type SequencerResult<T> = Result<T, SequencerError>;
+pub type SequencerResult<T, E> = Result<T, SequencerError<E>>;
 
 #[allow(async_fn_in_trait)]
-pub trait Sequencer {
-	async fn publish(&self, atb: Transaction) -> SequencerResult<()>;
+pub trait Sequencer<E> {
+	async fn publish(&self, atb: Transaction) -> SequencerResult<(), E>;
 
-	async fn wait_for_next_block(&self) -> SequencerResult<Option<Block>>;
+	async fn wait_for_next_block(&self) -> SequencerResult<Option<Block>, E>;
 }
 
 #[allow(async_fn_in_trait)]
-pub trait SharedSequencer {
-	async fn publish(&self, atb: AtomicTransactionBundle) -> SequencerResult<()>;
+pub trait SharedSequencer<E> {
+	async fn publish(&self, atb: AtomicTransactionBundle) -> SequencerResult<(), E>;
 
-	async fn wait_for_next_block(&self) -> SequencerResult<Option<Block>>;
+	async fn wait_for_next_block(&self) -> SequencerResult<Option<Block>, E>;
 }

--- a/util/movement-types/Cargo.toml
+++ b/util/movement-types/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true }
 # derivative = { workspace = true }
-anyhow = { workspace = true }
+thiserror = { workspace = true }
 sha2 = { workspace = true }
 
 [lints]

--- a/util/movement-types/src/lib.rs
+++ b/util/movement-types/src/lib.rs
@@ -1,6 +1,7 @@
 use core::fmt::Display;
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
+use thiserror::Error;
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Id(pub Vec<u8>);
@@ -23,6 +24,12 @@ impl Display for Id {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		write!(f, "{:?}", &self.0)
 	}
+}
+
+#[derive(Error, Debug)]
+pub enum TransactionError {
+	#[error("AtomicTransactionBundle must contain exactly one transaction")]
+	AtomicTransactionBundleMustContainExactlyOneTransaction,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -63,13 +70,13 @@ pub struct AtomicTransactionBundle {
 }
 
 impl TryFrom<AtomicTransactionBundle> for Transaction {
-	type Error = anyhow::Error;
+	type Error = TransactionError;
 
 	fn try_from(value: AtomicTransactionBundle) -> Result<Self, Self::Error> {
 		if value.transactions.len() == 1 {
 			Ok(value.transactions[0].data.clone())
 		} else {
-			Err(anyhow::anyhow!("AtomicTransactionBundle must contain exactly one transaction"))
+			Err(TransactionError::AtomicTransactionBundleMustContainExactlyOneTransaction)
 		}
 	}
 }

--- a/util/movement-types/src/lib.rs
+++ b/util/movement-types/src/lib.rs
@@ -6,136 +6,120 @@ use sha2::Digest;
 pub struct Id(pub Vec<u8>);
 
 impl Id {
-    pub fn test() -> Self {
-        Self(vec![0])
-    }
+	pub fn test() -> Self {
+		Self(vec![0])
+	}
 
-    pub fn to_vec(&self) -> Vec<u8> {
-        self.0.clone()
-    }
+	pub fn to_vec(&self) -> Vec<u8> {
+		self.0.clone()
+	}
 
-    pub fn genesis_block() -> Self {
-        Self(vec![0])
-    }
-
+	pub fn genesis_block() -> Self {
+		Self(vec![0])
+	}
 }
 
 impl Display for Id {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", &self.0)
-    }
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{:?}", &self.0)
+	}
 }
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Transaction(pub Vec<u8>);
 
 impl From<Vec<u8>> for Transaction {
-    fn from(data : Vec<u8>) -> Self {
-        Self(data)
-    }
+	fn from(data: Vec<u8>) -> Self {
+		Self(data)
+	}
 }
 
 impl Transaction {
-    pub fn new(data : Vec<u8>) -> Self {
-        Self(data)
-    }
+	pub fn new(data: Vec<u8>) -> Self {
+		Self(data)
+	}
 
-    pub fn id(&self) -> Id {
-        let mut hasher = sha2::Sha256::new();
-        hasher.update(&self.0);
-        Id(hasher.finalize().to_vec())
-    }
+	pub fn id(&self) -> Id {
+		let mut hasher = sha2::Sha256::new();
+		hasher.update(&self.0);
+		Id(hasher.finalize().to_vec())
+	}
 
-    pub fn test() -> Self {
-        Self(vec![0])
-    }
-
+	pub fn test() -> Self {
+		Self(vec![0])
+	}
 }
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TransactionEntry {
-    pub consumer_id : Id,
-    pub data : Transaction,
+	pub consumer_id: Id,
+	pub data: Transaction,
 }
 
-
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct AtomicTransactionBundle{
-    pub sequencer_id : Id,
-    pub transactions : Vec<TransactionEntry>,
+pub struct AtomicTransactionBundle {
+	pub sequencer_id: Id,
+	pub transactions: Vec<TransactionEntry>,
 }
 
 impl TryFrom<AtomicTransactionBundle> for Transaction {
-    type Error = anyhow::Error;
+	type Error = anyhow::Error;
 
-    fn try_from(value: AtomicTransactionBundle) -> Result<Self, Self::Error> {
-        
-        if value.transactions.len() == 1 {
-            Ok(value.transactions[0].data.clone())
-        } else {
-            Err(anyhow::anyhow!("AtomicTransactionBundle must contain exactly one transaction"))
-        }
-
-    }
+	fn try_from(value: AtomicTransactionBundle) -> Result<Self, Self::Error> {
+		if value.transactions.len() == 1 {
+			Ok(value.transactions[0].data.clone())
+		} else {
+			Err(anyhow::anyhow!("AtomicTransactionBundle must contain exactly one transaction"))
+		}
+	}
 }
 
 impl From<Transaction> for AtomicTransactionBundle {
-    fn from(transaction : Transaction) -> Self {
-        Self {
-            sequencer_id : Id::default(),
-            transactions : vec![TransactionEntry {
-                consumer_id : Id::default(),
-                data : transaction
-            }]
-        }
-    }
+	fn from(transaction: Transaction) -> Self {
+		Self {
+			sequencer_id: Id::default(),
+			transactions: vec![TransactionEntry { consumer_id: Id::default(), data: transaction }],
+		}
+	}
 }
-
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum BlockMetadata {
-    #[default]
-    BlockMetadata,
+	#[default]
+	BlockMetadata,
 }
-
-
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Block {
-    pub metadata : BlockMetadata,
-    pub parent : Vec<u8>,
-    pub transactions : Vec<Transaction>,
+	pub metadata: BlockMetadata,
+	pub parent: Vec<u8>,
+	pub transactions: Vec<Transaction>,
 }
 
 impl Block {
+	pub fn new(metadata: BlockMetadata, parent: Vec<u8>, transactions: Vec<Transaction>) -> Self {
+		Self { metadata, parent, transactions }
+	}
 
-    pub fn new(metadata : BlockMetadata, parent : Vec<u8>, transactions : Vec<Transaction>) -> Self {
-        Self {
-            metadata,
-            parent,
-            transactions
-        }
-    }
+	pub fn id(&self) -> Id {
+		let mut hasher = sha2::Sha256::new();
+		hasher.update(&self.parent);
+		for transaction in &self.transactions {
+			hasher.update(&transaction.0);
+		}
+		Id(hasher.finalize().to_vec())
+	}
 
-    pub fn id(&self) -> Id {
-        let mut hasher = sha2::Sha256::new();
-        hasher.update(&self.parent);
-        for transaction in &self.transactions {
-            hasher.update(&transaction.0);
-        }
-        Id(hasher.finalize().to_vec())
-    }
+	pub fn test() -> Self {
+		Self {
+			metadata: BlockMetadata::BlockMetadata,
+			parent: vec![0],
+			transactions: vec![Transaction::test()],
+		}
+	}
 
-    pub fn test() -> Self {
-        Self {
-            metadata : BlockMetadata::BlockMetadata,
-            parent : vec![0],
-            transactions : vec![Transaction::test()]
-        }
-    }
-
-    pub fn add_transaction(&mut self, transaction : Transaction) {
-        self.transactions.push(transaction);
-    }
-
+	pub fn add_transaction(&mut self, transaction: Transaction) {
+		self.transactions.push(transaction);
+	}
 }
+


### PR DESCRIPTION
# Summary
- **Status**: `draft`
- **Categories**: `protocol-units`.

This draft pull request demonstrates the utilization of generics as a
substitute for boxed errors in error variants. Leveraging generics can
potentially enhance type safety, improve performance by avoiding heap al
locations, and provide clearer insights into our error handling mechanisms by
explicitly defining error types.                                                                                                       
                                                                                                                                                                                                                     
Key Changes Proposed:                                                                                                                                                                                                
1. Replace `Box<dyn Error>` with a generic type parameter in relevant error variants.                                                                                                                                
2. Update function signatures and implementations to accommodate the new generic types.                                                                                                                              
