### PR TITLE
Graceful Restarts for Aptos Execution

### DIFF
--- a/.github/workflows/build-push-containers.yml
+++ b/.github/workflows/build-push-containers.yml
@@ -514,3 +514,5 @@ jobs:
       - name: Run docker-compose local.setup.test
         run: |
           nix develop --command bash  -c "docker --version && docker compose up --help && timeout 5m just suzuka-full-node docker-compose local.setup.test --abort-on-container-failure"
+          # see if restarts are graceful
+          nix develop --command bash  -c "docker --version && docker compose up --help && timeout 5m just suzuka-full-node docker-compose local.setup.test --abort-on-container-failure"

--- a/.github/workflows/build-push-containers.yml
+++ b/.github/workflows/build-push-containers.yml
@@ -513,6 +513,6 @@ jobs:
 
       - name: Run docker-compose local.setup.test
         run: |
-          nix develop --command bash  -c "docker --version && docker compose up --help && timeout 5m just suzuka-full-node docker-compose local.setup.test --abort-on-container-failure"
+          nix develop --command bash  -c "docker --version && docker compose up --help && timeout 7m just suzuka-full-node docker-compose local.setup.test --abort-on-container-failure || [ $? -eq 124 ]"
           # see if restarts are graceful
-          nix develop --command bash  -c "docker --version && docker compose up --help && timeout 5m just suzuka-full-node docker-compose local.setup.test --abort-on-container-failure"
+          nix develop --command bash  -c "docker --version && docker compose up --help && timeout 7m just suzuka-full-node docker-compose local.setup.test --abort-on-container-failure || [ $? -eq 124 ]"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,7 +46,10 @@ jobs:
 
     - name: Run M1 DA Light Node tests in nix environment
       # adjust the log level while debugging
-      run: CELESTIA_LOG_LEVEL=FATAL nix develop --command bash  -c "just suzuka-full-node native build.setup.test.local -t=false"  
+      run: |
+        CELESTIA_LOG_LEVEL=FATAL nix develop --command bash  -c "just suzuka-full-node native build.setup.test.local -t=false"  
+        # see if restarts are graceful
+        CELESTIA_LOG_LEVEL=FATAL nix develop --command bash  -c "just suzuka-full-node native build.setup.test.local -t=false"  
 
   m1-da-light-node:
     if: false # this is effectively tested by the above

--- a/protocol-units/execution/opt-executor/src/executor/initialization.rs
+++ b/protocol-units/execution/opt-executor/src/executor/initialization.rs
@@ -70,30 +70,45 @@ impl Executor {
 		(genesis, test_validators)
 	}
 
-	pub fn bootstrap_empty_db(
+	pub fn maybe_bootstrap_empty_db(
 		db_dir: &PathBuf,
 		chain_id: ChainId,
 		public_key: &Ed25519PublicKey,
+		maptos_config: &Config,
 	) -> Result<(DbReaderWriter, ValidatorSigner), anyhow::Error> {
+
+		let db_rw = DbReaderWriter::new(AptosDB::new_for_test(db_dir));
 		let (genesis, validators) =
 			Self::genesis_change_set_and_validators(chain_id, Some(1), public_key);
 		let genesis_txn = Transaction::GenesisTransaction(WriteSetPayload::Direct(genesis));
-		let db_rw = DbReaderWriter::new(AptosDB::new_for_test(db_dir));
-
-		assert!(db_rw.reader.get_latest_ledger_info_option()?.is_none());
-
-		// Bootstrap empty DB.
-		let waypoint = generate_waypoint::<AptosVM>(&db_rw, &genesis_txn)?;
-		maybe_bootstrap::<AptosVM>(&db_rw, &genesis_txn, waypoint)?
-			.ok_or(anyhow::anyhow!("Failed to bootstrap DB"))?;
-		assert!(db_rw.reader.get_latest_ledger_info_option()?.is_some());
-
 		let validator_signer = ValidatorSigner::new(
 			validators[0].data.owner_address,
 			validators[0].consensus_key.clone(),
 		);
 
+		// check for context
+		
+		match db_rw.reader.get_latest_ledger_info_option()? {
+			Some(ledger_info) => {
+				// context exists
+				tracing::info!(
+					"Ledger info found, not bootstrapping DB: {:?}",
+					ledger_info
+				);
+			},
+			None => {
+				// context does not exist
+				// simply continue
+				tracing::info!("No ledger info found, bootstrapping DB.");
+				let waypoint = generate_waypoint::<AptosVM>(&db_rw, &genesis_txn)?;
+				maybe_bootstrap::<AptosVM>(&db_rw, &genesis_txn, waypoint)?
+					.ok_or(anyhow::anyhow!("Failed to bootstrap DB"))?;
+				assert!(db_rw.reader.get_latest_ledger_info_option()?.is_some());
+			}
+		}
+
 		Ok((db_rw, validator_signer))
+
 	}
 
 	pub fn bootstrap(
@@ -102,10 +117,11 @@ impl Executor {
 		node_config: NodeConfig,
 		maptos_config: &Config,
 	) -> Result<Self, anyhow::Error> {
-		let (db, signer) = Self::bootstrap_empty_db(
+		let (db, signer) = Self::maybe_bootstrap_empty_db(
 			&maptos_config.chain.maptos_db_path.clone().context("No db path provided.")?,
 			maptos_config.chain.maptos_chain_id.clone(),
 			&maptos_config.chain.maptos_private_key.clone().public_key(),
+			maptos_config
 		)?;
 		let reader = db.reader.clone();
 		let core_mempool = Arc::new(RwLock::new(CoreMempool::new(&node_config)));

--- a/protocol-units/execution/opt-executor/src/executor/initialization.rs
+++ b/protocol-units/execution/opt-executor/src/executor/initialization.rs
@@ -75,7 +75,6 @@ impl Executor {
 		db_dir: &PathBuf,
 		chain_id: ChainId,
 		public_key: &Ed25519PublicKey,
-		maptos_config: &Config,
 	) -> Result<(DbReaderWriter, ValidatorSigner), anyhow::Error> {
 
 		let db_rw = DbReaderWriter::new(AptosDB::new_for_test(db_dir));

--- a/protocol-units/execution/opt-executor/src/executor/initialization.rs
+++ b/protocol-units/execution/opt-executor/src/executor/initialization.rs
@@ -121,7 +121,6 @@ impl Executor {
 			&maptos_config.chain.maptos_db_path.clone().context("No db path provided.")?,
 			maptos_config.chain.maptos_chain_id.clone(),
 			&maptos_config.chain.maptos_private_key.clone().public_key(),
-			maptos_config
 		)?;
 		let reader = db.reader.clone();
 		let core_mempool = Arc::new(RwLock::new(CoreMempool::new(&node_config)));


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

Adds graceful restarts for Aptos execution, i.e., can start from the current DB. 

We still create a new DA network. I will try to address this in a forthcoming PR, but it is more involved. However, it doesn't matter for the current deployment which has one node because heights are assigned by the executors themselves and settled on. 

This would matter if nodes were started at different times and on different networks because then the bootstrapping would potentially miss transactions from one network (ofc). 

Excluding fixes to the DA to keep this PR small. 

# Changelog

1. Very small change to `Executor::maybe_bootstrap_empty_db` in `maptos-opt-executor`. 

# Testing

1. Ran `suzuka-full-node` e2e back-to-back. Can improve upon tests by checking for state from before, but this is also a bit more complicated and will be reserved for a future PR. 

# Outstanding issues

1. DA graceful restarts.
2. Restart testing for state. 