### PR TITLE
mcr-settlement-setup: new crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11261,6 +11261,7 @@ dependencies = [
  "hex",
  "m1-da-light-node-setup",
  "m1-da-light-node-util",
+ "mcr-settlement-setup",
  "rand 0.7.3",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7234,6 +7234,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mcr-settlement-setup"
+version = "0.3.0"
+dependencies = [
+ "alloy-primitives",
+ "anyhow",
+ "dot-movement",
+ "k256",
+ "mcr-settlement-config",
+ "tracing",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "protocol-units/settlement/mcr/client",
     "protocol-units/settlement/mcr/config",
     "protocol-units/settlement/mcr/manager",
+    "protocol-units/settlement/mcr/setup",
     "protocol-units/movement-rest",
     "util/*",
     "util/buildtime/buildtime-helpers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "util/buildtime/buildtime-macros",
     "networks/monza/*",
     "networks/suzuka/*",
+    "protocol-units/settlement/mcr/setup",
 ]
 
 [workspace.package]
@@ -61,6 +62,7 @@ sequencing-util = { path = "protocol-units/sequencing/util" }
 mcr-settlement-client = { path = "protocol-units/settlement/mcr/client" }
 mcr-settlement-config = { path = "protocol-units/settlement/mcr/config" }
 mcr-settlement-manager = { path = "protocol-units/settlement/mcr/manager" }
+mcr-settlement-setup = { path = "protocol-units/settlement/mcr/setup" }
 ## types
 movement-types = { path = "util/movement-types" }
 ## dot movement
@@ -183,6 +185,7 @@ hex = { version = "0.4.3", default-features = false, features = [
     "serde",
 ] }
 ics23 = { version = "0.11.0" }
+k256 = { version = "0.13.3" }
 itertools = { version = "0.12.1", default-features = false }
 jmt = "0.9.0"
 jsonrpsee = { version = "0.20.1", features = ["jsonrpsee-types"] }

--- a/networks/suzuka/setup/Cargo.toml
+++ b/networks/suzuka/setup/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "suzuka-full-node-setup"
 version = { workspace = true }
-edition  = { workspace = true }
-license  = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
@@ -12,6 +12,12 @@ rust-version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+dot-movement = { workspace = true }
+m1-da-light-node-util = { workspace = true }
+m1-da-light-node-setup = { workspace = true }
+mcr-settlement-setup = { workspace = true }
+suzuka-config = { workspace = true }
+
 anyhow = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
@@ -19,16 +25,12 @@ serde_json = { workspace = true }
 serde = { workspace = true }
 commander = { workspace = true }
 tracing = { workspace = true }
-m1-da-light-node-util = { workspace = true }
-dot-movement = { workspace = true }
 rand = { workspace = true }
 hex = { workspace = true }
 celestia-rpc = { workspace = true }
 celestia-types = { workspace = true }
 async-recursion = { workspace = true }
 tracing-subscriber = { workspace = true }
-m1-da-light-node-setup = { workspace = true }
-suzuka-config = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/networks/suzuka/setup/src/local.rs
+++ b/networks/suzuka/setup/src/local.rs
@@ -1,60 +1,61 @@
-use dot_movement::DotMovement;
-use tracing::info;
 use crate::SuzukaFullNodeSetupOperations;
+use dot_movement::DotMovement;
 use m1_da_light_node_setup::M1DaLightNodeSetupOperations;
+use mcr_settlement_setup::Setup as _;
+
+use tracing::debug;
 
 #[derive(Debug, Clone)]
 pub struct Local {
-    m1_da_light_node_strategy : m1_da_light_node_setup::local::Local,
+	m1_da_light_node_strategy: m1_da_light_node_setup::local::Local,
+	mcr_settlement_strategy: mcr_settlement_setup::Local,
 }
 
 impl Local {
-    
-    pub fn new() -> Self {
-        Self {
-            m1_da_light_node_strategy : m1_da_light_node_setup::local::Local::new(),
-        }
-    }
+	pub fn new() -> Self {
+		Self {
+			m1_da_light_node_strategy: m1_da_light_node_setup::local::Local::new(),
+			mcr_settlement_strategy: Default::default(),
+		}
+	}
 
-    async fn run_m1_da_light_node_setup(
-        &self,
-        dot_movement : DotMovement,
-        mut config : suzuka_config::Config
-    ) -> Result<suzuka_config::Config, anyhow::Error> {
-        
-        // Get the m1_da_light_node_config from the suzuka config
-        let m1_da_light_node_config = config.execution_config.light_node_config.clone();
+	async fn run_m1_da_light_node_setup(
+		&self,
+		dot_movement: DotMovement,
+		mut config: suzuka_config::Config,
+	) -> Result<suzuka_config::Config, anyhow::Error> {
+		// Get the m1_da_light_node_config from the suzuka config
+		let m1_da_light_node_config = config.execution_config.light_node_config.clone();
 
-        // Run the m1_da_light_node_setup
-        info!("Running m1_da_light_node_setup");
-        let m1_da_light_node_config = self.m1_da_light_node_strategy.setup(
-            dot_movement.clone(),
-            m1_da_light_node_config
-        ).await?;
+		// Run the m1_da_light_node_setup
+		debug!("Running m1_da_light_node_setup");
+		let m1_da_light_node_config = self
+			.m1_da_light_node_strategy
+			.setup(dot_movement.clone(), m1_da_light_node_config)
+			.await?;
 
-        // Modify the suzuka config accordingly
-        config.execution_config.light_node_config = m1_da_light_node_config;
+		// Modify the suzuka config accordingly
+		config.execution_config.light_node_config = m1_da_light_node_config;
 
-        Ok(config)
+		debug!("Running mcr_settlement_setup");
+		let mcr_settlement_config = config.mcr.clone();
+		config.mcr =
+			self.mcr_settlement_strategy.setup(&dot_movement, mcr_settlement_config).await?;
 
-    }
-
+		Ok(config)
+	}
 }
 
 impl SuzukaFullNodeSetupOperations for Local {
-    async fn setup(
-        &self,
-        dot_movement : DotMovement,
-        config : suzuka_config::Config
-    ) -> Result<suzuka_config::Config, anyhow::Error> {
+	async fn setup(
+		&self,
+		dot_movement: DotMovement,
+		config: suzuka_config::Config,
+	) -> Result<suzuka_config::Config, anyhow::Error> {
+		// Run the m1_da_light_node_setup
+		let config = self.run_m1_da_light_node_setup(dot_movement.clone(), config).await?;
 
-        // Run the m1_da_light_node_setup
-        let config = self.run_m1_da_light_node_setup(
-            dot_movement.clone(),
-            config
-        ).await?;
-
-        // Placeholder for returning the actual configuration.
-        Ok(config)
-    }
+		// Placeholder for returning the actual configuration.
+		Ok(config)
+	}
 }

--- a/protocol-units/settlement/mcr/setup/Cargo.toml
+++ b/protocol-units/settlement/mcr/setup/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "mcr-settlement-setup"
+description = "Setting up of MCR configuration"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+mcr-settlement-config = { workspace = true }
+dot-movement = { workspace = true }
+
+alloy-primitives = { workspace = true }
+
+anyhow = { workspace = true }
+k256 = { workspace = true }
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/protocol-units/settlement/mcr/setup/src/lib.rs
+++ b/protocol-units/settlement/mcr/setup/src/lib.rs
@@ -1,0 +1,18 @@
+use dot_movement::DotMovement;
+use mcr_settlement_config::Config;
+
+use std::future::Future;
+
+pub mod local;
+
+/// Abstraction trait for MCR settlement setup strategies.
+pub trait Setup {
+	/// Sets up the MCR settlement client configuration.
+	/// If required configuration values are unset, fills them with
+	/// values decided by this setup strategy.
+	fn setup(
+		&self,
+		dot_movement: &DotMovement,
+		config: Config,
+	) -> impl Future<Output = Result<Config, anyhow::Error>> + Send;
+}

--- a/protocol-units/settlement/mcr/setup/src/lib.rs
+++ b/protocol-units/settlement/mcr/setup/src/lib.rs
@@ -3,7 +3,9 @@ use mcr_settlement_config::Config;
 
 use std::future::Future;
 
-pub mod local;
+mod local;
+
+pub use local::Local;
 
 /// Abstraction trait for MCR settlement setup strategies.
 pub trait Setup {

--- a/protocol-units/settlement/mcr/setup/src/local.rs
+++ b/protocol-units/settlement/mcr/setup/src/local.rs
@@ -1,0 +1,56 @@
+use super::Setup;
+
+use dot_movement::DotMovement;
+use mcr_settlement_config::Config;
+
+use alloy_primitives::hex;
+
+use k256::ecdsa::SigningKey;
+use tracing::info;
+
+use std::future::Future;
+
+/// The local setup strategy for MCR settlement
+#[derive(Debug, Clone)]
+pub struct Local {
+	eth_rpc_port: u16,
+	eth_ws_port: u16,
+}
+
+impl Local {
+	/// Instantiates the local setup strategy with ports on localhost
+	/// to configure for Ethernet RPC and WebSocket client access.
+	pub fn new(eth_rpc_port: u16, eth_ws_port: u16) -> Self {
+		Self { eth_rpc_port, eth_ws_port }
+	}
+}
+
+impl Setup for Local {
+	fn setup(
+		&self,
+		_dot_movement: &DotMovement,
+		mut config: Config,
+	) -> impl Future<Output = Result<Config, anyhow::Error>> + Send {
+		async move {
+			// Can't use rand 0.7 while k256 is on rand 0.6
+			let mut rng = k256::elliptic_curve::rand_core::OsRng;
+
+			info!("setting up MCR Ethereum client");
+
+			if config.rpc_url.is_none() {
+				config.rpc_url = Some(format!("http://localhost:{}", self.eth_rpc_port));
+			}
+			if config.ws_url.is_none() {
+				config.ws_url = Some(format!("http://localhost:{}", self.eth_ws_port));
+			}
+			if config.signer_private_key.is_none() {
+				let key = SigningKey::random(&mut rng);
+				let key_bytes = key.to_bytes();
+				let private_key = hex::encode(key_bytes.as_slice());
+				config.signer_private_key = Some(private_key);
+			}
+
+			Ok(config)
+		}
+	}
+}

--- a/protocol-units/settlement/mcr/setup/src/local.rs
+++ b/protocol-units/settlement/mcr/setup/src/local.rs
@@ -10,6 +10,9 @@ use tracing::info;
 
 use std::future::Future;
 
+const DEFAULT_ETH_RPC_PORT: u16 = 8545;
+const DEFAULT_ETH_WS_PORT: u16 = 8545;
+
 /// The local setup strategy for MCR settlement
 #[derive(Debug, Clone)]
 pub struct Local {
@@ -22,6 +25,12 @@ impl Local {
 	/// to configure for Ethernet RPC and WebSocket client access.
 	pub fn new(eth_rpc_port: u16, eth_ws_port: u16) -> Self {
 		Self { eth_rpc_port, eth_ws_port }
+	}
+}
+
+impl Default for Local {
+	fn default() -> Self {
+		Local::new(DEFAULT_ETH_RPC_PORT, DEFAULT_ETH_WS_PORT)
 	}
 }
 


### PR DESCRIPTION
# Summary
- **Categories**: `protocol-units`.

Add micro-crate `mcr-settlement-setup` to provide
setup infrastructure for MCR settlement configurations. 

Use it in suzuka-full-node-setup.

# Changelog

* Added crate `mcr-settlement-setup`.

# Testing

None added. The crate will be used by the e2e tests.