### PR TITLE
Remove `Arc<RwLock<_>>` around `DbReaderWriter`

### DIFF
--- a/protocol-units/execution/monza/executor/src/v1.rs
+++ b/protocol-units/execution/monza/executor/src/v1.rs
@@ -311,21 +311,18 @@ mod tests {
 		if let Some((_max_blockheight, last_commit)) =
 			committed_blocks.iter().max_by_key(|(&k, _)| k)
 		{
-			let db = executor.executor.db.clone();
-			let db_writer = db.write_owned().await.writer.clone();
+			let db_writer = executor.executor.db.writer.clone();
 			db_writer.revert_commit(
 				version_to_revert,
 				last_commit.cur_ver,
 				revert.hash,
 				revert.info.clone(),
 			)?;
-
-			drop(db_writer);
 		} else {
 			panic!("No blocks to revert");
 		}
 
-		let db_reader = executor.executor.db.read_owned().await.reader.clone();
+		let db_reader = executor.executor.db.reader.clone();
 		let latest_version = db_reader.get_latest_version()?;
 		assert_eq!(latest_version, version_to_revert - 1);
 

--- a/protocol-units/execution/monza/fin-executor/src/executor.rs
+++ b/protocol-units/execution/monza/fin-executor/src/executor.rs
@@ -56,7 +56,7 @@ pub struct Executor {
 	/// The current state of the executor.
 	pub status: ExecutorState,
 	/// The access to db.
-	pub db: Arc<RwLock<DbReaderWriter>>,
+	pub db: DbReaderWriter,
 	/// The signer of the executor's transactions.
 	pub signer: ValidatorSigner,
 	/// The access to the core mempool.
@@ -79,7 +79,7 @@ impl Executor {
 		Self {
 			block_executor: Arc::new(RwLock::new(block_executor)),
 			status: ExecutorState::Idle,
-			db: Arc::new(RwLock::new(reader_writer)),
+			db: reader_writer,
 			signer,
 			mempool,
 		}
@@ -106,12 +106,12 @@ impl Executor {
 		mempool: CoreMempool
 	) -> Result<Self, anyhow::Error> {
 
-		let db_rw = Self::bootstrap_empty_db(db_dir)?;
+		let db = Self::bootstrap_empty_db(db_dir)?;
 
 		Ok(Self {
-			block_executor: Arc::new(RwLock::new(BlockExecutor::new(db_rw.clone()))),
+			block_executor: Arc::new(RwLock::new(BlockExecutor::new(db.clone()))),
 			status: ExecutorState::Idle,
-			db: Arc::new(RwLock::new(db_rw)),
+			db,
 			signer,
 			mempool,
 		})

--- a/protocol-units/execution/suzuka/fin-executor/src/executor.rs
+++ b/protocol-units/execution/suzuka/fin-executor/src/executor.rs
@@ -56,7 +56,7 @@ pub struct Executor {
 	/// The current state of the executor.
 	pub status: ExecutorState,
 	/// The access to db.
-	pub db: Arc<RwLock<DbReaderWriter>>,
+	pub db: DbReaderWriter,
 	/// The signer of the executor's transactions.
 	pub signer: ValidatorSigner,
 	/// The access to the core mempool.
@@ -79,7 +79,7 @@ impl Executor {
 		Self {
 			block_executor: Arc::new(RwLock::new(block_executor)),
 			status: ExecutorState::Idle,
-			db: Arc::new(RwLock::new(reader_writer)),
+			db: reader_writer,
 			signer,
 			mempool,
 		}
@@ -106,12 +106,12 @@ impl Executor {
 		mempool: CoreMempool
 	) -> Result<Self, anyhow::Error> {
 
-		let db_rw = Self::bootstrap_empty_db(db_dir)?;
+		let db = Self::bootstrap_empty_db(db_dir)?;
 
 		Ok(Self {
-			block_executor: Arc::new(RwLock::new(BlockExecutor::new(db_rw.clone()))),
+			block_executor: Arc::new(RwLock::new(BlockExecutor::new(db.clone()))),
 			status: ExecutorState::Idle,
-			db: Arc::new(RwLock::new(db_rw)),
+			db,
 			signer,
 			mempool,
 		})


### PR DESCRIPTION
# Summary
- **Categories**: `protocol-units`

`DbReaderWriter` itself is two (ludicrously redundant) `Arc` pointers, so it's cheaply cloneable and generally, there's no need to guard or share this object.

To be further fixed some day: https://github.com/aptos-labs/aptos-core/issues/13464

# Changelog

- Simplified management of `DbReaderWriter` handles inside executor state.

# Testing

Existing tests pass after the refactoring.
