### PR TITLE
fix bridge package publishing issue: init_module takes only 1 signer

### DIFF
--- a/protocol-units/bridge/move-modules/sources/atomic_bridge.move
+++ b/protocol-units/bridge/move-modules/sources/atomic_bridge.move
@@ -49,21 +49,21 @@ module atomic_bridge::atomic_bridge_counterparty {
     struct BridgeTransferCancelledEvent has store, drop {
         bridge_transfer_id: vector<u8>,
     }
-
-    entry fun init_module(deployer: &signer, moveth_minter: &signer) {
+    
+    entry fun init_module(deployer: &signer) {
         let bridge_transfer_store = BridgeTransferStore {
             pending_transfers: smart_table::new(),
             completed_transfers: smart_table::new(),
             aborted_transfers: smart_table::new(),
         };
         let bridge_config = BridgeConfig {
-            moveth_minter: signer::address_of(moveth_minter),
+            moveth_minter: signer::address_of(deployer),
             bridge_module_deployer: signer::address_of(deployer),
         };
         move_to(deployer, bridge_transfer_store);
         move_to(deployer, bridge_config);
     }
-
+    
     public fun lock_bridge_transfer_assets(
         caller: &signer,
         initiator: vector<u8>, //eth address
@@ -95,7 +95,7 @@ module atomic_bridge::atomic_bridge_counterparty {
 
         true
     }
-
+    
     public fun complete_bridge_transfer(
         caller: &signer,
         bridge_transfer_id: vector<u8>,
@@ -119,7 +119,7 @@ module atomic_bridge::atomic_bridge_counterparty {
             },
         );
     }
-
+    
     public fun abort_bridge_transfer(
         caller: &signer,
         bridge_transfer_id: vector<u8>
@@ -140,13 +140,14 @@ module atomic_bridge::atomic_bridge_counterparty {
         );
     }
 
+    
     #[test(creator = @atomic_bridge)]
     fun test_init_module(
         creator: &signer,
     ) acquires BridgeTransferStore, BridgeConfig {
         let owner = signer::address_of(creator);
         let moveth_minter = @0x1; 
-        init_module(creator, creator);
+        init_module(creator);
 
         // Verify that the BridgeTransferStore and BridgeConfig have been init_moduled
         let bridge_store = borrow_global<BridgeTransferStore>(signer::address_of(creator));
@@ -185,7 +186,7 @@ module atomic_bridge::atomic_bridge_counterparty {
 
 
         // In this case the moveth_minter (2nd param) is also the creator.
-        init_module(creator, creator);
+        init_module(creator);
 
         let bridge_transfer_id = b"transfer1";
         let pre_image = b"secret";
@@ -234,4 +235,5 @@ module atomic_bridge::atomic_bridge_counterparty {
         assert!(transfer_details.hash_lock == hash_lock, 3);
         assert!(transfer_details.initiator == initiator, 4);
     }
+    
 }


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

Bridge move modules package was compiling and passing tests but not publishing. It was because `init_module` in `atomic_bridge::atomic_bridge_counterparty` can only take 1 arg. Module tests were not exposing the error for some reason. 

# Changelog

I modified `init_module` and related tests to only take one signer. This change makes it so `moveth_minter` must have the same address as the module publisher. If I understand correctly, this will be okay to do because the plan is to implement a resource account pattern where the module is published under the resource account and the resource account is the minter. I may be misunderstanding that, so please review and adjust accordingly, @0xmovses.

# Testing

Unit tests in module pass,  module publishes successfully.

One way to publish the module is change `Move.toml` as follows:

```
[addresses]
atomic_bridge = "<your-address>"
moveth = "<your-address>"
master_minter = "0xbab"
minter = "0xface"
pauser = "0xdafe"
denylister = "0xcade"

# [dev-addresses]
# moveth = "0xbeef"
# atomic_bridge = "0xfeef"
# master_minter = "0xbab"
# minter = "0xface"
# pauser = "0xdafe"
# denylister = "0xcade"
```

And publish to Aptos devnet. (As far as I know, Movement does not have a network up yet that includes `function_info` and `dispatchable_fungible_asset` modules in the framework.)

# Outstanding issues
I may be incorrect in assuming it's okay to force the moveth minter to be the same account as the module publisher. My solution is proposed as one way to make the module compile but may need some modification to make sense in the system design.