### PR TITLE
feat: whitelist staking

### DIFF
--- a/protocol-units/settlement/mcr/contracts/src/staking/MovementStaking.sol
+++ b/protocol-units/settlement/mcr/contracts/src/staking/MovementStaking.sol
@@ -268,7 +268,7 @@ contract MovementStaking is
     }
 
     // stakes for the next epoch
-    function stake(address domain, IERC20 custodian, uint256 amount) external onlyWhitelisted {
+    function stake(address domain, IERC20 custodian, uint256 amount) external onlyRole(WHITELIST_ROLE) {
         // add the attester to the list of attesters
         attestersByDomain[domain].add(msg.sender);
 
@@ -312,7 +312,7 @@ contract MovementStaking is
         address domain,
         address custodian,
         uint256 amount
-    ) external onlyWhitelisted {
+    ) external onlyRole(WHITELIST_ROLE) {
         // indicate that we are going to unstake this amount in the next epoch
         // ! this doesn't actually happen until we roll over the epoch
         // note: by tracking in the next epoch we need to make sure when we roll over an epoch we check the amount rolled over from stake by the unstake in the next epoch
@@ -548,20 +548,12 @@ contract MovementStaking is
         }
     }
 
-    modifier onlyWhitelisted() {
-        if (!whitelisted[msg.sender])
-            revert AddressNotWhitelisted();
-        _;
-    }
-
     function whitelistAddress(address addr) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        whitelisted[addr] = true;
-        emit AddressWhitelisted(addr);
+        grantRole(WHITELIST_ROLE, addr);
     }
 
     function removeAddressFromWhitelist(address addr) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        whitelisted[addr] = false;
-        emit AddressRemovedFromWhitelist(addr);
+        revokeRole(WHITELIST_ROLE, addr);
     }
 
 }

--- a/protocol-units/settlement/mcr/contracts/src/staking/MovementStaking.sol
+++ b/protocol-units/settlement/mcr/contracts/src/staking/MovementStaking.sol
@@ -268,7 +268,7 @@ contract MovementStaking is
     }
 
     // stakes for the next epoch
-    function stake(address domain, IERC20 custodian, uint256 amount) external {
+    function stake(address domain, IERC20 custodian, uint256 amount) external onlyWhitelisted {
         // add the attester to the list of attesters
         attestersByDomain[domain].add(msg.sender);
 
@@ -312,7 +312,7 @@ contract MovementStaking is
         address domain,
         address custodian,
         uint256 amount
-    ) external {
+    ) external onlyWhitelisted {
         // indicate that we are going to unstake this amount in the next epoch
         // ! this doesn't actually happen until we roll over the epoch
         // note: by tracking in the next epoch we need to make sure when we roll over an epoch we check the amount rolled over from stake by the unstake in the next epoch
@@ -547,4 +547,21 @@ contract MovementStaking is
             _payAttester(attesters[i], custodians[i], amounts[i]);
         }
     }
+
+    modifier onlyWhitelisted() {
+        if (!whitelisted[msg.sender])
+            revert AddressNotWhitelisted();
+        _;
+    }
+
+    function whitelistAddress(address addr) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        whitelisted[addr] = true;
+        emit AddressWhitelisted(addr);
+    }
+
+    function removeAddressFromWhitelist(address addr) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        whitelisted[addr] = false;
+        emit AddressRemovedFromWhitelist(addr);
+    }
+
 }

--- a/protocol-units/settlement/mcr/contracts/src/staking/MovementStakingStorage.sol
+++ b/protocol-units/settlement/mcr/contracts/src/staking/MovementStakingStorage.sol
@@ -35,4 +35,6 @@ contract MovementStakingStorage {
         mapping(uint256 epoch =>
             mapping(address attester => uint256 stake))) public epochTotalStakeByDomain;
 
+    // track whitelisted addresses for staking
+    mapping(address => bool) public whitelisted;
 }

--- a/protocol-units/settlement/mcr/contracts/src/staking/MovementStakingStorage.sol
+++ b/protocol-units/settlement/mcr/contracts/src/staking/MovementStakingStorage.sol
@@ -35,6 +35,6 @@ contract MovementStakingStorage {
         mapping(uint256 epoch =>
             mapping(address attester => uint256 stake))) public epochTotalStakeByDomain;
 
-    // track whitelisted addresses for staking
-    mapping(address => bool) public whitelisted;
+    // the whitelist role needed to stake/unstake
+    bytes32 public constant WHITELIST_ROLE = keccak256("WHITELIST_ROLE");
 }

--- a/protocol-units/settlement/mcr/contracts/src/staking/interfaces/IMovementStaking.sol
+++ b/protocol-units/settlement/mcr/contracts/src/staking/interfaces/IMovementStaking.sol
@@ -100,8 +100,4 @@ interface IMovementStaking {
     event EpochRolledOver(address indexed domain, uint256 epoch);
     error StakeExceedsGenesisStake();
     error CustodianTransferAmountMismatch();
-    
-    event AddressWhitelisted(address indexed addr);
-    event AddressRemovedFromWhitelist(address indexed addr);
-    error AddressNotWhitelisted();
 }

--- a/protocol-units/settlement/mcr/contracts/src/staking/interfaces/IMovementStaking.sol
+++ b/protocol-units/settlement/mcr/contracts/src/staking/interfaces/IMovementStaking.sol
@@ -70,6 +70,9 @@ interface IMovementStaking {
         uint256[] calldata refundAmounts
     ) external;
 
+    function whitelistAddress(address addr) external;
+    function removeAddressFromWhitelist(address addr) external;
+
     event AttesterStaked(
         address indexed domain,
         uint256 indexed epoch,
@@ -97,4 +100,8 @@ interface IMovementStaking {
     event EpochRolledOver(address indexed domain, uint256 epoch);
     error StakeExceedsGenesisStake();
     error CustodianTransferAmountMismatch();
+    
+    event AddressWhitelisted(address indexed addr);
+    event AddressRemovedFromWhitelist(address indexed addr);
+    error AddressNotWhitelisted();
 }

--- a/protocol-units/settlement/mcr/contracts/test/settlement/MCR.sol
+++ b/protocol-units/settlement/mcr/contracts/test/settlement/MCR.sol
@@ -53,11 +53,14 @@ contract MCRTest is Test, IMCR {
 
         // three well-funded signers
         address payable alice = payable(vm.addr(1));
+        staking.whitelistAddress(alice);
         moveToken.mint(alice, 100);
         address payable bob = payable(vm.addr(2));
+        staking.whitelistAddress(bob);
         moveToken.mint(bob, 100);
         address payable carol = payable(vm.addr(3));
         moveToken.mint(carol, 100);
+        staking.whitelistAddress(carol);
 
         // have them participate in the genesis ceremony
         vm.prank(alice);
@@ -118,11 +121,14 @@ contract MCRTest is Test, IMCR {
 
         // three well-funded signers
         address payable alice = payable(vm.addr(1));
+        staking.whitelistAddress(alice);
         moveToken.mint(alice, 100);
         address payable bob = payable(vm.addr(2));
         moveToken.mint(bob, 100);
+        staking.whitelistAddress(bob);
         address payable carol = payable(vm.addr(3));
         moveToken.mint(carol, 100);
+        staking.whitelistAddress(carol);
 
         // have them participate in the genesis ceremony
         vm.prank(alice);
@@ -207,10 +213,13 @@ contract MCRTest is Test, IMCR {
 
         // three well-funded signers
         address payable alice = payable(vm.addr(1));
+        staking.whitelistAddress(alice);
         moveToken.mint(alice, 100);
         address payable bob = payable(vm.addr(2));
+        staking.whitelistAddress(bob);
         moveToken.mint(bob, 100);
         address payable carol = payable(vm.addr(3));
+        staking.whitelistAddress(carol);
         moveToken.mint(carol, 100);
 
         // have them participate in the genesis ceremony
@@ -322,10 +331,15 @@ contract MCRTest is Test, IMCR {
 
         // three well-funded signers
         address payable alice = payable(vm.addr(1));
+        staking.whitelistAddress(alice);
         moveToken.mint(alice, 100);
+
         address payable bob = payable(vm.addr(2));
+        staking.whitelistAddress(bob);
         moveToken.mint(bob, 100);
+
         address payable carol = payable(vm.addr(3));
+        staking.whitelistAddress(carol);
         moveToken.mint(carol, 100);
 
         // have them participate in the genesis ceremony
@@ -410,6 +424,7 @@ contract MCRTest is Test, IMCR {
 
             // add a new signer
             address payable newSigner = payable(vm.addr(4 + i));
+            staking.whitelistAddress(newSigner);
             moveToken.mint(newSigner, 100);
             vm.prank(newSigner);
             moveToken.approve(address(staking), 33);

--- a/protocol-units/settlement/mcr/contracts/test/staking/MovementStaking.t.sol
+++ b/protocol-units/settlement/mcr/contracts/test/staking/MovementStaking.t.sol
@@ -60,10 +60,10 @@ contract MovementStakingTest is Test {
         address whitelister = vm.addr(1);
         // Whitelist them
         staking.whitelistAddress(whitelister);
-        assertEq(staking.whitelisted(whitelister), true);
+        assertEq(staking.hasRole(staking.WHITELIST_ROLE(), whitelister), true);
         // Remove them from the whitelist
         staking.removeAddressFromWhitelist(whitelister);
-        assertEq(staking.whitelisted(whitelister), false);
+        assertEq(staking.hasRole(staking.WHITELIST_ROLE(), whitelister), false);
         // As a whitelister let's see if I can whitelist myself
         vm.prank(whitelister);
         vm.expectRevert();

--- a/protocol-units/settlement/mcr/contracts/test/staking/MovementStaking.t.sol
+++ b/protocol-units/settlement/mcr/contracts/test/staking/MovementStaking.t.sol
@@ -49,6 +49,27 @@ contract MovementStakingTest is Test {
 
     }
 
+    function testWhitelist() public {
+        MOVEToken moveToken = new MOVEToken();
+        moveToken.initialize();
+
+        MovementStaking staking = new MovementStaking();
+        staking.initialize(moveToken);
+        
+        // Our whitelister
+        address whitelister = vm.addr(1);
+        // Whitelist them
+        staking.whitelistAddress(whitelister);
+        assertEq(staking.whitelisted(whitelister), true);
+        // Remove them from the whitelist
+        staking.removeAddressFromWhitelist(whitelister);
+        assertEq(staking.whitelisted(whitelister), false);
+        // As a whitelister let's see if I can whitelist myself
+        vm.prank(whitelister);
+        vm.expectRevert();
+        staking.whitelistAddress(whitelister);
+    }
+
     function testSimpleStaker() public {
 
         MOVEToken moveToken = new MOVEToken();
@@ -66,6 +87,7 @@ contract MovementStakingTest is Test {
 
         // stake at the domain
         address payable staker = payable(vm.addr(2));
+        staking.whitelistAddress(staker);
         moveToken.mint(staker, 100);
         vm.prank(staker);
         moveToken.approve(address(staking), 100);
@@ -73,7 +95,6 @@ contract MovementStakingTest is Test {
         staking.stake(domain, moveToken, 100);
         assertEq(moveToken.balanceOf(staker), 0);
         assertEq(staking.getStakeAtEpoch(domain, 0, address(moveToken), staker), 100);
-
     }
 
     function testSimpleGenesisCeremony() public {
@@ -93,6 +114,7 @@ contract MovementStakingTest is Test {
 
         // genesis ceremony
         address payable staker = payable(vm.addr(2));
+        staking.whitelistAddress(staker);
         moveToken.mint(staker, 100);
         vm.prank(staker);
         moveToken.approve(address(staking), 100);
@@ -122,7 +144,9 @@ contract MovementStakingTest is Test {
 
         // genesis ceremony
         address payable staker = payable(vm.addr(2));
+        staking.whitelistAddress(staker);
         moveToken.mint(staker, 100);
+        staking.whitelistAddress(staker);
         vm.prank(staker);
         moveToken.approve(address(staking), 100);
         vm.prank(staker);
@@ -160,6 +184,7 @@ contract MovementStakingTest is Test {
 
         // genesis ceremony
         address payable staker = payable(vm.addr(2));
+        staking.whitelistAddress(staker);
         moveToken.mint(staker, 100);
         vm.prank(staker);
         moveToken.approve(address(staking), 100);
@@ -206,6 +231,7 @@ contract MovementStakingTest is Test {
 
         // genesis ceremony
         address payable staker = payable(vm.addr(2));
+        staking.whitelistAddress(staker);
         moveToken.mint(staker, 150);
         vm.prank(staker);
         moveToken.approve(address(staking), 100);
@@ -266,6 +292,7 @@ contract MovementStakingTest is Test {
 
         // genesis ceremony
         address payable staker = payable(vm.addr(2));
+        staking.whitelistAddress(staker);
         moveToken.mint(staker, 150);
         vm.prank(staker);
         moveToken.approve(address(staking), 100);


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`

<!--
Add your summary text here. 
 -->
In order to gate the attesters on our network a whitelist is being used to prevent those not in this list to stake/unstake and hence not become attesters.  Technically one could just gate `stake` but for completeness `unstake` is also gated with the list.

# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->
Includes changes to the storage for the whitelist of addresses, setters and modifier.

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

Tests have been added to cover the whitelist functionality and have been updated where `stake` is being used as now each staker has to be whitelisted.

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->