### PR TITLE
Update aptos-core version for the faucet sequencing fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
@@ -710,7 +710,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -723,7 +723,7 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -733,7 +733,7 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -748,7 +748,7 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -794,7 +794,7 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -824,7 +824,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "hex",
@@ -833,7 +833,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -878,7 +878,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -900,7 +900,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "futures",
  "rustversion",
@@ -910,7 +910,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "shadow-rs",
 ]
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -933,7 +933,7 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -945,7 +945,7 @@ dependencies = [
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -957,7 +957,7 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -991,7 +991,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1014,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-crypto-derive",
@@ -1060,7 +1060,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
@@ -1070,7 +1070,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-config",
  "aptos-crypto",
@@ -1101,7 +1101,7 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1176,7 +1176,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1208,7 +1208,7 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-experimental-runtimes",
  "aptos-infallible",
@@ -1220,7 +1220,7 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -1237,7 +1237,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-block-partitioner",
@@ -1271,7 +1271,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-block-partitioner",
@@ -1308,7 +1308,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -1331,7 +1331,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-block-partitioner",
@@ -1353,7 +1353,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-runtimes",
  "core_affinity",
@@ -1366,7 +1366,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1400,7 +1400,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -1415,7 +1415,7 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -1490,7 +1490,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "either",
  "move-core-types",
@@ -1499,7 +1499,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -1515,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1538,7 +1538,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
@@ -1553,7 +1553,7 @@ dependencies = [
 [[package]]
 name = "aptos-genesis"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -1578,22 +1578,22 @@ dependencies = [
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1621,7 +1621,7 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1631,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
@@ -1678,7 +1678,7 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1692,7 +1692,7 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
@@ -1702,7 +1702,7 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-infallible",
  "aptos-log-derive",
@@ -1723,7 +1723,7 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
@@ -1737,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -1777,7 +1777,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-runtimes",
  "aptos-types",
@@ -1791,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-infallible",
  "bytes 1.6.0",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -1811,7 +1811,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-gas-schedule",
@@ -1837,7 +1837,7 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -1860,7 +1860,7 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -1877,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
@@ -1894,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1942,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-build-info",
  "aptos-infallible",
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
@@ -1968,7 +1968,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -1981,7 +1981,7 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1994,7 +1994,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-config",
  "aptos-types",
@@ -2007,7 +2007,7 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -2017,7 +2017,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -2030,7 +2030,7 @@ dependencies = [
 [[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "ipnet",
 ]
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -2049,7 +2049,7 @@ dependencies = [
 [[package]]
 name = "aptos-rate-limiter"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-infallible",
  "aptos-logger",
@@ -2063,7 +2063,7 @@ dependencies = [
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -2089,7 +2089,7 @@ dependencies = [
 [[package]]
 name = "aptos-retrier"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-logger",
  "tokio",
@@ -2098,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-config",
  "rocksdb",
@@ -2107,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "rayon",
  "tokio",
@@ -2116,7 +2116,7 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2133,7 +2133,7 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-crypto",
  "aptos-drop-helper",
@@ -2153,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -2174,7 +2174,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2193,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -2212,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2234,7 +2234,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -2245,7 +2245,7 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2257,7 +2257,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2289,7 +2289,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -2303,7 +2303,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-compression",
  "aptos-config",
@@ -2319,7 +2319,7 @@ dependencies = [
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-gas-schedule",
@@ -2340,7 +2340,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -2349,7 +2349,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -2362,7 +2362,7 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2413,12 +2413,12 @@ dependencies = [
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
@@ -2434,7 +2434,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2490,7 +2490,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -2512,7 +2512,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -2527,7 +2527,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2548,7 +2548,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "aptos-event-notifications",
@@ -7397,7 +7397,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7414,7 +7414,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -7429,12 +7429,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7449,7 +7449,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7461,7 +7461,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -7476,7 +7476,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "clap 4.5.9",
@@ -7493,7 +7493,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7539,7 +7539,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "difference",
@@ -7556,7 +7556,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7585,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -7618,7 +7618,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7663,7 +7663,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "clap 4.5.9",
@@ -7681,7 +7681,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "codespan",
@@ -7700,7 +7700,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7714,7 +7714,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7733,7 +7733,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -7752,7 +7752,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "hex",
@@ -7765,7 +7765,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "hex",
@@ -7779,7 +7779,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "codespan",
@@ -7807,7 +7807,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7844,7 +7844,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7883,7 +7883,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7913,7 +7913,7 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -7944,7 +7944,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7972,7 +7972,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "abstract-domain-derive",
  "codespan",
@@ -7999,7 +7999,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "hex",
@@ -8022,7 +8022,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "once_cell",
  "serde",
@@ -8031,7 +8031,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -8049,7 +8049,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "better_any",
@@ -8080,7 +8080,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "better_any",
  "bytes 1.6.0",
@@ -8105,7 +8105,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "anyhow",
  "bytes 1.6.0",
@@ -8120,7 +8120,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d#6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d"
 dependencies = [
  "bcs 0.1.4",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,35 +90,35 @@ serde_yaml = "0.9.34"
 ## Aptos dependencies
 ### We use a forked version so that we can override dependency versions. This is required
 ### to be avoid dependency conflicts with other Sovereign Labs crates.
-aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8", features = [
+aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d", features = [
     "cloneable-private-keys",
 ] }
-aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
+aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
+aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d" }
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
 ethereum-types = "0.14.1"
 ethers = "=2.0.10"
@@ -159,8 +159,8 @@ alloy = { git = "https://github.com/alloy-rs/alloy.git", package = "alloy", rev 
     "signers",
     "signer-yubihsm",
     "pubsub",
-    "providers"
-]}
+    "providers",
+] }
 alloy-contract = { git = "https://github.com/alloy-rs/alloy.git", rev = "83343b172585fe4e040fb104b4d1421f58cbf9a2" }
 alloy-network = { git = "https://github.com/alloy-rs/alloy.git", rev = "83343b172585fe4e040fb104b4d1421f58cbf9a2" }
 alloy-primitives = { version = "0.7.2", default-features = false }
@@ -248,7 +248,7 @@ url = "2.2.2"
 x25519-dalek = "1.0.1"
 zstd-sys = "2.0.9"
 inotify = "0.10.2"
-rustix = "0.38.34" 
+rustix = "0.38.34"
 
 
 [workspace.lints.rust]


### PR DESCRIPTION
# Summary
Brings in the latest commit on from aptos-core suzuka (the latest known commit with the patch fix added)
https://github.com/movementlabsxyz/aptos-core/commits/suzuka/

# Changelog
- Updates the rev tag for all aptos dependencies, https://github.com/movementlabsxyz/aptos-core/commit/6b1e45dc58d4a1e95b8b8a7356fa721f30a48e2d

# Testing
- Tested manually here https://github.com/movementlabsxyz/movement/pull/179

# Outstanding issues
