### PR TITLE
chore: update tests in the workspace to compile

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,7 +25,7 @@ jobs:
       uses: DeterminateSystems/nix-installer-action@main
 
     - name: Run Cargo Check in nix environment
-      run: nix develop --command bash  -c "cargo check"  
+      run: nix develop --command bash  -c "cargo check --all-targets"  
 
   suzuka-full-node:
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7035,6 +7035,7 @@ dependencies = [
  "dot-movement",
  "hex",
  "m1-da-light-node-grpc",
+ "m1-da-light-node-setup",
  "m1-da-light-node-util",
  "prost",
  "serde_json",

--- a/protocol-units/da/m1/light-node-verifier/Cargo.toml
+++ b/protocol-units/da/m1/light-node-verifier/Cargo.toml
@@ -9,7 +9,8 @@ homepage = { workspace = true }
 publish = { workspace = true }
 rust-version = { workspace = true }
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+integration-tests = []
 
 [dependencies]
 tokio = { workspace = true }

--- a/protocol-units/da/m1/light-node-verifier/Cargo.toml
+++ b/protocol-units/da/m1/light-node-verifier/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "m1-da-light-node-verifier"
 version = { workspace = true }
-edition  = { workspace = true }
-license  = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
@@ -26,6 +26,9 @@ anyhow = { workspace = true }
 hex = { workspace = true }
 async-stream = { workspace = true }
 serde_json = { workspace = true }
+
+[dev-dependencies]
+m1-da-light-node-setup = { workspace = true }
 dot-movement = { workspace = true }
 
 [lints]

--- a/protocol-units/da/m1/light-node-verifier/src/v1.rs
+++ b/protocol-units/da/m1/light-node-verifier/src/v1.rs
@@ -77,7 +77,7 @@ impl Verifier for V1Verifier {
 	}
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "integration-tests"))]
 mod tests {
 	use super::*;
 	use celestia_types::blob::GasPrice;

--- a/protocol-units/da/m1/light-node-verifier/src/v1.rs
+++ b/protocol-units/da/m1/light-node-verifier/src/v1.rs
@@ -78,22 +78,21 @@ impl Verifier for V1Verifier {
 }
 
 #[cfg(test)]
-pub mod test {
+mod tests {
 	use super::*;
 	use celestia_types::blob::GasPrice;
-	use m1_da_light_node_util::Config;
+	use m1_da_light_node_util::config::M1DaLightNodeConfig;
 
 	/// todo: Investigate why this test sporadically fails.
 	#[tokio::test]
 	pub async fn test_valid_verifies() -> Result<(), anyhow::Error> {
 		let dot_movement = dot_movement::DotMovement::try_from_env()?;
-		let path = dot_movement.get_path().join("config.toml");
-		let config = Config::try_from_toml_file(&path).unwrap_or_default();
+		let config =
+			m1_da_light_node_setup::setup(dot_movement, M1DaLightNodeConfig::default()).await?;
 		let client = Arc::new(config.connect_celestia().await?);
-		let celestia_namespace = config.try_celestia_namespace()?;
+		let celestia_namespace = config.celestia_namespace();
 
-		let verifier =
-			V1Verifier { client: client.clone(), namespace: celestia_namespace.clone() };
+		let verifier = V1Verifier { client: client.clone(), namespace: celestia_namespace.clone() };
 
 		let data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 		let blob = Blob::new(celestia_namespace.clone(), data.clone())?;
@@ -110,13 +109,12 @@ pub mod test {
 	#[tokio::test]
 	pub async fn test_absent_does_not_verify() -> Result<(), anyhow::Error> {
 		let dot_movement = dot_movement::DotMovement::try_from_env()?;
-		let path = dot_movement.get_path().join("config.toml");
-		let config = Config::try_from_toml_file(&path).unwrap_or_default();
+		let config =
+			m1_da_light_node_setup::setup(dot_movement, M1DaLightNodeConfig::default()).await?;
 		let client = Arc::new(config.connect_celestia().await?);
-		let celestia_namespace = config.try_celestia_namespace()?;
+		let celestia_namespace = config.celestia_namespace();
 
-		let verifier =
-			V1Verifier { client: client.clone(), namespace: celestia_namespace.clone() };
+		let verifier = V1Verifier { client: client.clone(), namespace: celestia_namespace.clone() };
 
 		let data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 		let blob = Blob::new(celestia_namespace.clone(), data.clone())?;
@@ -144,13 +142,12 @@ pub mod test {
 	#[tokio::test]
 	pub async fn test_wrong_height_does_not_verify() -> Result<(), anyhow::Error> {
 		let dot_movement = dot_movement::DotMovement::try_from_env()?;
-		let path = dot_movement.get_path().join("config.toml");
-		let config = Config::try_from_toml_file(&path).unwrap_or_default();
+		let config =
+			m1_da_light_node_setup::setup(dot_movement, M1DaLightNodeConfig::default()).await?;
 		let client = Arc::new(config.connect_celestia().await?);
-		let celestia_namespace = config.try_celestia_namespace()?;
+		let celestia_namespace = config.celestia_namespace();
 
-		let verifier =
-			V1Verifier { client: client.clone(), namespace: celestia_namespace.clone() };
+		let verifier = V1Verifier { client: client.clone(), namespace: celestia_namespace.clone() };
 
 		let data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 		let blob = Blob::new(celestia_namespace.clone(), data.clone())?;

--- a/protocol-units/execution/dof/src/v1.rs
+++ b/protocol-units/execution/dof/src/v1.rs
@@ -383,13 +383,13 @@ mod tests {
 		// Create an executor instance from the environment configuration.
 		let (tx, _rx) = async_channel::unbounded::<SignedTransaction>();
 		let config = Config::default();
-		let aptos_config = config.try_aptos_config()?;
+		let chain_config = config.chain.clone();
 		let executor = Executor::try_from_config(tx, config)?;
 
 		// Initialize a root account using a predefined keypair and the test root address.
 		let root_account = LocalAccount::new(
 			aptos_test_root_address(),
-			AccountKey::from_private_key(aptos_config.try_aptos_private_key()?),
+			AccountKey::from_private_key(chain_config.maptos_private_key),
 			0,
 		);
 
@@ -398,7 +398,7 @@ mod tests {
 		let mut rng = ::rand::rngs::StdRng::from_seed(seed);
 
 		// Create a transaction factory with the chain ID of the executor.
-		let tx_factory = TransactionFactory::new(aptos_config.try_chain_id()?);
+		let tx_factory = TransactionFactory::new(chain_config.maptos_chain_id);
 
 		// Simulate the execution of multiple blocks.
 		for _ in 0..10 {
@@ -452,13 +452,13 @@ mod tests {
 		// Create an executor instance from the environment configuration.
 		let (tx, _rx) = async_channel::unbounded::<SignedTransaction>();
 		let config = Config::default();
-		let aptos_config = config.try_aptos_config()?;
+		let chain_config = config.chain.clone();
 		let executor = Executor::try_from_config(tx, config)?;
 
 		// Initialize a root account using a predefined keypair and the test root address.
 		let root_account = LocalAccount::new(
 			aptos_test_root_address(),
-			AccountKey::from_private_key(aptos_config.try_aptos_private_key()?),
+			AccountKey::from_private_key(chain_config.maptos_private_key),
 			0,
 		);
 
@@ -467,7 +467,7 @@ mod tests {
 		let mut rng = ::rand::rngs::StdRng::from_seed(seed);
 
 		// Create a transaction factory with the chain ID of the executor.
-		let tx_factory = TransactionFactory::new(aptos_config.try_chain_id()?);
+		let tx_factory = TransactionFactory::new(chain_config.maptos_chain_id);
 		let mut transaction_hashes = Vec::new();
 
 		// Simulate the execution of multiple blocks.

--- a/protocol-units/execution/fin-view/src/fin_view.rs
+++ b/protocol-units/execution/fin-view/src/fin_view.rs
@@ -10,7 +10,7 @@ use maptos_execution_util::config::Config;
 use poem::{http::Method, listener::TcpListener, middleware::Cors, EndpointExt, Route, Server};
 use tracing::info;
 
-use std::{fmt::format, sync::Arc};
+use std::sync::Arc;
 
 #[derive(Clone)]
 /// The API view into the finalized state of the chain.
@@ -101,11 +101,11 @@ mod tests {
 	async fn test_set_finalized_block_height_get_api() -> Result<(), anyhow::Error> {
 		// Create an Executor and a FinalityView instance from the environment configuration.
 		let config = Config::default();
-		let executor = Executor::try_from_config(config.clone())?;
+		let executor = Executor::try_from_config(&config)?;
 		let finality_view = FinalityView::try_from_config(
 			executor.db.reader.clone(),
 			executor.mempool_client_sender.clone(),
-			config,
+			config.clone(),
 		)?;
 
 		// Initialize a root account using a predefined keypair and the test root address.


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**: `protocol-units`.

Update the tests in workspace crates that had compilation failures
because they needed adaptation to the new config and setup APIs,
so that the tests build.

# Testing

`cargo check --all-targets`
`cargo check -p m1-da-light-node-verifier --tests --features integration-tests`

No effort to make the updated tests pass yet.
This change is only to resolve build failures in `cargo check --all-targets` that is used by IDEs to show build problems.

# Outstanding issues

Need to produce workable test setups and add test runs to the CI so that the crate tests are run. This should be a subject for a separate planned task.