### PR TITLE
ENG-446 Remove FinalityMode

### DIFF
--- a/networks/monza/monza-full-node/src/partial.rs
+++ b/networks/monza/monza-full-node/src/partial.rs
@@ -12,7 +12,6 @@ use monza_executor::{
     MonzaExecutor,
     ExecutableBlock,
     HashValue,
-    FinalityMode,
     Transaction,
     SignatureVerifiedTransaction,
     SignedTransaction,
@@ -185,10 +184,7 @@ impl <T : MonzaExecutor + Send + Sync + Clone>MonzaPartialNode<T> {
                 block
             );
             let block_id = executable_block.block_id;
-            self.executor.execute_block(
-                FinalityMode::Opt,
-                executable_block
-            ).await?;
+            self.executor.execute_block_opt(executable_block).await?;
 
             debug!("Executed block: {:?}", block_id);
 

--- a/networks/suzuka/suzuka-full-node/src/partial.rs
+++ b/networks/suzuka/suzuka-full-node/src/partial.rs
@@ -9,7 +9,7 @@ use mcr_settlement_manager::{
 };
 use movement_types::{Block, BlockCommitmentEvent};
 use suzuka_executor::{
-	v1::SuzukaExecutorV1, ExecutableBlock, ExecutableTransactions, FinalityMode, HashValue,
+	v1::SuzukaExecutorV1, ExecutableBlock, ExecutableTransactions, HashValue,
 	SignatureVerifiedTransaction, SignedTransaction, SuzukaExecutor, Transaction,
 };
 
@@ -200,7 +200,7 @@ where
 			let executable_block = ExecutableBlock::new(block_hash, block);
 			let block_id = executable_block.block_id;
 			let commitment =
-				self.executor.execute_block(FinalityMode::Opt, executable_block).await?;
+				self.executor.execute_block_opt(executable_block).await?;
 
             debug!("Executed block: {:?}", block_id);
 

--- a/protocol-units/execution/maptos/util/src/finality_mode.rs
+++ b/protocol-units/execution/maptos/util/src/finality_mode.rs
@@ -1,6 +1,0 @@
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum FinalityMode {
-    Dyn,
-    Opt,
-    Fin
-}

--- a/protocol-units/execution/maptos/util/src/lib.rs
+++ b/protocol-units/execution/maptos/util/src/lib.rs
@@ -1,4 +1,1 @@
-pub mod finality_mode;
 pub mod config;
-
-pub use finality_mode::*;

--- a/protocol-units/execution/monza/executor/src/lib.rs
+++ b/protocol-units/execution/monza/executor/src/lib.rs
@@ -10,7 +10,6 @@ pub use aptos_types::{
 pub use aptos_crypto::hash::HashValue;
 pub use aptos_api::runtime::Apis;
 
-pub use maptos_execution_util::FinalityMode;
 pub use movement_types::BlockCommitment;
 
 use async_channel::Sender;
@@ -24,10 +23,9 @@ pub trait MonzaExecutor {
     /// Runs the necessary background tasks.
     async fn run_background_tasks(&self) -> Result<(), anyhow::Error>;
 
-    /// Executes a block dynamically
-    async fn execute_block(
+    /// Executes a block optimistically
+    async fn execute_block_opt(
         &self,
-        mode: FinalityMode, 
         block: ExecutableBlock,
     ) -> Result<BlockCommitment, anyhow::Error>;
 
@@ -38,7 +36,7 @@ pub trait MonzaExecutor {
 	);
 
 	/// Gets the dyn API.
-	fn get_api(&self, mode: FinalityMode) -> Apis;
+	fn get_apis(&self) -> Apis;
 
     /// Get block head height.
     async fn get_block_head_height(&self) -> Result<u64, anyhow::Error>;

--- a/protocol-units/execution/suzuka/executor/src/lib.rs
+++ b/protocol-units/execution/suzuka/executor/src/lib.rs
@@ -10,7 +10,6 @@ pub use aptos_types::{
 pub use aptos_crypto::hash::HashValue;
 use aptos_api::runtime::Apis;
 
-pub use maptos_execution_util::FinalityMode;
 use movement_types::BlockCommitment;
 
 use async_channel::Sender;
@@ -24,10 +23,9 @@ pub trait SuzukaExecutor {
     /// Runs the necessary background tasks.
     async fn run_background_tasks(&self) -> Result<(), anyhow::Error>;
 
-    /// Executes a block dynamically
-    async fn execute_block(
+    /// Executes a block optimistically
+    async fn execute_block_opt(
         &self,
-        mode: FinalityMode, 
         block: ExecutableBlock,
     ) -> Result<BlockCommitment, anyhow::Error>;
 
@@ -38,7 +36,7 @@ pub trait SuzukaExecutor {
 	);
 
 	/// Gets the dyn API.
-	fn get_api(&self, mode: FinalityMode) -> Apis;
+	fn get_apis(&self) -> Apis;
 
     /// Get block head height.
     async fn get_block_head_height(&self) -> Result<u64, anyhow::Error>;


### PR DESCRIPTION
# Summary
- **Categories**: `protocol-units`

The dynamic selector of finality modes is a vestige,
remove it making the internal composition of executors static.

# Changelog

- Removed the `FinalityMode` dynamic selector from executor interfaces.

# Testing

Existing tests need to pass after code refactoring.

# Outstanding issues
