### PR TITLE
chore: remove Status field from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,4 @@
 # Summary
-- **Status**: `draft` <!-- `review`, `suspended` -->
 - **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
 - **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.
 


### PR DESCRIPTION
# Summary
- **Categories**: `misc`.

As currently intended, the Status text field will duplicate the actual status as managed by GitHub, so it's either double work or prone to be out of date.