### PR TITLE
Godfig-based Setup of M1 DA Light Node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4708,6 +4708,7 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -7005,6 +7006,7 @@ dependencies = [
  "celestia-types",
  "commander",
  "dot-movement",
+ "godfig",
  "hex",
  "m1-da-light-node-util",
  "rand 0.7.3",

--- a/protocol-units/da/m1/setup/Cargo.toml
+++ b/protocol-units/da/m1/setup/Cargo.toml
@@ -31,6 +31,7 @@ celestia-rpc = { workspace = true }
 celestia-types = { workspace = true }
 async-recursion = { workspace = true }
 tracing-subscriber = { workspace = true }
+godfig = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/util/dot-movement/Cargo.toml
+++ b/util/dot-movement/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/util/dot-movement/src/lib.rs
+++ b/util/dot-movement/src/lib.rs
@@ -18,6 +18,38 @@ impl DotMovement {
 		self.0.join("config.json")
 	}
 
+	pub async fn try_get_or_create_config_file(&self) -> Result<tokio::fs::File, anyhow::Error> {
+		let config_path = self.get_config_json_path();
+
+		// get res for opening in read-write mode
+		let res = tokio::fs::OpenOptions::new()
+			.read(true)
+			.write(true)
+			.open(config_path.clone())
+			.await;
+
+		match res {
+			Ok(file) => Ok(file),
+			Err(e) => {
+
+				// create parent directories
+				tokio::fs::DirBuilder::new()
+					.recursive(true)
+					.create(config_path.parent().ok_or(
+						anyhow::anyhow!("Failed to get parent directory of config path")
+					)?)
+					.await?;
+
+				
+				// create the file
+				let file = tokio::fs::File::create_new(config_path)
+				.await?;
+				
+				Ok(file)
+			}
+		}
+	}
+
 	/// Tries to get a configuration from a JSON file.
 	pub fn try_get_config_from_json<T: serde::de::DeserializeOwned>(
 		&self,


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$
- **Categories**: `protocol-units`

Uses `godfig` to perform `m1-da-light-node-setup`.

# Changelog

Simply changes setup over from `m1-da-light-node-setup` to Godfig. 

# Testing

1. `just m1-da-light-node native build.setup.test.local`

# Outstanding issues
1. This cans still be cleaned up a lot elsewhere. But, in the interest of keeping a small PR, I'm pausing here. 