### PR TITLE
chore: fix typos & references

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ The Movement SDK is a collection of tools and libraries for building, deploying,
 - [`scripts`](./scripts): Scripts for running Movement Labs software. See the [scripts README](./scripts/README.md) for more information about the organization of scripts.
 - [`process-compose`](./process-compose): Process compose files for running Movement Labs software. These files are part of the standard flow for running and testing components in the Movement Network. See the [scripts README](./scripts/README.md) for more information about the organization of scripts.
 - [`protocol-units`](./protocol-units): Protocol units for the Movement Network. These are the core building blocks of the Movement Network. See the [protocol-units README](./protocol-units/README.md) for more information about the organization of protocol units.
-- [`util`](./util): Utility crates for the Movement SDK. These crates provide useful functions, macros, and types for use in Movement SDK projects. See the [util README](./util/README.md) for more information about the organization of utility crates.
-- [`proto`](./proto): Protocol buffer definitions for the Movement Network. These definitions are used to generate code for interacting with the Movement Network. See the [proto README](./proto/README.md) for more information about the organization of protocol buffer definitions.
+- [`util`](./util): Utility crates for the Movement SDK. These crates provide useful functions, macros, and types for use in Movement SDK projects.
+- [`proto`](./proto): Protocol buffer definitions for the Movement Network. These definitions are used to generate code for interacting with the Movement Network.
 
 ## `m1-da-light-node`
 

--- a/protocol-units/cryptography/tentacles/src/types/proof/definition.rs
+++ b/protocol-units/cryptography/tentacles/src/types/proof/definition.rs
@@ -262,8 +262,8 @@ impl<H: SimpleHasher> SparseMerkleProof<H> {
         // The number of default leaves we need to add to the previous root. When splitting a leaf node, we create a new internal node
         // in place of the former leaf that has two leaf children. Hence we need to add some default siblings because the leaf node may
         // not be at the last level of the subtree of the last nibble.
-        // To get this number, we need to take the number of siblings modulo 4 (this yields the hight of the splitted leaf in the last binary subtree,
-        // or the number of bits in the last nibble of the splitted leaf), substract it to 4 (to get the number of bits needed to complete the last nibble)
+        // To get this number, we need to take the number of siblings modulo 4 (this yields the height of the splitted leaf in the last binary subtree,
+        // or the number of bits in the last nibble of the splitted leaf), subtract it to 4 (to get the number of bits needed to complete the last nibble)
         // and then take the result modulo 4 (in case num_siblings % 4 is zero, which happens when the leaf is at the lowest height of the last binary subtree).
         let default_siblings_prev_root = (4 - (num_siblings % 4)) % 4;
 

--- a/protocol-units/settlement/mcr/client/src/send_eth_tx.rs
+++ b/protocol-units/settlement/mcr/client/src/send_eth_tx.rs
@@ -79,7 +79,7 @@ pub async fn send_tx<
 	for _ in 0..nb_retry {
 		let call_builder = base_call_builder.clone().gas(estimate_gas);
 
-		//detect if the gas price doesn't execeed the limit.
+		//detect if the gas price doesn't exceed the limit.
 		let gas_price = call_builder.provider.get_gas_price().await?;
 		let tx_fee_wei = estimate_gas * gas_price;
 		if tx_fee_wei > gas_limit {


### PR DESCRIPTION
# Summary
fixed typos in some comments & removed references to two README files that do not and have not existed