### PR TITLE
mcr-settlement-config: slim crate for MCR-related configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7045,14 +7045,23 @@ dependencies = [
  "async-stream",
  "async-trait",
  "futures",
+ "mcr-settlement-config",
  "movement-types",
- "serde",
  "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
  "tracing",
  "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "mcr-settlement-config"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "toml 0.8.2",
 ]
 
 [[package]]
@@ -11009,7 +11018,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "maptos-execution-util",
- "mcr-settlement-client",
+ "mcr-settlement-config",
  "serde",
  "serde_derive",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "protocol-units/sequencing/memseq/*",
     "protocol-units/mempool/*",
     "protocol-units/settlement/mcr/client",
+    "protocol-units/settlement/mcr/config",
     "protocol-units/settlement/mcr/manager",
     "util/*",
     "util/buildtime/buildtime-helpers",
@@ -55,6 +56,7 @@ memseq-util = { path = "protocol-units/sequencing/memseq/util" }
 sequencing-util = { path = "protocol-units/sequencing/util" }
 ## settlement
 mcr-settlement-client = { path = "protocol-units/settlement/mcr/client" }
+mcr-settlement-config = { path = "protocol-units/settlement/mcr/config" }
 mcr-settlement-manager = { path = "protocol-units/settlement/mcr/manager" }
 ## types
 movement-types = { path = "util/movement-types" }
@@ -135,6 +137,9 @@ secp256k1 = { version = "0.27", default-features = false, features = [
 ## Celestia Dependencies
 celestia-rpc = { git = "https://github.com/eigerco/lumina" }
 celestia-types = { git = "https://github.com/eigerco/lumina" }
+
+## Alloy dependencies
+alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy.git" }
 
 anyhow = "1.0"
 async-channel = "2.2.1"

--- a/networks/suzuka/suzuka-config/Cargo.toml
+++ b/networks/suzuka/suzuka-config/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 maptos-execution-util = { workspace = true }
-mcr-settlement-client = { workspace = true }
+mcr-settlement-config = { workspace = true }
 anyhow = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/networks/suzuka/suzuka-config/src/lib.rs
+++ b/networks/suzuka/suzuka-config/src/lib.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 use maptos_execution_util::config::Config as ExecConfig;
-use mcr_settlement_client::eth_client::Config as McrConfig;
+use mcr_settlement_config::Config as McrConfig;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {

--- a/protocol-units/settlement/mcr/client/Cargo.toml
+++ b/protocol-units/settlement/mcr/client/Cargo.toml
@@ -12,6 +12,8 @@ rust-version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+mcr-settlement-config = { workspace = true }
+
 #move to workspace when impl is done.
 alloy = { git = "https://github.com/alloy-rs/alloy.git", package = "alloy", features = [
     "pubsub",
@@ -28,26 +30,23 @@ alloy_network = { git = "https://github.com/alloy-rs/alloy.git", package = "allo
 alloy_transport = { git = "https://github.com/alloy-rs/alloy.git", package = "alloy-transport" }
 alloy_transport_http = { git = "https://github.com/alloy-rs/alloy.git", package = "alloy-transport-http" }
 alloy_contract = { git = "https://github.com/alloy-rs/alloy.git", package = "alloy-contract" }
-alloy_signer_wallet = { git = "https://github.com/alloy-rs/alloy.git", package = "alloy-signer-wallet" }
+alloy-signer-wallet = { workspace = true }
 alloy_rpc_types = { git = "https://github.com/alloy-rs/alloy.git", package = "alloy-rpc-types" }
 alloy_transport_ws = { git = "https://github.com/alloy-rs/alloy.git", package = "alloy-transport-ws" }
-
-thiserror = "1.0.60"
-
 
 anyhow = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 movement-types = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 futures = { workspace = true }
+serde_json = { workspace = true }
 alloy_node_bindings = { git = "https://github.com/alloy-rs/alloy.git", package = "alloy-node-bindings" }
 
 [features]

--- a/protocol-units/settlement/mcr/client/Cargo.toml
+++ b/protocol-units/settlement/mcr/client/Cargo.toml
@@ -51,10 +51,10 @@ futures = { workspace = true }
 alloy_node_bindings = { git = "https://github.com/alloy-rs/alloy.git", package = "alloy-node-bindings" }
 
 [features]
-mock = []
 default = ["eth"]
-stub = []
+integration-tests = ["eth"]
 eth = []
+mock = []
 
 [lints]
 workspace = true

--- a/protocol-units/settlement/mcr/client/src/eth_client.rs
+++ b/protocol-units/settlement/mcr/client/src/eth_client.rs
@@ -284,6 +284,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg(feature = "integration-tests")]
 mod tests {
 	use super::*;
 	use alloy_primitives::Bytes;
@@ -304,7 +305,6 @@ mod tests {
 	// After genesis ceremony, 2 validator send the commitment for height 1.
 	// Validator2 send a commitment for height 2 to trigger next epoch and fire event.
 	// Wait the commitment accepted event.
-	#[cfg(feature = "integration-tests")]
 	#[tokio::test]
 	async fn test_send_commitment() -> Result<(), anyhow::Error> {
 		//Activate to debug the test.

--- a/protocol-units/settlement/mcr/client/src/eth_client.rs
+++ b/protocol-units/settlement/mcr/client/src/eth_client.rs
@@ -3,6 +3,7 @@ use crate::send_eth_tx::SendTxErrorRule;
 use crate::send_eth_tx::UnderPriced;
 use crate::send_eth_tx::VerifyRule;
 use crate::{CommitmentStream, McrSettlementClientOperations};
+use mcr_settlement_config::Config;
 use movement_types::BlockCommitment;
 use movement_types::{Commitment, Id};
 
@@ -25,42 +26,10 @@ use alloy_transport::BoxTransport;
 use alloy_transport_ws::WsConnect;
 
 use anyhow::Context;
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio_stream::StreamExt;
 
 use std::array::TryFromSliceError;
-
-const MCR_CONTRACT_ADDRESS: &str = "0xBf7c7AE15E23B2E19C7a1e3c36e245A71500e181";
-const MAX_TX_SEND_RETRIES: u32 = 10;
-const DEFAULT_TX_GAS_LIMIT: u128 = 10_000_000_000_000_000;
-
-/// Configuration of the MCR settlement client.
-///
-/// This structure is meant to be used in serialization.
-/// Validation is done by the builder interface of the [`Client`].
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Config {
-	pub rpc_url: Option<String>,
-	pub ws_url: Option<String>,
-	pub signer_private_key: Option<String>,
-	pub mcr_contract_address: String,
-	pub gas_limit: u128,
-	pub num_tx_send_retries: u32,
-}
-
-impl Default for Config {
-	fn default() -> Self {
-		Config {
-			rpc_url: None,
-			ws_url: None,
-			signer_private_key: None,
-			mcr_contract_address: MCR_CONTRACT_ADDRESS.into(),
-			gas_limit: DEFAULT_TX_GAS_LIMIT,
-			num_tx_send_retries: MAX_TX_SEND_RETRIES,
-		}
-	}
-}
 
 #[derive(Error, Debug)]
 pub enum McrEthConnectorError {
@@ -134,7 +103,7 @@ impl
 			signer_address,
 			contract_address,
 			config.gas_limit,
-			config.num_tx_send_retries,
+			config.tx_send_retries,
 		)
 		.await
 	}

--- a/protocol-units/settlement/mcr/client/src/eth_client.rs
+++ b/protocol-units/settlement/mcr/client/src/eth_client.rs
@@ -304,7 +304,7 @@ mod tests {
 	// After genesis ceremony, 2 validator send the commitment for height 1.
 	// Validator2 send a commitment for height 2 to trigger next epoch and fire event.
 	// Wait the commitment accepted event.
-	//#[cfg(feature = "integration-tests")]
+	#[cfg(feature = "integration-tests")]
 	#[tokio::test]
 	async fn test_send_commitment() -> Result<(), anyhow::Error> {
 		//Activate to debug the test.

--- a/protocol-units/settlement/mcr/config/Cargo.toml
+++ b/protocol-units/settlement/mcr/config/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "mcr-settlement-config"
+description = "Configuration of the MCR settlement client"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+toml = { workspace = true }
+
+[lints]
+workspace = true

--- a/protocol-units/settlement/mcr/config/src/lib.rs
+++ b/protocol-units/settlement/mcr/config/src/lib.rs
@@ -1,0 +1,86 @@
+//! This crate provides configuration parameters for the MCR settlement
+//! component of a Movement node.
+
+use serde::{Deserialize, Serialize};
+
+const MCR_CONTRACT_ADDRESS: &str = "0xBf7c7AE15E23B2E19C7a1e3c36e245A71500e181";
+const DEFAULT_TX_SEND_RETRIES: u32 = 10;
+const DEFAULT_GAS_LIMIT: u128 = 10_000_000_000_000_000;
+
+/// Configuration of the MCR settlement client.
+///
+/// This structure is meant to be used in serialization of human-readable
+/// configuration formats.
+/// Validation is done when constructing a client instance; see the
+/// mcr-settlement-client crate for details.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Config {
+	pub rpc_url: Option<String>,
+	pub ws_url: Option<String>,
+	// TODO: this should be managed in a secrets vault
+	pub signer_private_key: Option<String>,
+	#[serde(default = "default_mcr_contract_address")]
+	pub mcr_contract_address: String,
+	#[serde(default = "default_gas_limit")]
+	pub gas_limit: u128,
+	#[serde(default = "default_tx_send_retries")]
+	pub tx_send_retries: u32,
+}
+
+fn default_mcr_contract_address() -> String {
+	MCR_CONTRACT_ADDRESS.into()
+}
+
+const fn default_gas_limit() -> u128 {
+	DEFAULT_GAS_LIMIT
+}
+
+const fn default_tx_send_retries() -> u32 {
+	DEFAULT_TX_SEND_RETRIES
+}
+
+impl Default for Config {
+	fn default() -> Self {
+		Config {
+			rpc_url: None,
+			ws_url: None,
+			signer_private_key: None,
+			mcr_contract_address: default_mcr_contract_address(),
+			gas_limit: default_gas_limit(),
+			tx_send_retries: default_tx_send_retries(),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	const EXAMPLE_CONFIG_TOML: &str = r#"
+		rpc_url = 'http://localhost:8545'
+		ws_url = 'http://localhost:8546'
+		signer_private_key = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+	"#;
+
+	#[test]
+	fn test_parse_from_toml_with_defaults() -> anyhow::Result<()> {
+		let Config {
+			rpc_url,
+			ws_url,
+			signer_private_key,
+			mcr_contract_address,
+			gas_limit,
+			tx_send_retries,
+		} = toml::from_str(EXAMPLE_CONFIG_TOML)?;
+		assert_eq!(rpc_url.unwrap(), "http://localhost:8545");
+		assert_eq!(ws_url.unwrap(), "http://localhost:8546");
+		assert_eq!(
+			signer_private_key.unwrap(),
+			"0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+		);
+		assert_eq!(mcr_contract_address, MCR_CONTRACT_ADDRESS);
+		assert_eq!(gas_limit, DEFAULT_GAS_LIMIT);
+		assert_eq!(tx_send_retries, DEFAULT_TX_SEND_RETRIES);
+		Ok(())
+	}
+}


### PR DESCRIPTION
Resolves #125

# Summary
- **Categories**: `protocol-units`.

Move the Config struct from `mcr-settlement-client` to the dedicated micro-crate, so that dependencies of `suzuka-config` can be slim.

# Changelog

* `mcr-settlement-config`: a new crate to manage node configuration parameters pertaining to MCR settlement.

# Testing

Add tests for deserializing from TOML,
check in particular that the default values are set as expected.