### PR TITLE
MOVETH module mint resource account refactor

### DIFF
--- a/protocol-units/bridge/move-modules/Move.toml
+++ b/protocol-units/bridge/move-modules/Move.toml
@@ -4,10 +4,11 @@ version = "1.0.0"
 authors = []
 
 [addresses]
-atomic_bridge = "0xd704dffbd878b8928d72c4a5db2eb326310bcb2f2291aa541f40b86853f90fa6"
-moveth = "0xd704dffbd878b8928d72c4a5db2eb326310bcb2f2291aa541f40b86853f90fa6"
-master_minter = "0xfeef"
-minter = "0xbab"
+atomic_bridge = "0xc26f08a91754150c6c8ab9a79f51d1d23bf70828e8fd62b6ea49ec2a9bf95cfa"
+moveth = "0xc26f08a91754150c6c8ab9a79f51d1d23bf70828e8fd62b6ea49ec2a9bf95cfa"
+master_minter = "0xc26f08a91754150c6c8ab9a79f51d1d23bf70828e8fd62b6ea49ec2a9bf95cfa"
+resource_addr = "0xc26f08a91754150c6c8ab9a79f51d1d23bf70828e8fd62b6ea49ec2a9bf95cfa"
+minter = "0x99c117835788d6310c09ba4c88b3f81058b9b1684d74bc62f2bbbd7b06ed8d79"
 pauser = "0xface"
 denylister = "0xcade"
 

--- a/protocol-units/bridge/move-modules/Move.toml
+++ b/protocol-units/bridge/move-modules/Move.toml
@@ -4,20 +4,20 @@ version = "1.0.0"
 authors = []
 
 [addresses]
-atomic_bridge = "_"
-moveth = "_"
-master_minter = "_"
-minter = "_"
-pauser = "_"
-denylister = "_"
-
-[dev-addresses]
-moveth = "0xbeef"
-atomic_bridge = "0xfeef"
-master_minter = "0xbab"
-minter = "0xface"
-pauser = "0xdafe"
+atomic_bridge = "0xd704dffbd878b8928d72c4a5db2eb326310bcb2f2291aa541f40b86853f90fa6"
+moveth = "0xd704dffbd878b8928d72c4a5db2eb326310bcb2f2291aa541f40b86853f90fa6"
+master_minter = "0xfeef"
+minter = "0xbab"
+pauser = "0xface"
 denylister = "0xcade"
+
+# [dev-addresses]
+# moveth = "0xbeef"
+# atomic_bridge = "0xfeef"
+# master_minter = "0xbab"
+# minter = "0xface"
+# pauser = "0xdafe"
+# denylister = "0xcade"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"

--- a/protocol-units/bridge/move-modules/sources/atomic_bridge.move
+++ b/protocol-units/bridge/move-modules/sources/atomic_bridge.move
@@ -146,7 +146,7 @@ module atomic_bridge::atomic_bridge_counterparty {
     ) acquires BridgeTransferStore, BridgeConfig {
         let owner = signer::address_of(creator);
         let moveth_minter = @0x1; 
-        init_module(creator, creator);
+        init_module(creator);
 
         // Verify that the BridgeTransferStore and BridgeConfig have been init_moduled
         let bridge_store = borrow_global<BridgeTransferStore>(signer::address_of(creator));
@@ -185,7 +185,7 @@ module atomic_bridge::atomic_bridge_counterparty {
 
 
         // In this case the moveth_minter (2nd param) is also the creator.
-        init_module(creator, creator);
+        init_module(creator);
 
         let bridge_transfer_id = b"transfer1";
         let pre_image = b"secret";

--- a/protocol-units/bridge/move-modules/sources/atomic_bridge.move
+++ b/protocol-units/bridge/move-modules/sources/atomic_bridge.move
@@ -50,14 +50,14 @@ module atomic_bridge::atomic_bridge_counterparty {
         bridge_transfer_id: vector<u8>,
     }
 
-    entry fun init_module(deployer: &signer, moveth_minter: &signer) {
+    entry fun init_module(deployer: &signer) {
         let bridge_transfer_store = BridgeTransferStore {
             pending_transfers: smart_table::new(),
             completed_transfers: smart_table::new(),
             aborted_transfers: smart_table::new(),
         };
         let bridge_config = BridgeConfig {
-            moveth_minter: signer::address_of(moveth_minter),
+            moveth_minter: signer::address_of(deployer),
             bridge_module_deployer: signer::address_of(deployer),
         };
         move_to(deployer, bridge_transfer_store);


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

Refactored `moveth` module for resource account. Tests still need to be rewritten as they were from the old minting model.

# Changelog

- Module is published under resource account. 
- In `init_module` the `Roles`, `Management`, and `State` resources are moved to the resource account address.  
- Changed `Move.toml` so `atomic_bridge`, `moveth`, `master_minter`, and `resource_addr` take the resource account address, and `minter` takes the address of whoever published the module, for convenience.

So for example in this case to publish I'm running

```
aptos move create-resource-account-and-publish-package --seed 0123456789 --address-name moveth --profile default --named-addresses source_addr=0x99c117835788d6310c09ba4c88b3f81058b9b1684d74bc62f2bbbd7b06ed8d79
```

and to mint I'm running

```
aptos move run --function-id 0xc26f08a91754150c6c8ab9a79f51d1d23bf70828e8fd62b6ea49ec2a9bf95cfa::moveth::mint  --args address:0xb118a531aa5efb194f5e322aeee8e9d1e98c6220936d1cee90e1480911d51d64 u64:5
``` 

# Testing

I'll rewrite the tests later today. Right now they fail, and it appears that the `mint` function is failing at some point.

# Outstanding issues
It appears that the mint function is not working, despite not returning errors. Will rewrite the tests for the resource account model later today.

I could use feedback on the general logical design and suggestions as to why the mint function fails without errors. 