### PR TITLE
feat: suzuka with manager and godfig.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11198,6 +11198,7 @@ dependencies = [
  "anyhow",
  "async-channel",
  "dot-movement",
+ "godfig",
  "m1-da-light-node-client",
  "m1-da-light-node-util",
  "maptos-dof-execution",

--- a/networks/suzuka/suzuka-full-node/Cargo.toml
+++ b/networks/suzuka/suzuka-full-node/Cargo.toml
@@ -29,7 +29,7 @@ movement-types = { workspace = true }
 movement-rest = { workspace = true }
 suzuka-config = { workspace = true }
 dot-movement = { workspace = true }
-
+godfig = { workspace = true }
 tracing-subscriber = { workspace = true, optional = true }
 
 [features]

--- a/networks/suzuka/suzuka-full-node/src/lib.rs
+++ b/networks/suzuka/suzuka-full-node/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod partial;
+pub mod manager;
 
 #[cfg(test)]
 pub mod tests;

--- a/networks/suzuka/suzuka-full-node/src/main.rs
+++ b/networks/suzuka/suzuka-full-node/src/main.rs
@@ -1,28 +1,25 @@
-use anyhow::Context;
-use suzuka_full_node::{partial::SuzukaPartialNode, SuzukaFullNode};
+use suzuka_full_node::{
+	manager::Manager,
+	partial::SuzukaPartialNode
+};
+use maptos_dof_execution::v1::Executor;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-	#[cfg(feature = "logging")]
-	{
-		use tracing_subscriber::EnvFilter;
+	
+	use tracing_subscriber::EnvFilter;
 
-		tracing_subscriber::fmt()
-			.with_env_filter(
-				EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-			)
-			.init();
-	}
+	tracing_subscriber::fmt()
+		.with_env_filter(
+			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+		)
+		.init();
 
 	let dot_movement = dot_movement::DotMovement::try_from_env()?;
-	let config = dot_movement.try_get_config_from_json::<suzuka_config::Config>()?;
-	let (executor, background_task) = SuzukaPartialNode::try_from_config(config)
-		.await
-		.context("Failed to create the executor")?;
-
-	tokio::spawn(background_task);
-
-	executor.run().await.context("Failed to run suzuka")?;
-
+	let config_path = dot_movement.get_config_json_path();
+	let config_file = tokio::fs::File::open(config_path).await?;
+	let manager = Manager::<SuzukaPartialNode<Executor>>::new(config_file).await?;
+	manager.try_run().await?;
+	
 	Ok(())
 }

--- a/networks/suzuka/suzuka-full-node/src/manager.rs
+++ b/networks/suzuka/suzuka-full-node/src/manager.rs
@@ -1,0 +1,43 @@
+use crate::SuzukaFullNode;
+use anyhow::Context;
+use super::partial::SuzukaPartialNode;
+use godfig::{
+    Godfig,
+    backend::config_file::ConfigFile
+};
+use suzuka_config::Config;
+use maptos_dof_execution::v1::Executor;
+
+#[derive(Clone)]
+pub struct Manager<Dof>
+    where 
+    Dof : SuzukaFullNode {
+    godfig: Godfig<Config, ConfigFile>,
+    _marker : std::marker::PhantomData<Dof>,
+}
+
+// Implements a very simple manager using a marker strategy pattern.
+impl Manager<SuzukaPartialNode<Executor>> {
+    pub async fn new(file : tokio::fs::File) -> Result<Self, anyhow::Error> {
+        let godfig = Godfig::new(ConfigFile::new(file), vec![]);
+        Ok(Self {
+            godfig,
+            _marker: std::marker::PhantomData,
+        })
+    }
+
+    pub async fn try_run(&self) -> Result<(), anyhow::Error> {
+        
+        let config = self.godfig.try_wait_for_ready().await?;
+        
+        let (executor, background_task) = SuzukaPartialNode::try_from_config(config)
+		.await
+		.context("Failed to create the executor")?;
+
+	    tokio::spawn(background_task);
+
+	    executor.run().await.context("Failed to run suzuka")?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$
- **Categories**: `protocol-units`

Uses `godfig` with manger pattern to run Suzuka Full Node.

# Changelog

1. Uses `godfig::try_wait_for` to await the appropriate config setting in Suzuka. 

# Testing

1. `just suzuka-full-node native build.setup.test.local`. 

# Outstanding issues
1. Still starts services one after another. This will not be modified until Suzuka Full Node go around. 
2. More clean can be cone, but pausing here to keep PR smallish. 