### PR TITLE
Sequence Number Panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,11 +11,22 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.70",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "addchain"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2e69442aa5628ea6951fa33e24efe8313f4321a91bd729fc2f75bdfc858570"
+dependencies = [
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -334,7 +345,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "auto_impl",
- "dashmap",
+ "dashmap 5.5.3",
  "futures",
  "futures-utils-wasm",
  "lru 0.12.3",
@@ -382,8 +393,8 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d83524c1f6162fcb5b0decf775498a125066c86dda6066ed609531b0e912f85a"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -509,8 +520,8 @@ dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -526,8 +537,8 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.2.6",
  "proc-macro-error",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
  "syn-solidity",
  "tiny-keccak",
@@ -543,8 +554,8 @@ dependencies = [
  "const-hex",
  "dunce",
  "heck 0.5.0",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "serde_json",
  "syn 2.0.70",
  "syn-solidity",
@@ -710,7 +721,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -723,7 +734,7 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -733,9 +744,8 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
- "anyhow",
  "aptos-logger",
  "aptos-types",
  "bcs 0.1.4",
@@ -748,7 +758,7 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -756,8 +766,6 @@ dependencies = [
  "aptos-build-info",
  "aptos-config",
  "aptos-crypto",
- "aptos-db-indexer",
- "aptos-framework",
  "aptos-gas-schedule",
  "aptos-global-constants",
  "aptos-logger",
@@ -766,16 +774,15 @@ dependencies = [
  "aptos-runtimes",
  "aptos-storage-interface",
  "aptos-types",
- "aptos-utils",
  "aptos-vm",
  "async-trait",
  "bcs 0.1.4",
  "bytes 1.6.0",
- "fail 0.5.1",
+ "fail",
  "futures",
  "hex",
  "hyper 0.14.30",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "mime",
  "mini-moka",
  "move-core-types",
@@ -788,31 +795,30 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "url",
 ]
 
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-config",
  "aptos-crypto",
- "aptos-db-indexer",
  "aptos-framework",
  "aptos-logger",
  "aptos-openapi",
+ "aptos-resource-viewer",
  "aptos-storage-interface",
  "aptos-types",
  "aptos-vm",
  "async-trait",
  "bcs 0.1.4",
+ "bytes 1.6.0",
  "hex",
  "indoc",
  "move-binary-format",
  "move-core-types",
- "move-resource-viewer",
  "once_cell",
  "poem",
  "poem-openapi",
@@ -824,7 +830,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "hex",
@@ -833,7 +839,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -842,7 +848,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -860,35 +866,33 @@ dependencies = [
  "claims",
  "concurrent-queue",
  "crossbeam",
- "dashmap",
+ "dashmap 5.5.3",
  "derivative",
- "fail 0.5.1",
+ "fail",
  "move-binary-format",
  "move-core-types",
  "move-vm-types",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand 0.7.3",
  "rayon",
  "scopeguard",
- "serde",
 ]
 
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
- "anyhow",
  "aptos-crypto",
  "aptos-logger",
  "aptos-metrics-core",
  "aptos-types",
  "bcs 0.1.4",
  "clap 4.5.9",
- "dashmap",
- "itertools 0.10.5",
+ "dashmap 5.5.3",
+ "itertools 0.12.1",
  "jemallocator",
  "move-core-types",
  "once_cell",
@@ -900,7 +904,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "futures",
  "rustversion",
@@ -910,7 +914,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "shadow-rs",
 ]
@@ -918,14 +922,13 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-framework",
  "aptos-package-builder",
  "aptos-types",
  "bcs 0.1.4",
- "include_dir 0.7.4",
  "move-core-types",
  "once_cell",
 ]
@@ -933,11 +936,10 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-infallible",
- "aptos-logger",
  "aptos-metrics-core",
  "futures",
 ]
@@ -945,7 +947,7 @@ dependencies = [
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -957,11 +959,10 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-crypto",
- "aptos-crypto-derive",
  "aptos-global-constants",
  "aptos-logger",
  "aptos-secure-storage",
@@ -972,10 +973,8 @@ dependencies = [
  "bcs 0.1.4",
  "byteorder",
  "cfg-if",
- "cfg_block",
  "get_if_addrs",
  "maplit",
- "mirai-annotations",
  "num_cpus",
  "number_range",
  "poem-openapi",
@@ -991,7 +990,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1003,24 +1002,30 @@ dependencies = [
  "aptos-short-hex-str",
  "aptos-types",
  "bcs 0.1.4",
- "itertools 0.10.5",
+ "fail",
+ "futures",
+ "itertools 0.12.1",
+ "mini-moka",
  "mirai-annotations",
  "once_cell",
  "rand 0.7.3",
  "rayon",
  "serde",
+ "tokio",
 ]
 
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "aptos-crypto-derive",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.4.2",
+ "ark-groth16",
  "ark-std 0.4.0",
  "base64 0.13.1",
  "bcs 0.1.4",
@@ -1031,83 +1036,58 @@ dependencies = [
  "curve25519-dalek-ng",
  "digest 0.9.0",
  "ed25519-dalek",
+ "ff",
  "hex",
  "hkdf 0.10.0",
  "libsecp256k1",
  "merlin",
  "more-asserts",
+ "neptune",
  "num-bigint 0.3.3",
  "num-integer",
  "once_cell",
  "p256",
  "poseidon-ark",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
  "rand 0.7.3",
  "rand_core 0.5.1",
+ "ring 0.16.20",
  "serde",
  "serde-name",
  "serde_bytes",
  "sha2 0.10.8",
  "sha2 0.9.9",
+ "sha3",
  "signature 2.2.0",
  "static_assertions",
  "thiserror",
  "tiny-keccak",
+ "typenum",
  "x25519-dalek",
 ]
 
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "aptos-data-client"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
-dependencies = [
- "aptos-config",
- "aptos-crypto",
- "aptos-id-generator",
- "aptos-infallible",
- "aptos-logger",
- "aptos-metrics-core",
- "aptos-netcore",
- "aptos-network",
- "aptos-storage-interface",
- "aptos-storage-service-client",
- "aptos-storage-service-types",
- "aptos-time-service",
- "aptos-types",
- "arc-swap",
- "async-trait",
- "dashmap",
- "futures",
- "itertools 0.10.5",
- "maplit",
- "ordered-float",
- "rand 0.8.5",
- "serde",
- "thiserror",
- "tokio",
 ]
 
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
  "aptos-config",
  "aptos-crypto",
  "aptos-db-indexer",
+ "aptos-db-indexer-schemas",
  "aptos-executor",
  "aptos-executor-types",
  "aptos-experimental-runtimes",
@@ -1116,78 +1096,82 @@ dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
  "aptos-proptest-helpers",
+ "aptos-resource-viewer",
  "aptos-rocksdb-options",
  "aptos-schemadb",
  "aptos-scratchpad",
  "aptos-storage-interface",
  "aptos-temppath",
  "aptos-types",
- "aptos-vm",
  "arc-swap",
  "arr_macro",
  "bcs 0.1.4",
  "byteorder",
  "claims",
- "dashmap",
+ "dashmap 5.5.3",
  "either",
- "itertools 0.10.5",
+ "hex",
+ "itertools 0.12.1",
  "lru 0.7.8",
  "move-core-types",
- "move-resource-viewer",
  "num-derive",
- "num_cpus",
  "once_cell",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
  "rayon",
  "serde",
  "static_assertions",
  "status-line",
- "thiserror",
 ]
 
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-config",
- "aptos-crypto",
- "aptos-infallible",
+ "aptos-db-indexer-schemas",
  "aptos-logger",
- "aptos-metrics-core",
+ "aptos-resource-viewer",
  "aptos-rocksdb-options",
  "aptos-schemadb",
- "aptos-scratchpad",
  "aptos-storage-interface",
  "aptos-types",
- "aptos-vm",
+ "bcs 0.1.4",
+ "bytes 1.6.0",
+ "dashmap 5.5.3",
+ "move-core-types",
+]
+
+[[package]]
+name = "aptos-db-indexer-schemas"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+dependencies = [
+ "anyhow",
+ "aptos-schemadb",
+ "aptos-storage-interface",
+ "aptos-types",
  "bcs 0.1.4",
  "byteorder",
- "bytes 1.6.0",
- "dashmap",
- "move-core-types",
- "move-resource-viewer",
- "num-derive",
  "serde",
 ]
 
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-crypto",
  "aptos-crypto-derive",
  "bcs 0.1.4",
- "bellman",
  "blst",
  "blstrs",
  "criterion",
- "ff 0.13.0",
- "group 0.13.0",
+ "ff",
+ "group",
  "hex",
  "merlin",
  "more-asserts",
@@ -1208,9 +1192,8 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
- "aptos-experimental-runtimes",
  "aptos-infallible",
  "aptos-metrics-core",
  "once_cell",
@@ -1220,7 +1203,7 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -1228,7 +1211,6 @@ dependencies = [
  "aptos-infallible",
  "aptos-storage-interface",
  "aptos-types",
- "async-trait",
  "futures",
  "serde",
  "thiserror",
@@ -1237,10 +1219,9 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
- "aptos-block-partitioner",
  "aptos-consensus-types",
  "aptos-crypto",
  "aptos-drop-helper",
@@ -1251,18 +1232,17 @@ dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
  "aptos-scratchpad",
- "aptos-secure-net",
+ "aptos-sdk",
  "aptos-storage-interface",
  "aptos-types",
  "aptos-vm",
  "arr_macro",
  "bcs 0.1.4",
  "bytes 1.6.0",
- "dashmap",
- "fail 0.5.1",
- "itertools 0.10.5",
+ "dashmap 5.5.3",
+ "fail",
+ "itertools 0.12.1",
  "move-core-types",
- "num_cpus",
  "once_cell",
  "rayon",
  "serde",
@@ -1271,20 +1251,16 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
- "anyhow",
  "aptos-block-partitioner",
  "aptos-config",
- "aptos-crypto",
- "aptos-executor-types",
  "aptos-infallible",
  "aptos-language-e2e-tests",
  "aptos-logger",
  "aptos-metrics-core",
  "aptos-node-resource-metrics",
  "aptos-push-metrics",
- "aptos-retrier",
  "aptos-secure-net",
  "aptos-storage-interface",
  "aptos-types",
@@ -1293,22 +1269,19 @@ dependencies = [
  "clap 4.5.9",
  "crossbeam-channel",
  "ctrlc",
- "dashmap",
- "itertools 0.10.5",
+ "dashmap 5.5.3",
+ "itertools 0.12.1",
  "num_cpus",
  "once_cell",
- "rand 0.7.3",
  "rayon",
  "serde",
- "serde_json",
  "thiserror",
- "tokio",
 ]
 
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -1318,7 +1291,6 @@ dependencies = [
  "aptos-db",
  "aptos-executor",
  "aptos-executor-types",
- "aptos-genesis",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
@@ -1331,10 +1303,9 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
- "aptos-block-partitioner",
  "aptos-crypto",
  "aptos-drop-helper",
  "aptos-scratchpad",
@@ -1343,8 +1314,7 @@ dependencies = [
  "aptos-types",
  "bcs 0.1.4",
  "criterion",
- "dashmap",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "once_cell",
  "serde",
  "thiserror",
@@ -1353,7 +1323,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-runtimes",
  "core_affinity",
@@ -1366,7 +1336,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1400,7 +1370,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -1409,13 +1379,12 @@ dependencies = [
  "poem",
  "prometheus",
  "serde",
- "serde_json",
 ]
 
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -1425,7 +1394,6 @@ dependencies = [
  "aptos-move-stdlib",
  "aptos-native-interface",
  "aptos-sdk-builder",
- "aptos-table-natives",
  "aptos-types",
  "aptos-vm-types",
  "ark-bls12-381",
@@ -1434,11 +1402,9 @@ dependencies = [
  "ark-ff 0.4.2",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
- "base64 0.13.1",
  "bcs 0.1.4",
  "better_any",
  "blake2-rfc",
- "blst",
  "bulletproofs",
  "byteorder",
  "clap 4.5.9",
@@ -1447,8 +1413,7 @@ dependencies = [
  "either",
  "flate2",
  "hex",
- "include_dir 0.7.4",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "libsecp256k1",
  "log",
  "lru 0.7.8",
@@ -1471,12 +1436,9 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "rand_core 0.5.1",
- "rayon",
  "ripemd",
  "serde",
  "serde_bytes",
- "serde_json",
- "serde_yaml 0.8.26",
  "sha2 0.10.8",
  "sha2 0.9.9",
  "sha3",
@@ -1490,7 +1452,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "either",
  "move-core-types",
@@ -1499,14 +1461,13 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
  "aptos-logger",
  "aptos-types",
  "aptos-vm-types",
- "bcs 0.1.4",
  "move-binary-format",
  "move-core-types",
  "move-vm-types",
@@ -1515,16 +1476,13 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
- "aptos-framework",
  "aptos-gas-algebra",
  "aptos-gas-meter",
- "aptos-package-builder",
  "aptos-types",
  "aptos-vm-types",
- "bcs 0.1.4",
  "handlebars",
  "inferno",
  "move-binary-format",
@@ -1538,12 +1496,10 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
- "aptos-types",
- "either",
  "move-core-types",
  "move-vm-types",
  "paste",
@@ -1551,49 +1507,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "aptos-genesis"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
-dependencies = [
- "anyhow",
- "aptos-cached-packages",
- "aptos-config",
- "aptos-crypto",
- "aptos-db",
- "aptos-executor",
- "aptos-framework",
- "aptos-keygen",
- "aptos-logger",
- "aptos-storage-interface",
- "aptos-temppath",
- "aptos-types",
- "aptos-vm",
- "aptos-vm-genesis",
- "bcs 0.1.4",
- "rand 0.7.3",
- "serde",
- "serde_yaml 0.8.26",
-]
-
-[[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1607,12 +1538,12 @@ dependencies = [
  "arr_macro",
  "bcs 0.1.4",
  "byteorder",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "num-derive",
  "num-traits",
  "once_cell",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
  "rayon",
  "serde",
  "thiserror",
@@ -1621,7 +1552,7 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1631,11 +1562,10 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
- "aptos-aggregator",
  "aptos-bitvec",
  "aptos-block-executor",
  "aptos-cached-packages",
@@ -1646,8 +1576,6 @@ dependencies = [
  "aptos-gas-profiling",
  "aptos-gas-schedule",
  "aptos-keygen",
- "aptos-memory-usage-tracker",
- "aptos-native-interface",
  "aptos-proptest-helpers",
  "aptos-temppath",
  "aptos-types",
@@ -1658,18 +1586,18 @@ dependencies = [
  "bcs 0.1.4",
  "bytes 1.6.0",
  "goldenfile",
- "hex",
  "move-binary-format",
  "move-command-line-common",
  "move-core-types",
  "move-ir-compiler",
  "move-model",
+ "move-vm-runtime",
  "move-vm-types",
  "num_cpus",
  "once_cell",
  "petgraph 0.5.1",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
  "rand 0.7.3",
  "rayon",
  "serde",
@@ -1678,37 +1606,38 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
  "hex",
  "ledger-apdu",
  "ledger-transport-hid",
- "once_cell",
  "thiserror",
 ]
 
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-infallible",
  "aptos-log-derive",
+ "aptos-node-identity",
  "backtrace",
  "chrono",
  "erased-serde",
+ "futures",
  "hostname",
  "once_cell",
  "prometheus",
@@ -1716,6 +1645,7 @@ dependencies = [
  "serde_json",
  "strum 0.24.1",
  "strum_macros 0.24.3",
+ "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",
 ]
@@ -1723,12 +1653,11 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
  "aptos-types",
- "aptos-vm-types",
  "move-binary-format",
  "move-core-types",
  "move-vm-types",
@@ -1737,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -1745,7 +1674,6 @@ dependencies = [
  "aptos-config",
  "aptos-consensus-types",
  "aptos-crypto",
- "aptos-data-client",
  "aptos-event-notifications",
  "aptos-infallible",
  "aptos-logger",
@@ -1753,22 +1681,23 @@ dependencies = [
  "aptos-metrics-core",
  "aptos-netcore",
  "aptos-network",
+ "aptos-peer-monitoring-service-types",
  "aptos-runtimes",
  "aptos-short-hex-str",
  "aptos-storage-interface",
+ "aptos-time-service",
  "aptos-types",
  "aptos-vm-validator",
- "async-trait",
  "bcs 0.1.4",
- "fail 0.5.1",
+ "fail",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "maplit",
+ "num_cpus",
  "once_cell",
  "rand 0.7.3",
  "rayon",
  "serde",
- "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -1777,9 +1706,8 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
- "aptos-runtimes",
  "aptos-types",
  "async-trait",
  "futures",
@@ -1791,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-infallible",
  "bytes 1.6.0",
@@ -1802,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -1811,45 +1739,32 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
- "anyhow",
  "aptos-gas-schedule",
  "aptos-native-interface",
- "either",
- "hex",
- "log",
- "move-binary-format",
- "move-command-line-common",
- "move-compiler",
  "move-core-types",
- "move-docgen",
- "move-errmapgen",
- "move-prover",
  "move-vm-runtime",
  "move-vm-types",
  "sha2 0.9.9",
  "sha3",
  "smallvec",
- "walkdir",
 ]
 
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
  "aptos-crypto",
- "aptos-infallible",
  "aptos-types",
  "aptos-vm-types",
- "bcs 0.1.4",
  "bytes 1.6.0",
  "claims",
  "crossbeam",
- "dashmap",
+ "dashmap 5.5.3",
  "derivative",
  "move-binary-format",
  "move-core-types",
@@ -1860,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -1877,7 +1792,7 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
@@ -1894,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1902,7 +1817,6 @@ dependencies = [
  "aptos-compression",
  "aptos-config",
  "aptos-crypto",
- "aptos-crypto-derive",
  "aptos-id-generator",
  "aptos-infallible",
  "aptos-logger",
@@ -1910,7 +1824,6 @@ dependencies = [
  "aptos-netcore",
  "aptos-num-variants",
  "aptos-peer-monitoring-service-types",
- "aptos-rate-limiter",
  "aptos-short-hex-str",
  "aptos-time-service",
  "aptos-types",
@@ -1921,28 +1834,38 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "maplit",
  "once_cell",
  "ordered-float",
  "pin-project 1.1.5",
  "rand 0.7.3",
  "rand 0.8.5",
- "ring 0.16.20",
  "serde",
  "serde_bytes",
  "serde_json",
- "sha2 0.9.9",
  "thiserror",
  "tokio",
  "tokio-retry",
+ "tokio-stream",
  "tokio-util",
+]
+
+[[package]]
+name = "aptos-node-identity"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+dependencies = [
+ "anyhow",
+ "aptos-types",
+ "claims",
+ "once_cell",
 ]
 
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-build-info",
  "aptos-infallible",
@@ -1958,17 +1881,17 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -1981,11 +1904,11 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-framework",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "move-command-line-common",
  "move-package",
  "tempfile",
@@ -1994,12 +1917,11 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-config",
  "aptos-types",
  "bcs 0.1.4",
- "cfg_block",
  "serde",
  "thiserror",
 ]
@@ -2007,22 +1929,21 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "crossbeam",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
 ]
 
 [[package]]
 name = "aptos-protos"
 version = "1.3.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "futures-core",
  "pbjson",
  "prost",
- "prost-types",
  "serde",
  "tonic",
 ]
@@ -2030,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "ipnet",
 ]
@@ -2038,7 +1959,7 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -2047,23 +1968,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "aptos-rate-limiter"
+name = "aptos-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
- "aptos-infallible",
- "aptos-logger",
- "aptos-metrics-core",
- "futures",
- "pin-project 1.1.5",
- "tokio",
- "tokio-util",
+ "anyhow",
+ "aptos-types",
+ "aptos-vm",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
+ "move-resource-viewer",
 ]
 
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -2073,11 +1994,8 @@ dependencies = [
  "aptos-types",
  "bcs 0.1.4",
  "bytes 1.6.0",
- "futures",
  "hex",
- "move-binary-format",
  "move-core-types",
- "poem-openapi",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -2087,18 +2005,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "aptos-retrier"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
-dependencies = [
- "aptos-logger",
- "tokio",
-]
-
-[[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-config",
  "rocksdb",
@@ -2107,7 +2016,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "rayon",
  "tokio",
@@ -2116,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2133,17 +2042,16 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-crypto",
  "aptos-drop-helper",
  "aptos-experimental-runtimes",
  "aptos-infallible",
- "aptos-logger",
  "aptos-metrics-core",
  "aptos-types",
  "bitvec 1.0.1",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "once_cell",
  "proptest",
  "rayon",
@@ -2153,28 +2061,29 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
- "aptos-api-types",
  "aptos-cached-packages",
  "aptos-crypto",
  "aptos-global-constants",
  "aptos-ledger",
  "aptos-rest-client",
  "aptos-types",
+ "base64 0.13.1",
  "bcs 0.1.4",
  "ed25519-dalek-bip32",
+ "hex",
  "move-core-types",
  "rand_core 0.5.1",
- "serde",
+ "serde_json",
  "tiny-bip39",
 ]
 
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2183,7 +2092,6 @@ dependencies = [
  "heck 0.4.1",
  "move-core-types",
  "once_cell",
- "regex",
  "serde-generate",
  "serde-reflection",
  "serde_yaml 0.8.26",
@@ -2193,12 +2101,11 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
  "aptos-protos",
- "aptos-retrier",
  "bcs 0.1.4",
  "crossbeam-channel",
  "once_cell",
@@ -2212,9 +2119,8 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
- "anyhow",
  "aptos-crypto",
  "aptos-infallible",
  "aptos-logger",
@@ -2234,7 +2140,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -2245,19 +2151,18 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-infallible",
  "crossbeam",
- "once_cell",
  "rayon",
 ]
 
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2268,70 +2173,33 @@ dependencies = [
  "aptos-secure-net",
  "aptos-types",
  "aptos-vm",
- "arr_macro",
  "bcs 0.1.4",
- "bytes 1.6.0",
  "crossbeam-channel",
- "dashmap",
- "itertools 0.10.5",
+ "dashmap 5.5.3",
  "move-core-types",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
  "rayon",
- "rocksdb",
  "serde",
  "thiserror",
  "threadpool",
 ]
 
 [[package]]
-name = "aptos-storage-service-client"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
-dependencies = [
- "aptos-channels",
- "aptos-config",
- "aptos-network",
- "aptos-storage-service-types",
- "aptos-types",
- "async-trait",
- "thiserror",
-]
-
-[[package]]
-name = "aptos-storage-service-types"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
-dependencies = [
- "aptos-compression",
- "aptos-config",
- "aptos-crypto",
- "aptos-time-service",
- "aptos-types",
- "bcs 0.1.4",
- "num-traits",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
- "anyhow",
  "aptos-gas-schedule",
  "aptos-native-interface",
- "aptos-types",
  "better_any",
  "bytes 1.6.0",
  "move-binary-format",
  "move-core-types",
  "move-table-extension",
  "move-vm-runtime",
- "move-vm-test-utils",
  "move-vm-types",
  "sha3",
  "smallvec",
@@ -2340,7 +2208,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -2349,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -2362,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2370,6 +2238,7 @@ dependencies = [
  "aptos-crypto-derive",
  "aptos-dkg",
  "aptos-experimental-runtimes",
+ "aptos-infallible",
  "ark-bn254",
  "ark-ff 0.4.2",
  "ark-groth16",
@@ -2378,25 +2247,31 @@ dependencies = [
  "base64 0.13.1",
  "bcs 0.1.4",
  "bytes 1.6.0",
- "chrono",
- "derivative",
  "fixed",
+ "fxhash",
+ "hashbrown 0.14.5",
  "hex",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "jsonwebtoken",
  "move-binary-format",
+ "move-bytecode-verifier",
  "move-core-types",
  "move-table-extension",
+ "move-vm-runtime",
  "move-vm-types",
  "num-bigint 0.3.3",
  "num-derive",
  "num-traits",
  "once_cell",
  "passkey-types",
+ "poem-openapi",
+ "poem-openapi-derive",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
+ "quick_cache",
  "rand 0.7.3",
  "rayon",
+ "ring 0.16.20",
  "rsa",
  "serde",
  "serde-big-array",
@@ -2407,18 +2282,17 @@ dependencies = [
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "thiserror",
- "tiny-keccak",
 ]
 
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
@@ -2434,11 +2308,10 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
- "aptos-bitvec",
  "aptos-block-executor",
  "aptos-block-partitioner",
  "aptos-crypto",
@@ -2460,49 +2333,43 @@ dependencies = [
  "aptos-utils",
  "aptos-vm-logging",
  "aptos-vm-types",
- "base64-url",
+ "ark-bn254",
+ "ark-groth16",
  "bcs 0.1.4",
  "bytes 1.6.0",
  "claims",
  "crossbeam-channel",
- "dashmap",
  "derive_more",
- "fail 0.5.1",
+ "fail",
+ "futures",
  "hex",
- "jsonwebtoken",
  "move-binary-format",
- "move-bytecode-utils",
- "move-bytecode-verifier",
  "move-core-types",
  "move-vm-runtime",
  "move-vm-types",
  "num_cpus",
  "once_cell",
- "ouroboros 0.15.6",
+ "ouroboros",
  "rand 0.7.3",
  "rayon",
  "serde",
- "serde_json",
- "smallvec",
- "tracing",
 ]
 
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
- "anyhow",
  "aptos-cached-packages",
  "aptos-crypto",
  "aptos-framework",
  "aptos-gas-schedule",
  "aptos-types",
  "aptos-vm",
- "aptos-vm-types",
  "bcs 0.1.4",
  "bytes 1.6.0",
  "move-core-types",
+ "move-vm-runtime",
  "move-vm-types",
  "once_cell",
  "rand 0.7.3",
@@ -2512,7 +2379,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -2527,7 +2394,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2540,6 +2407,7 @@ dependencies = [
  "either",
  "move-binary-format",
  "move-core-types",
+ "move-vm-runtime",
  "move-vm-types",
  "rand 0.7.3",
  "serde",
@@ -2548,16 +2416,16 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
- "aptos-event-notifications",
  "aptos-logger",
  "aptos-storage-interface",
  "aptos-types",
  "aptos-vm",
  "aptos-vm-logging",
- "fail 0.5.1",
+ "fail",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -2680,7 +2548,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
 dependencies = [
- "quote 1.0.36",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2690,7 +2558,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
- "quote 1.0.36",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2702,7 +2570,7 @@ checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
- "quote 1.0.36",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2714,8 +2582,8 @@ checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2789,8 +2657,8 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2845,7 +2713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6368f9ae5c6ec403ca910327ae0c9437b0a85255b6950c90d497e6177f6e5e"
 dependencies = [
  "proc-macro-hack",
- "quote 1.0.36",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2878,6 +2746,17 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
@@ -2889,13 +2768,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite",
+ "log",
+ "parking",
+ "polling",
+ "rustix 0.37.27",
+ "slab",
+ "socket2 0.4.10",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -2916,8 +2824,8 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -2927,8 +2835,8 @@ version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -2966,8 +2874,8 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -3074,15 +2982,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64-url"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb9fb9fb058cc3063b5fc88d9a21eefa2735871498a04e1650da76ed511c8569"
-dependencies = [
- "base64 0.21.7",
-]
-
-[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3123,18 +3022,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "bellman"
-version = "0.13.1"
+name = "bellpepper"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4dd656ef4fdf7debb6d87d4dd92642fcbcdb78cbf6600c13e25c87e4d1a3807"
+checksum = "9ae286c2cb403324ab644c7cc68dceb25fe52ca9429908a726d7ed272c1edf7b"
 dependencies = [
- "bitvec 1.0.1",
+ "bellpepper-core",
+ "byteorder",
+ "ff",
+]
+
+[[package]]
+name = "bellpepper-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8abb418570756396d722841b19edfec21d4e89e1cf8990610663040ecb1aea"
+dependencies = [
  "blake2s_simd",
  "byteorder",
- "ff 0.12.1",
- "group 0.12.1",
- "rand_core 0.6.4",
- "subtle",
+ "ff",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -3152,8 +3060,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3deeecb812ca5300b7d3f66f730cc2ebd3511c3d36c691dd79c165d5b19a26e3"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -3174,19 +3082,18 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.65.1"
+version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
- "peeking_take_while",
- "prettyplease",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "regex",
  "rustc-hash",
  "shlex",
@@ -3273,6 +3180,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2b_simd"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.4",
+ "constant_time_eq 0.3.0",
+]
+
+[[package]]
 name = "blake2s_simd"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3324,7 +3242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "358358b19add120a5afc3dd1c8e9161d6d06c44dfec2ef8da58b7fe5c369c90d"
 dependencies = [
  "cid",
- "dashmap",
+ "dashmap 5.5.3",
  "multihash",
  "thiserror",
 ]
@@ -3349,8 +3267,8 @@ checksum = "7a8a8ed6fefbeef4a8c7b460e4110e12c5e22a5b7cf32621aae6ad650c4dcf29"
 dependencies = [
  "blst",
  "byte-slice-cast",
- "ff 0.13.0",
- "group 0.13.0",
+ "ff",
+ "group",
  "pairing",
  "rand_core 0.6.4",
  "serde",
@@ -3386,7 +3304,7 @@ dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.86",
+ "proc-macro2",
  "syn 1.0.109",
 ]
 
@@ -3398,8 +3316,8 @@ checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.1.0",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
  "syn_derive",
 ]
@@ -3410,8 +3328,8 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -3421,9 +3339,37 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "bridge-cli"
+version = "0.3.0"
+
+[[package]]
+name = "bridge-service"
+version = "0.3.0"
+
+[[package]]
+name = "bridge-shared"
+version = "0.3.0"
+dependencies = [
+ "async-trait",
+ "dashmap 6.0.1",
+ "delegate",
+ "derive_more",
+ "futures",
+ "futures-time",
+ "futures-timer",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
+ "static_str_ops",
+ "test-log",
+ "thiserror",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3479,7 +3425,7 @@ name = "buildtime-macros"
 version = "0.3.0"
 dependencies = [
  "buildtime-helpers",
- "quote 1.0.36",
+ "quote",
  "syn 2.0.70",
  "tonic-build",
 ]
@@ -3793,12 +3739,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "cfg_block"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18758054972164c3264f7c8386f5fc6da6114cb46b619fd365d4e3b2dc3ae487"
-
-[[package]]
 name = "chrono"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3954,8 +3894,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
  "heck 0.5.0",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -4113,9 +4053,9 @@ version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
- "unicode-xid 0.2.4",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -4337,7 +4277,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio",
- "parking_lot 0.12.3",
+ "parking_lot",
  "signal-hook",
  "signal-hook-mio",
  "winapi 0.3.9",
@@ -4353,7 +4293,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio",
- "parking_lot 0.12.3",
+ "parking_lot",
  "signal-hook",
  "signal-hook-mio",
  "winapi 0.3.9",
@@ -4512,8 +4452,8 @@ checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -4526,8 +4466,8 @@ checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "strsim 0.11.1",
  "syn 2.0.70",
 ]
@@ -4539,7 +4479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core 0.14.4",
- "quote 1.0.36",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4550,7 +4490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
- "quote 1.0.36",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -4564,7 +4504,21 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.10",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -4635,6 +4589,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "delegate"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.70",
+]
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4667,8 +4632,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4678,8 +4643,8 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -4690,8 +4655,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "rustc_version 0.4.0",
  "syn 2.0.70",
 ]
@@ -4887,9 +4852,9 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest 0.10.7",
- "ff 0.13.0",
+ "ff",
  "generic-array",
- "group 0.13.0",
+ "group",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -4920,9 +4885,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -4931,6 +4905,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
  "log",
 ]
 
@@ -4976,6 +4962,12 @@ checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
@@ -4991,7 +4983,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
- "event-listener",
+ "event-listener 5.3.1",
  "pin-project-lite",
 ]
 
@@ -5003,17 +4995,6 @@ checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
-]
-
-[[package]]
-name = "fail"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3c61c59fdc91f5dbc3ea31ee8623122ce80057058be560654c5d410d181a6"
-dependencies = [
- "lazy_static",
- "log",
- "rand 0.7.3",
 ]
 
 [[package]]
@@ -5034,6 +5015,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a88c69768c0a15262df21899142bc6df9b9b823546d4b4b9a7bc2d6c448ec6fd"
 dependencies = [
  "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -5064,24 +5054,31 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "bitvec 1.0.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "ff"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "bitvec 1.0.1",
+ "byteorder",
+ "ff_derive",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "ff_derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f54704be45ed286151c5e11531316eaef5b8f5af7d597b806fdb8af108d84a"
+dependencies = [
+ "addchain",
+ "cfg-if",
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5272,13 +5269,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -5293,6 +5305,18 @@ name = "futures-task"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-time"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6404853a6824881fe5f7d662d147dc4e84ecd2259ba0378f272a71dab600758a"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-io",
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-timer"
@@ -5337,6 +5361,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5351,6 +5384,18 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "gensym"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913dce4c5f06c2ea40fc178c06f777ac89fc6b1383e90c254fafb1abe4ba3c82"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.70",
+ "uuid",
 ]
 
 [[package]]
@@ -5487,22 +5532,11 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.0",
+ "ff",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rand_xorshift",
@@ -5868,7 +5902,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -5967,7 +6001,7 @@ dependencies = [
  "http-body 1.0.0",
  "hyper 1.4.1",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tower",
  "tower-service",
@@ -6099,8 +6133,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -6116,16 +6150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "glob",
- "include_dir_macros",
-]
-
-[[package]]
 name = "include_dir_impl"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6133,19 +6157,9 @@ checksum = "0a0c890c85da4bab7bce4204c707396bbd3c6c8a681716a51c8814cfc2b682df"
 dependencies = [
  "anyhow",
  "proc-macro-hack",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
 ]
 
 [[package]]
@@ -6192,8 +6206,8 @@ dependencies = [
  "clap 4.5.9",
  "crossbeam-channel",
  "crossbeam-utils",
- "dashmap",
- "env_logger",
+ "dashmap 5.5.3",
+ "env_logger 0.10.2",
  "indexmap 2.2.6",
  "is-terminal",
  "itoa",
@@ -6231,10 +6245,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab388864246d58a276e60e7569a833d9cc4cd75c66e5ca77c177dad38e59996"
 dependencies = [
  "ahash 0.7.8",
- "dashmap",
+ "dashmap 5.5.3",
  "hashbrown 0.12.3",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
 ]
 
 [[package]]
@@ -6482,8 +6496,8 @@ checksum = "7895f186d5921065d96e16bd795e5ca89ac8356ec423fafc6e3d7cf8ec11aee4"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-crate 3.1.0",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -6698,9 +6712,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.11.0+8.1.1"
+version = "0.16.0+8.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
+checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -6795,6 +6809,12 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -7046,7 +7066,7 @@ dependencies = [
  "aptos-proptest-helpers",
  "aptos-sdk",
  "aptos-types",
- "async-channel",
+ "async-channel 2.3.1",
  "async-trait",
  "chrono",
  "maptos-execution-util",
@@ -7125,7 +7145,8 @@ dependencies = [
  "aptos-vm-genesis",
  "aptos-vm-logging",
  "aptos-vm-types",
- "async-channel",
+ "aptos-vm-validator",
+ "async-channel 2.3.1",
  "async-trait",
  "bcs 0.1.4",
  "borsh 0.10.3",
@@ -7134,7 +7155,7 @@ dependencies = [
  "clap 4.5.9",
  "derive_more",
  "dirs",
- "fail 0.5.1",
+ "fail",
  "futures",
  "hex",
  "lazy_static",
@@ -7347,7 +7368,7 @@ checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
- "dashmap",
+ "dashmap 5.5.3",
  "skeptic",
  "smallvec",
  "tagptr",
@@ -7397,11 +7418,11 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "heck 0.3.3",
+ "heck 0.4.1",
  "log",
  "move-binary-format",
  "move-bytecode-verifier",
@@ -7414,13 +7435,13 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "backtrace",
  "indexmap 1.9.3",
+ "move-bytecode-spec",
  "move-core-types",
- "once_cell",
  "ref-cast",
  "serde",
  "variant_count",
@@ -7429,12 +7450,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7447,9 +7468,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-bytecode-spec"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+dependencies = [
+ "once_cell",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7461,10 +7492,9 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
- "anyhow",
- "fail 0.4.0",
+ "fail",
  "move-binary-format",
  "move-borrow-graph",
  "move-core-types",
@@ -7476,16 +7506,14 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "clap 4.5.9",
  "crossterm 0.26.1",
  "move-binary-format",
  "move-bytecode-source-map",
- "move-command-line-common",
  "move-disassembler",
- "move-ir-types",
  "regex",
  "tui",
 ]
@@ -7493,60 +7521,44 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
- "bcs 0.1.4",
- "bytes 1.6.0",
  "clap 4.5.9",
  "codespan-reporting",
  "colored",
- "difference",
- "itertools 0.10.5",
  "move-binary-format",
- "move-bytecode-source-map",
- "move-bytecode-utils",
- "move-bytecode-verifier",
  "move-bytecode-viewer",
  "move-command-line-common",
  "move-compiler",
+ "move-compiler-v2",
  "move-core-types",
  "move-coverage",
  "move-disassembler",
  "move-docgen",
  "move-errmapgen",
- "move-ir-types",
  "move-model",
  "move-package",
  "move-prover",
- "move-resource-viewer",
  "move-stdlib",
- "move-symbol-pool",
  "move-unit-test",
  "move-vm-runtime",
  "move-vm-test-utils",
- "move-vm-types",
  "once_cell",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "serde_yaml 0.8.26",
  "tempfile",
- "toml_edit 0.14.4",
- "walkdir",
 ]
 
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "difference",
  "dirs-next",
  "hex",
  "move-core-types",
- "num-bigint 0.4.6",
+ "num-bigint 0.3.3",
  "once_cell",
  "serde",
  "sha2 0.9.9",
@@ -7556,13 +7568,12 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
  "clap 4.5.9",
  "codespan-reporting",
- "difference",
  "hex",
  "move-binary-format",
  "move-borrow-graph",
@@ -7573,34 +7584,31 @@ dependencies = [
  "move-ir-to-bytecode",
  "move-ir-types",
  "move-symbol-pool",
- "num-bigint 0.4.6",
  "once_cell",
  "petgraph 0.5.1",
  "regex",
  "sha3",
  "tempfile",
- "walkdir",
 ]
 
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
  "bcs 0.1.4",
  "clap 4.5.9",
- "codespan",
  "codespan-reporting",
  "ethnum",
  "flexi_logger",
  "im",
- "itertools 0.10.5",
- "lazy_static",
+ "itertools 0.12.1",
  "log",
  "move-binary-format",
  "move-bytecode-source-map",
+ "move-bytecode-verifier",
  "move-command-line-common",
  "move-compiler",
  "move-core-types",
@@ -7611,14 +7619,13 @@ dependencies = [
  "move-symbol-pool",
  "num",
  "once_cell",
- "petgraph 0.6.5",
- "serde",
+ "petgraph 0.5.1",
 ]
 
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -7631,7 +7638,7 @@ dependencies = [
  "once_cell",
  "primitive-types 0.10.1",
  "proptest",
- "proptest-derive 0.3.0",
+ "proptest-derive",
  "rand 0.8.5",
  "ref-cast",
  "serde",
@@ -7643,7 +7650,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7655,7 +7662,6 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-ir-types",
- "once_cell",
  "petgraph 0.5.1",
  "serde",
 ]
@@ -7663,14 +7669,13 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "clap 4.5.9",
  "colored",
  "move-binary-format",
  "move-bytecode-source-map",
- "move-bytecode-verifier",
  "move-command-line-common",
  "move-compiler",
  "move-core-types",
@@ -7681,17 +7686,17 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
+ "clap 4.5.9",
  "codespan",
  "codespan-reporting",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "move-compiler",
  "move-core-types",
  "move-model",
- "num",
  "once_cell",
  "regex",
  "serde",
@@ -7700,11 +7705,9 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
- "bcs 0.1.4",
- "log",
  "move-command-line-common",
  "move-core-types",
  "move-model",
@@ -7714,7 +7717,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7723,17 +7726,14 @@ dependencies = [
  "move-bytecode-source-map",
  "move-bytecode-verifier",
  "move-command-line-common",
- "move-core-types",
  "move-ir-to-bytecode",
- "move-ir-types",
- "move-symbol-pool",
  "serde_json",
 ]
 
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -7745,14 +7745,13 @@ dependencies = [
  "move-ir-to-bytecode-syntax",
  "move-ir-types",
  "move-symbol-pool",
- "ouroboros 0.9.5",
- "thiserror",
+ "ouroboros",
 ]
 
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "hex",
@@ -7765,9 +7764,8 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
- "anyhow",
  "hex",
  "move-command-line-common",
  "move-core-types",
@@ -7779,17 +7777,16 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "codespan",
  "codespan-reporting",
  "internment",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "move-binary-format",
  "move-bytecode-source-map",
- "move-bytecode-verifier",
  "move-command-line-common",
  "move-compiler",
  "move-core-types",
@@ -7801,20 +7798,17 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
- "trace",
 ]
 
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
- "bcs 0.1.4",
  "clap 4.5.9",
  "colored",
- "dirs-next",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "move-abigen",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -7830,13 +7824,12 @@ dependencies = [
  "once_cell",
  "petgraph 0.5.1",
  "regex",
- "reqwest 0.11.27",
  "serde",
  "serde_yaml 0.8.26",
  "sha2 0.9.9",
  "tempfile",
  "termcolor",
- "toml 0.5.11",
+ "toml 0.7.8",
  "walkdir",
  "whoami",
 ]
@@ -7844,53 +7837,41 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
- "async-trait",
  "atty",
  "clap 4.5.9",
- "codespan",
  "codespan-reporting",
- "futures",
- "hex",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "move-abigen",
- "move-binary-format",
  "move-command-line-common",
  "move-compiler",
  "move-compiler-v2",
- "move-core-types",
  "move-docgen",
  "move-errmapgen",
- "move-ir-types",
  "move-model",
  "move-prover-boogie-backend",
  "move-prover-bytecode-pipeline",
  "move-stackless-bytecode",
- "num",
  "once_cell",
- "pretty",
- "rand 0.8.5",
  "serde",
- "serde_json",
  "simplelog",
- "tokio",
- "toml 0.5.11",
+ "toml 0.7.8",
 ]
 
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "async-trait",
  "codespan",
  "codespan-reporting",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "move-binary-format",
  "move-command-line-common",
@@ -7902,10 +7883,9 @@ dependencies = [
  "num",
  "once_cell",
  "pretty",
- "rand 0.8.5",
+ "rand 0.7.3",
  "regex",
  "serde",
- "serde_json",
  "tera",
  "tokio",
 ]
@@ -7913,46 +7893,30 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
- "async-trait",
- "atty",
- "clap 4.5.9",
- "codespan",
  "codespan-reporting",
- "futures",
- "hex",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "move-binary-format",
  "move-core-types",
  "move-model",
  "move-stackless-bytecode",
- "num",
- "once_cell",
- "pretty",
- "rand 0.8.5",
  "serde",
- "serde_json",
- "simplelog",
- "tokio",
- "toml 0.5.11",
 ]
 
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
- "bcs 0.1.4",
  "hex",
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
- "once_cell",
  "serde",
 ]
 
@@ -7972,34 +7936,26 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "abstract-domain-derive",
- "codespan",
  "codespan-reporting",
  "ethnum",
  "im",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "move-binary-format",
- "move-borrow-graph",
- "move-bytecode-verifier",
- "move-command-line-common",
- "move-compiler",
  "move-core-types",
- "move-ir-to-bytecode",
  "move-model",
  "num",
- "once_cell",
  "paste",
  "petgraph 0.5.1",
- "serde",
 ]
 
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "hex",
@@ -8022,7 +7978,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "once_cell",
  "serde",
@@ -8031,17 +7987,14 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
- "anyhow",
- "bcs 0.1.4",
  "better_any",
  "bytes 1.6.0",
  "move-binary-format",
  "move-core-types",
  "move-vm-runtime",
  "move-vm-types",
- "once_cell",
  "sha3",
  "smallvec",
 ]
@@ -8049,29 +8002,26 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "better_any",
- "bytes 1.6.0",
  "clap 4.5.9",
  "codespan-reporting",
  "colored",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "move-binary-format",
  "move-bytecode-utils",
  "move-command-line-common",
  "move-compiler",
  "move-core-types",
  "move-ir-types",
- "move-model",
  "move-resource-viewer",
  "move-stdlib",
  "move-symbol-pool",
  "move-table-extension",
  "move-vm-runtime",
  "move-vm-test-utils",
- "move-vm-types",
  "once_cell",
  "rayon",
  "regex",
@@ -8080,11 +8030,11 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "better_any",
  "bytes 1.6.0",
- "fail 0.4.0",
+ "fail",
  "hashbrown 0.14.5",
  "lazy_static",
  "lru 0.7.8",
@@ -8093,10 +8043,9 @@ dependencies = [
  "move-core-types",
  "move-vm-types",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot",
  "serde",
  "sha3",
- "smallbitvec",
  "tracing",
  "triomphe",
  "typed-arena",
@@ -8105,13 +8054,13 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "anyhow",
  "bytes 1.6.0",
  "move-binary-format",
+ "move-bytecode-utils",
  "move-core-types",
- "move-table-extension",
  "move-vm-types",
  "once_cell",
  "serde",
@@ -8120,14 +8069,13 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d41e9c0c35ce563a3f3b070656abddeb994988e8#d41e9c0c35ce563a3f3b070656abddeb994988e8"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
 dependencies = [
  "bcs 0.1.4",
  "derivative",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "move-binary-format",
  "move-core-types",
- "once_cell",
  "serde",
  "smallbitvec",
  "smallvec",
@@ -8231,7 +8179,7 @@ checksum = "40a3eb6b7c682b65d1f631ec3176829d72ab450b3aacdd3f719bf220822e59ac"
 dependencies = [
  "libc",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "thiserror",
  "widestring",
  "winapi 0.3.9",
@@ -8252,6 +8200,25 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "neptune"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06626c9ac04c894e9a23d061ba1309f28506cdc5fe64156d28a15fb57fc8e438"
+dependencies = [
+ "bellpepper",
+ "bellpepper-core",
+ "blake2s_simd",
+ "blstrs",
+ "byteorder",
+ "ff",
+ "generic-array",
+ "log",
+ "pasta_curves",
+ "serde",
+ "trait-set",
 ]
 
 [[package]]
@@ -8413,8 +8380,8 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -8494,8 +8461,8 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -8567,8 +8534,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -8601,35 +8568,12 @@ dependencies = [
 
 [[package]]
 name = "ouroboros"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeff60e3e37407a80ead3e9458145b456e978c4068cddbfea6afb48572962ca"
-dependencies = [
- "ouroboros_macro 0.9.5",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "ouroboros"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1358bd1558bd2a083fed428ffeda486fbfb323e698cdda7794259d592ca72db"
 dependencies = [
  "aliasable",
- "ouroboros_macro 0.15.6",
-]
-
-[[package]]
-name = "ouroboros_macro"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f2cb802b5bdfdf52f1ffa0b54ce105e4d346e91990dd571f86c91321ad49e2"
-dependencies = [
- "Inflector",
- "proc-macro-error",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 1.0.109",
+ "ouroboros_macro",
 ]
 
 [[package]]
@@ -8640,8 +8584,8 @@ checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -8681,7 +8625,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group 0.13.0",
+ "group",
 ]
 
 [[package]]
@@ -8719,8 +8663,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -8731,8 +8675,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
  "proc-macro-crate 3.1.0",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -8744,37 +8688,12 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.10",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi 0.3.9",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -8819,6 +8738,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pasta_curves"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "hex",
+ "lazy_static",
+ "rand 0.8.5",
+ "serde",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8852,12 +8788,6 @@ dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
 ]
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
@@ -8912,8 +8842,8 @@ checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -9020,8 +8950,8 @@ version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -9031,8 +8961,8 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -9134,7 +9064,7 @@ dependencies = [
  "mime",
  "multer",
  "nix 0.27.1",
- "parking_lot 0.12.3",
+ "parking_lot",
  "percent-encoding",
  "pin-project-lite",
  "poem-derive",
@@ -9165,8 +9095,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ddcf4680d8d867e1e375116203846acb088483fa2070244f90589f458bbb31"
 dependencies = [
  "proc-macro-crate 2.0.0",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -9206,11 +9136,27 @@ dependencies = [
  "indexmap 1.9.3",
  "mime",
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "regex",
  "syn 1.0.109",
  "thiserror",
+]
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9263,7 +9209,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2",
  "syn 2.0.70",
 ]
 
@@ -9343,8 +9289,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
  "version_check",
 ]
@@ -9355,8 +9301,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "version_check",
 ]
 
@@ -9371,15 +9317,6 @@ name = "proc-macro-nested"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -9415,7 +9352,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot 0.12.3",
+ "parking_lot",
  "thiserror",
 ]
 
@@ -9441,23 +9378,12 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b46295382dc76166cb7cf2bb4a97952464e4b7ed5a43e6cd34e1fec3349ddc"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
-]
-
-[[package]]
-name = "proptest-derive"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -9500,8 +9426,8 @@ checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -9595,12 +9521,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "0.6.13"
+name = "quick_cache"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+checksum = "347e1a588d1de074eeb3c00eadff93db4db65aeb62aee852b1efd0949fe65b6c"
 dependencies = [
- "proc-macro2 0.4.30",
+ "ahash 0.8.11",
+ "equivalent",
+ "hashbrown 0.14.5",
+ "parking_lot",
 ]
 
 [[package]]
@@ -9609,7 +9538,7 @@ version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -9767,15 +9696,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -9818,8 +9738,8 @@ version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -10039,9 +9959,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
+checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -10155,6 +10075,20 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.1.4",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -10357,8 +10291,8 @@ version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "serde_derive_internals",
  "syn 2.0.70",
 ]
@@ -10485,7 +10419,7 @@ dependencies = [
  "bcs 0.1.6",
  "bincode",
  "heck 0.3.3",
- "include_dir 0.6.2",
+ "include_dir",
  "maplit",
  "serde",
  "serde-reflection",
@@ -10540,8 +10474,8 @@ version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -10551,8 +10485,8 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -10585,8 +10519,8 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -10636,8 +10570,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b80d3d6b56b64335c0180e5ffde23b3c5e08c14c585b51a15bd0e95393f46703"
 dependencies = [
  "darling 0.20.10",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -10699,7 +10633,8 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.8"
-source = "git+https://github.com/risc0/RustCrypto-hashes?tag=sha2-v0.10.8-risczero.0#244dc3b08788f7a4ccce14c66896ae3b4f24c166"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -10809,8 +10744,8 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab0381d1913eeaf4c7bc4094016c9a8de6c1120663afe32a90ff268ad7f80486"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -10948,9 +10883,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -11025,6 +10970,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "static_str_ops"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eef2389280bc4d03836302f127e5e784c63cd183e24fe35cf73dc7f3b13a47d4"
+dependencies = [
+ "gensym",
+ "lazy_static",
+]
+
+[[package]]
 name = "status-line"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11077,8 +11032,8 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck 0.3.3",
  "proc-macro-error",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -11113,8 +11068,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -11126,8 +11081,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "rustversion",
  "syn 2.0.70",
 ]
@@ -11139,8 +11094,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck 0.5.0",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "rustversion",
  "syn 2.0.70",
 ]
@@ -11235,7 +11190,7 @@ name = "suzuka-full-node"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "async-channel",
+ "async-channel 2.3.1",
  "dot-movement",
  "godfig",
  "m1-da-light-node-client",
@@ -11284,23 +11239,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -11310,8 +11254,8 @@ version = "2.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -11322,8 +11266,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c837dc8852cb7074e46b444afb81783140dab12c58867b49fb3898fbafedf7ea"
 dependencies = [
  "paste",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -11334,8 +11278,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -11406,7 +11350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand",
+ "fastrand 2.1.0",
  "rustix 0.38.34",
  "windows-sys 0.52.0",
 ]
@@ -11440,6 +11384,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93"
+dependencies = [
+ "env_logger 0.11.3",
+ "test-log-macros",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -11487,8 +11453,8 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -11608,10 +11574,10 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.7",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -11632,8 +11598,8 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -11743,6 +11709,18 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
@@ -11764,23 +11742,13 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
-dependencies = [
- "combine",
- "indexmap 1.9.3",
- "itertools 0.10.5",
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.2.6",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -11860,9 +11828,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
 dependencies = [
  "prettyplease",
- "proc-macro2 1.0.86",
+ "proc-macro2",
  "prost-build",
- "quote 1.0.36",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -11950,17 +11918,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
-name = "trace"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad0c048e114d19d1140662762bfdb10682f3bc806d8be18af846600214dd9af"
-dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "tracing"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11978,8 +11935,8 @@ version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -12061,8 +12018,19 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
- "quote 1.0.36",
+ "quote",
  "syn 2.0.70",
+]
+
+[[package]]
+name = "trait-set"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79e2e9c9ab44c6d7c20d5976961b47e8f49ac199154daa514b77cd1ab536625"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -12144,7 +12112,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a615d6c2764852a2e88a4f16e9ce1ea49bb776b5872956309e170d63a042a34f"
 dependencies = [
- "quote 1.0.36",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -12311,12 +12279,6 @@ checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
@@ -12424,6 +12386,7 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
+ "getrandom 0.2.15",
  "serde",
 ]
 
@@ -12439,7 +12402,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae2faf80ac463422992abf4de234731279c058aaf33171ca70277c98406b124"
 dependencies = [
- "quote 1.0.36",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -12469,6 +12432,12 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"
@@ -12526,8 +12495,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
  "wasm-bindgen-shared",
 ]
@@ -12550,7 +12519,7 @@ version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
- "quote 1.0.36",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -12560,8 +12529,8 @@ version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -13022,8 +12991,8 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -13042,8 +13011,8 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.70",
 ]
 
@@ -13074,8 +13043,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "ed25519-dalek"
-version = "2.0.0"
-source = "git+https://github.com/risc0/curve25519-dalek?tag=curve25519-4.1.0-risczero.1#42c4faf7dc3f640a7e3f7e4cbf43e7d5d6d46b67"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ members = [
     "networks/suzuka/*",
     "protocol-units/settlement/mcr/setup",
     "protocol-units/settlement/mcr/anvil",
+    "protocol-units/bridge/shared",
+    "protocol-units/bridge/cli",
+    "protocol-units/bridge/service",
 ]
 
 [workspace.package]
@@ -90,35 +93,36 @@ serde_yaml = "0.9.34"
 ## Aptos dependencies
 ### We use a forked version so that we can override dependency versions. This is required
 ### to be avoid dependency conflicts with other Sovereign Labs crates.
-aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8", features = [
+aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c", features = [
     "cloneable-private-keys",
 ] }
-aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
-aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d41e9c0c35ce563a3f3b070656abddeb994988e8" }
+aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
 ethereum-types = "0.14.1"
 ethers = "=2.0.10"
@@ -159,8 +163,8 @@ alloy = { git = "https://github.com/alloy-rs/alloy.git", package = "alloy", rev 
     "signers",
     "signer-yubihsm",
     "pubsub",
-    "providers"
-]}
+    "providers",
+] }
 alloy-contract = { git = "https://github.com/alloy-rs/alloy.git", rev = "83343b172585fe4e040fb104b4d1421f58cbf9a2" }
 alloy-network = { git = "https://github.com/alloy-rs/alloy.git", rev = "83343b172585fe4e040fb104b4d1421f58cbf9a2" }
 alloy-primitives = { version = "0.7.2", default-features = false }
@@ -219,7 +223,7 @@ rayon = "1.10.0"
 reqwest = "0.12.4"
 risc0-build = "0.20"
 risc0-zkvm = { version = "0.21", features = ["std", "getrandom"] }
-rocksdb = { version = "0.21.0", features = [
+rocksdb = { version = "0.22.0", features = [
     "snappy",
     "lz4",
     "zstd",
@@ -248,7 +252,7 @@ url = "2.2.2"
 x25519-dalek = "1.0.1"
 zstd-sys = "2.0.9"
 inotify = "0.10.2"
-rustix = "0.38.34" 
+rustix = "0.38.34"
 
 
 [workspace.lints.rust]
@@ -273,6 +277,4 @@ opt-level = 3
 [patch.crates-io]
 merlin = { git = "https://github.com/aptos-labs/merlin" }
 x25519-dalek = { git = "https://github.com/aptos-labs/x25519-dalek", branch = "zeroize_v1" }
-sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
-ed25519-dalek = { git = "https://github.com/risc0/curve25519-dalek", tag = "curve25519-4.1.0-risczero.1" }
 zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git", rev = "1779b385b42b08f958b767a37878dfa6a0b4f6a4" }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ classical semantic versioning.
 ## Prerequisites
 ### Prerequisites - Just command
 `just` is a handy way to save and run project-specific commands. Please install it
-[following just install instructioins](https://github.com/casey/just?tab=readme-ov-file#installation). `macOS` and `debian` based systems instructions below.
+[following just install instructions](https://github.com/casey/just?tab=readme-ov-file#installation). `macOS` and `debian` based systems instructions below.
 
 ### Just command - macOS
 ```bash 

--- a/docs/movement-node/run/manual/README.md
+++ b/docs/movement-node/run/manual/README.md
@@ -6,7 +6,7 @@ We recommend that you run a movement node using containers to leverage the porta
 1. Ubuntu 22.04 amd64
 2. [Docker](https://docs.docker.com/engine/install/ubuntu/)
 3. [Docker compose](https://docs.docker.com/compose/install/linux/)
-4. Make sure you are logged in as the user that wants to run the node
+4. Make sure you are logged in as the user who wants to run the node
 
 ## Run the movement node as an RPC provider
 

--- a/flake.lock
+++ b/flake.lock
@@ -53,24 +53,6 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "foundry": {
       "inputs": {
         "flake-utils": "flake-utils_2",
@@ -107,17 +89,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1715266358,
-        "narHash": "sha256-doPgfj+7FFe9rfzWo1siAV2mVCasW+Bh8I1cToAXEE4=",
+        "lastModified": 1719908484,
+        "narHash": "sha256-ol3YPu/4U4tOLsEG1NOo+ICON4BnKF16zB6AfbZE9xA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f1010e0469db743d14519a1efd37e23f8513d714",
+        "rev": "ae0b2bf3fab958fc7d83a7893ee57175fd2609d3",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f1010e0469db743d14519a1efd37e23f8513d714",
+        "rev": "ae0b2bf3fab958fc7d83a7893ee57175fd2609d3",
         "type": "github"
       }
     },
@@ -148,39 +130,24 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1712024007,
-        "narHash": "sha256-52cf+mHZJbSaDFdsBj6vN1hH52AXsMgEpS/ajzc9yQE=",
+        "lastModified": 1719886738,
+        "narHash": "sha256-6eaaoJUkr4g9J/rMC4jhj3Gv8Sa62rvlpjFe3xZaSjM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d45d957dc3c48792af7ce58eec5d84407655e8fa",
+        "rev": "db12d0c6ef002f16998723b5dd619fa7b8997086",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "rev": "db12d0c6ef002f16998723b5dd619fa7b8997086",
         "type": "github"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/f1010e0469db743d14519a1efd37e23f8513d714";
-    rust-overlay.url = "github:oxalica/rust-overlay";
+    nixpkgs.url = "github:NixOS/nixpkgs/ae0b2bf3fab958fc7d83a7893ee57175fd2609d3";
+    rust-overlay.url = "github:oxalica/rust-overlay/db12d0c6ef002f16998723b5dd619fa7b8997086";
     flake-utils.url = "github:numtide/flake-utils";
     foundry.url = "github:shazow/foundry.nix/monthly"; 
     crane.url = "github:ipetkov/crane";

--- a/networks/README.md
+++ b/networks/README.md
@@ -2,4 +2,4 @@
 This directory contains network runner entry points for the Movement Network. These are the entry points for running the Movement Network.
 
 ## `suzuka`
-Suzuka is the second network released in this repository after Monza which has since be removed whilst it was not being maintained. Suzuka features M1 data availability, Movement Aptos (Maptos) execution, and ETH settlement.
+Suzuka is the second network released in this repository after Monza which has since been removed whilst it was not being maintained. Suzuka features M1 data availability, Movement Aptos (Maptos) execution, and ETH settlement.

--- a/networks/suzuka/suzuka-client/.aptos/config.yaml
+++ b/networks/suzuka/suzuka-client/.aptos/config.yaml
@@ -1,8 +1,0 @@
----
-profiles:
-  default:
-    private_key: "0xfbc0596f14bd008b20269a52e22311842453ccd3dd64575bc656dc8e755244b7"
-    public_key: "0xbe11803a40d33723d0a294cb657dd2477af4c31cae019f1e4bd783084033d1f6"
-    account: 00da3c48fe5d426966ae33945eff05cdbc5fb9a986c92d26a9d7665d99efdeff
-    rest_url: "http://localhost:30731/"
-    faucet_url: "http://localhost:30732/"

--- a/networks/suzuka/suzuka-client/src/tests/mod.rs
+++ b/networks/suzuka/suzuka-client/src/tests/mod.rs
@@ -225,21 +225,18 @@ async fn test_example_interaction() -> Result<(), anyhow::Error> {
 
 	// second send should fail...
 	println!("Second send should fail");
-	let txn_hash = rest_client
+	match rest_client
 		.submit(&signed_txn)
-		.await
-		.context("Failed to submit transfer transaction with improperly formed sequencer number")?
-		.into_inner();
-	match rest_client.wait_for_transaction(&txn_hash).await {
+		.await {
 		Ok(transaction) => {
 			println!("Transaction succeeded unexpectedly {:?}", transaction.into_inner());
 			panic!("Expected transaction to fail");
-		},
+		},	
 		Err(e) => {
 			println!("Transaction failed expectedly: {:?}", e);
 		}
 	}
-
+	
 	// ...but not crash the node.
 	// So, this should work.
 	let txn_hash = coin_client

--- a/networks/suzuka/suzuka-client/src/tests/mod.rs
+++ b/networks/suzuka/suzuka-client/src/tests/mod.rs
@@ -1,18 +1,18 @@
 use crate::load_soak_testing::{execute_test, init_test, ExecutionConfig, Scenario, TestKind};
 use crate::{
-	coin_client::CoinClient,
+	coin_client::{CoinClient, /*TransferOptions*/},
 	rest_client::{
 		aptos_api_types::{TransactionOnChainData, ViewFunction},
 		Client, FaucetClient,
 	},
 	types::{chain_id::ChainId, LocalAccount},
+	transaction_builder::TransactionBuilder,
 };
 use anyhow::Context;
 use aptos_sdk::crypto::ed25519::Ed25519PrivateKey;
 use aptos_sdk::crypto::ValidCryptoMaterialStringExt;
 use aptos_sdk::move_types::identifier::Identifier;
 use aptos_sdk::move_types::language_storage::ModuleId;
-use aptos_sdk::transaction_builder::TransactionBuilder;
 use aptos_sdk::types::account_address::AccountAddress;
 use aptos_sdk::types::transaction::authenticator::AuthenticationKey;
 use aptos_sdk::types::transaction::EntryFunction;
@@ -179,6 +179,73 @@ async fn test_example_interaction() -> Result<(), anyhow::Error> {
 			.await
 			.context("Failed to get Bob's account balance the second time")?
 	);
+
+	// malformed sequence number
+	/*let options = TransferOptions::default();
+	let chain_id = rest_client
+            .get_index()
+            .await
+            .context("Failed to get chain ID")?
+            .inner()
+            .chain_id;
+	let transaction_builder = TransactionBuilder::new(
+		TransactionPayload::EntryFunction(EntryFunction::new(
+			ModuleId::new(AccountAddress::ONE, Identifier::new("coin").unwrap()),
+			Identifier::new("transfer").unwrap(),
+			vec![TypeTag::from_str(options.coin_type).unwrap()],
+			vec![
+				bcs::to_bytes(&bob.address()).unwrap(),
+				bcs::to_bytes(&1_000).unwrap(),
+			],
+		)),
+		SystemTime::now()
+			.duration_since(UNIX_EPOCH)
+			.unwrap()
+			.as_secs()
+			+ options.timeout_secs,
+		ChainId::new(chain_id),
+	)
+	.sender(alice.address())
+	.sequence_number(alice.sequence_number())
+	.max_gas_amount(options.max_gas_amount)
+	.gas_unit_price(options.gas_unit_price);
+	let signed_txn = alice.sign_with_transaction_builder(transaction_builder);
+
+	// first send should work
+	let txn_hash = rest_client
+		.submit(&signed_txn)
+		.await
+		.context("Failed to submit transfer transaction")?
+		.into_inner();
+	rest_client.wait_for_transaction(&txn_hash).await.context(
+		"Failed when waiting for the transfer transaction with a malformed sequence number",
+	)?;
+
+	// second send should fail...
+	let txn_hash = rest_client
+		.submit(&signed_txn)
+		.await
+		.context("Failed to submit transfer transaction")?
+		.into_inner();
+	match rest_client.wait_for_transaction(&txn_hash).await {
+		Ok(_) => panic!("Expected transaction to fail"),
+		Err(e) => {
+			println!("Expected transaction failed: {:?}", e);
+		}
+	}
+
+	// ...but not crash the node.
+	// So, this should work.
+	let txn_hash = coin_client
+		.transfer(&mut alice, bob.address(), 1_000, None)
+		.await
+		.context("Failed to submit transaction to transfer coins")?; // <:!:section_5
+															 // :!:>section_6
+	rest_client
+		.wait_for_transaction(&txn_hash)
+		.await
+		.context("Failed when waiting for the transfer transaction")?;*/
+
 
 	Ok(())
 }

--- a/networks/suzuka/suzuka-client/src/tests/mod.rs
+++ b/networks/suzuka/suzuka-client/src/tests/mod.rs
@@ -1,6 +1,6 @@
 use crate::load_soak_testing::{execute_test, init_test, ExecutionConfig, Scenario, TestKind};
 use crate::{
-	coin_client::{CoinClient, /*TransferOptions*/},
+	coin_client::{CoinClient, TransferOptions},
 	rest_client::{
 		aptos_api_types::{TransactionOnChainData, ViewFunction},
 		Client, FaucetClient,
@@ -181,7 +181,7 @@ async fn test_example_interaction() -> Result<(), anyhow::Error> {
 	);
 
 	// malformed sequence number
-	/*let options = TransferOptions::default();
+	let options = TransferOptions::default();
 	let chain_id = rest_client
             .get_index()
             .await
@@ -244,7 +244,7 @@ async fn test_example_interaction() -> Result<(), anyhow::Error> {
 	rest_client
 		.wait_for_transaction(&txn_hash)
 		.await
-		.context("Failed when waiting for the transfer transaction")?;*/
+		.context("Failed when waiting for the transfer transaction")?;
 
 
 	Ok(())

--- a/networks/suzuka/suzuka-client/src/tests/mod.rs
+++ b/networks/suzuka/suzuka-client/src/tests/mod.rs
@@ -228,9 +228,12 @@ async fn test_example_interaction() -> Result<(), anyhow::Error> {
 		.context("Failed to submit transfer transaction")?
 		.into_inner();
 	match rest_client.wait_for_transaction(&txn_hash).await {
-		Ok(_) => panic!("Expected transaction to fail"),
+		Ok(transaction) => {
+			println!("Transaction succeeded unexpectedly {:?}", transaction.into_inner());
+			panic!("Expected transaction to fail");
+		},
 		Err(e) => {
-			println!("Expected transaction failed: {:?}", e);
+			println!("Transaction failed expectedly: {:?}", e);
 		}
 	}
 

--- a/networks/suzuka/suzuka-client/src/tests/mod.rs
+++ b/networks/suzuka/suzuka-client/src/tests/mod.rs
@@ -181,6 +181,7 @@ async fn test_example_interaction() -> Result<(), anyhow::Error> {
 	);
 
 	// malformed sequence number
+	println!("\n=== Malformed Sequence Number ===");
 	let options = TransferOptions::default();
 	let chain_id = rest_client
             .get_index()
@@ -212,20 +213,22 @@ async fn test_example_interaction() -> Result<(), anyhow::Error> {
 	let signed_txn = alice.sign_with_transaction_builder(transaction_builder);
 
 	// first send should work
+	println!("First send should work");
 	let txn_hash = rest_client
 		.submit(&signed_txn)
 		.await
-		.context("Failed to submit transfer transaction")?
+		.context("Failed to submit transfer transaction with properly formed sequence number")?
 		.into_inner();
 	rest_client.wait_for_transaction(&txn_hash).await.context(
 		"Failed when waiting for the transfer transaction with a malformed sequence number",
 	)?;
 
 	// second send should fail...
+	println!("Second send should fail");
 	let txn_hash = rest_client
 		.submit(&signed_txn)
 		.await
-		.context("Failed to submit transfer transaction")?
+		.context("Failed to submit transfer transaction with improperly formed sequencer number")?
 		.into_inner();
 	match rest_client.wait_for_transaction(&txn_hash).await {
 		Ok(transaction) => {

--- a/networks/suzuka/suzuka-client/src/tests/mod.rs
+++ b/networks/suzuka/suzuka-client/src/tests/mod.rs
@@ -195,7 +195,7 @@ async fn test_example_interaction() -> Result<(), anyhow::Error> {
 			vec![TypeTag::from_str(options.coin_type).unwrap()],
 			vec![
 				bcs::to_bytes(&bob.address()).unwrap(),
-				bcs::to_bytes(&1_000).unwrap(),
+				bcs::to_bytes(&(1_000 as u64)).unwrap(),
 			],
 		)),
 		SystemTime::now()

--- a/networks/suzuka/suzuka-full-node/src/partial.rs
+++ b/networks/suzuka/suzuka-full-node/src/partial.rs
@@ -22,7 +22,7 @@ use tokio::sync::RwLock;
 use tokio_stream::StreamExt;
 use tracing::{debug, info, error};
 
-use std::future::{self, Future};
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 pub struct SuzukaPartialNode<T> {
@@ -250,7 +250,7 @@ where
 		}
 	}
 
-	Ok(future::pending().await)
+	Ok(())
 }
 
 impl<T> SuzukaFullNode for SuzukaPartialNode<T>

--- a/protocol-units/bridge/cli/Cargo.toml
+++ b/protocol-units/bridge/cli/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bridge-cli"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/protocol-units/bridge/cli/src/main.rs
+++ b/protocol-units/bridge/cli/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+	println!("Hello, world!");
+}

--- a/protocol-units/bridge/service/Cargo.toml
+++ b/protocol-units/bridge/service/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bridge-service"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/protocol-units/bridge/service/src/main.rs
+++ b/protocol-units/bridge/service/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+	println!("Hello, world!");
+}

--- a/protocol-units/bridge/shared/Cargo.toml
+++ b/protocol-units/bridge/shared/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "bridge-shared"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait = "0.1.80"
+delegate = "0.12.0"
+derive_more = { workspace = true, features = ["deref", "deref_mut"] } 
+futures.workspace = true
+futures-timer = "3.0.3"
+thiserror.workspace = true
+tracing.workspace = true
+rand.workspace = true
+rand_chacha = "0.2.2"
+futures-time = "3.0.0"
+
+[dev-dependencies]
+dashmap = "6.0.1"
+static_str_ops = "0.1.2"
+test-log = { version = "0.2.16", features = ["trace"] }
+tokio.workspace = true
+
+[lints]
+workspace = true

--- a/protocol-units/bridge/shared/src/blockchain_service.rs
+++ b/protocol-units/bridge/shared/src/blockchain_service.rs
@@ -1,0 +1,179 @@
+use std::{
+	pin::Pin,
+	task::{Context, Poll},
+};
+
+use futures::{Stream, StreamExt};
+
+use crate::{
+	bridge_contracts::{BridgeContractCounterparty, BridgeContractInitiator},
+	bridge_monitoring::{
+		BridgeContractCounterpartyEvent, BridgeContractCounterpartyMonitoring,
+		BridgeContractInitiatorEvent, BridgeContractInitiatorMonitoring,
+	},
+	types::{BridgeAddressType, BridgeHashType},
+};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ContractEvent<A, H> {
+	InitiatorEvent(BridgeContractInitiatorEvent<A, H>),
+	CounterpartyEvent(BridgeContractCounterpartyEvent<H>),
+}
+
+pub trait BlockchainService:
+	Stream<Item = ContractEvent<Self::Address, Self::Hash>> + Unpin
+{
+	type Address: BridgeAddressType;
+	type Hash: BridgeHashType;
+
+	type InitiatorContract: BridgeContractInitiator<Address = Self::Address, Hash = Self::Hash>;
+	type InitiatorMonitoring: BridgeContractInitiatorMonitoring<Address = Self::Address, Hash = Self::Hash>
+		+ Unpin;
+
+	type CounterpartyContract: BridgeContractCounterparty<
+		Address = Self::Address,
+		Hash = Self::Hash,
+	>;
+	type CounterpartyMonitoring: BridgeContractCounterpartyMonitoring<Address = Self::Address, Hash = Self::Hash>
+		+ Unpin;
+
+	fn initiator_contract(&self) -> &Self::InitiatorContract;
+	fn initiator_monitoring(&mut self) -> &mut Self::InitiatorMonitoring;
+	fn counterparty_contract(&self) -> &Self::CounterpartyContract;
+	fn counterparty_monitoring(&mut self) -> &mut Self::CounterpartyMonitoring;
+
+	fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		match (
+			self.initiator_monitoring().poll_next_unpin(cx),
+			self.counterparty_monitoring().poll_next_unpin(cx),
+		) {
+			(Poll::Ready(Some(event)), _) => {
+				Poll::Ready(Some(ContractEvent::InitiatorEvent(event)))
+			}
+			(_, Poll::Ready(Some(event))) => {
+				Poll::Ready(Some(ContractEvent::CounterpartyEvent(event)))
+			}
+			_ => Poll::Pending,
+		}
+	}
+}
+
+// Practical implementation
+
+pub struct AbstractBlockchainService<
+	InitiatorContract,
+	InitiatorContractMonitoring,
+	CounterpartyContract,
+	CounterpartyContractMonitoring,
+	Address,
+	Hash,
+> {
+	pub initiator_contract: InitiatorContract,
+	pub initiator_monitoring: InitiatorContractMonitoring,
+	pub counterparty_contract: CounterpartyContract,
+	pub counterparty_monitoring: CounterpartyContractMonitoring,
+	pub _phantom: std::marker::PhantomData<(Address, Hash)>,
+}
+
+impl<
+		InitiatorContract,
+		InitiatorContractMonitoring,
+		CounterpartyContract,
+		CounterpartyContractMonitoring,
+		Address,
+		Hash,
+	> BlockchainService
+	for AbstractBlockchainService<
+		InitiatorContract,
+		InitiatorContractMonitoring,
+		CounterpartyContract,
+		CounterpartyContractMonitoring,
+		Address,
+		Hash,
+	> where
+	InitiatorContract: BridgeContractInitiator<Address = Address, Hash = Hash>,
+	CounterpartyContract: BridgeContractCounterparty<Address = Address, Hash = Hash>,
+	InitiatorContractMonitoring: BridgeContractInitiatorMonitoring<Address = Address, Hash = Hash>,
+	CounterpartyContractMonitoring:
+		BridgeContractCounterpartyMonitoring<Address = Address, Hash = Hash>,
+	Address: BridgeAddressType,
+	Hash: BridgeHashType,
+{
+	type Address = Address;
+	type Hash = Hash;
+
+	type InitiatorContract = InitiatorContract;
+	type CounterpartyContract = CounterpartyContract;
+	type InitiatorMonitoring = InitiatorContractMonitoring;
+	type CounterpartyMonitoring = CounterpartyContractMonitoring;
+
+	fn initiator_contract(&self) -> &Self::InitiatorContract {
+		&self.initiator_contract
+	}
+
+	fn counterparty_contract(&self) -> &Self::CounterpartyContract {
+		&self.counterparty_contract
+	}
+
+	fn initiator_monitoring(&mut self) -> &mut Self::InitiatorMonitoring {
+		&mut self.initiator_monitoring
+	}
+
+	fn counterparty_monitoring(&mut self) -> &mut Self::CounterpartyMonitoring {
+		&mut self.counterparty_monitoring
+	}
+}
+
+impl<
+		InitiatorContract,
+		InitiatorContractMonitoring,
+		CounterpartyContract,
+		CounterpartyContractMonitoring,
+		Address,
+		Hash,
+	> Stream
+	for AbstractBlockchainService<
+		InitiatorContract,
+		InitiatorContractMonitoring,
+		CounterpartyContract,
+		CounterpartyContractMonitoring,
+		Address,
+		Hash,
+	> where
+	InitiatorContract: BridgeContractInitiator<Address = Address, Hash = Hash>,
+	CounterpartyContract: BridgeContractCounterparty<Address = Address, Hash = Hash>,
+	InitiatorContractMonitoring: BridgeContractInitiatorMonitoring<Address = Address, Hash = Hash>,
+	CounterpartyContractMonitoring:
+		BridgeContractCounterpartyMonitoring<Address = Address, Hash = Hash>,
+	Address: BridgeAddressType,
+	Hash: BridgeHashType,
+{
+	type Item = ContractEvent<Address, Hash>;
+
+	fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+		let this = self.get_mut();
+		this.poll_next_event(cx)
+	}
+}
+
+impl<
+		InitiatorContract,
+		InitiatorContractMonitoring,
+		CounterpartyContract,
+		CounterpartyContractMonitoring,
+		Address,
+		Hash,
+	> std::fmt::Debug
+	for AbstractBlockchainService<
+		InitiatorContract,
+		InitiatorContractMonitoring,
+		CounterpartyContract,
+		CounterpartyContractMonitoring,
+		Address,
+		Hash,
+	>
+{
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct(stringify!("AbstractBlockchainService")).finish()
+	}
+}

--- a/protocol-units/bridge/shared/src/bridge_contracts.rs
+++ b/protocol-units/bridge/shared/src/bridge_contracts.rs
@@ -1,0 +1,105 @@
+use thiserror::Error;
+
+use crate::types::{
+	Amount, BridgeAddressType, BridgeHashType, BridgeTransferDetails, BridgeTransferId, HashLock,
+	HashLockPreImage, InitiatorAddress, RecipientAddress, TimeLock,
+};
+
+#[derive(Error, Debug, Clone)]
+pub enum BridgeContractInitiatorError {
+	#[error("Failed to initiate bridge transfer")]
+	InitiateTransferError,
+	#[error("Failed to complete bridge transfer")]
+	CompleteTransferError,
+	#[error("Generic error: {0}")]
+	GenericError(String),
+}
+
+impl BridgeContractInitiatorError {
+	pub fn generic<E: std::error::Error>(e: E) -> Self {
+		Self::GenericError(e.to_string())
+	}
+}
+
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+pub enum BridgeContractCounterpartyError {
+	#[error("Failed to lock bridge transfer assets")]
+	LockTransferAssetsError,
+	#[error("Failed to complete bridge transfer")]
+	CompleteTransferError,
+	#[error("Failed to abort bridge transfer")]
+	AbortTransferError,
+	#[error("Generic error: {0}")]
+	GenericError(String),
+}
+
+impl BridgeContractCounterpartyError {
+	pub fn generic<E: std::error::Error>(e: E) -> Self {
+		Self::GenericError(e.to_string())
+	}
+}
+
+pub type BridgeContractInitiatorResult<T> = Result<T, BridgeContractInitiatorError>;
+pub type BridgeContractCounterpartyResult<T> = Result<T, BridgeContractCounterpartyError>;
+
+#[async_trait::async_trait]
+pub trait BridgeContractInitiator: Clone + Unpin + Send + Sync {
+	type Address: BridgeAddressType;
+	type Hash: BridgeHashType;
+
+	async fn initiate_bridge_transfer(
+		&mut self,
+		initiator_address: InitiatorAddress<Self::Address>,
+		recipient_address: RecipientAddress,
+		hash_lock: HashLock<Self::Hash>,
+		time_lock: TimeLock,
+		amount: Amount,
+	) -> BridgeContractInitiatorResult<()>;
+
+	async fn complete_bridge_transfer(
+		&mut self,
+		bridge_transfer_id: BridgeTransferId<Self::Hash>,
+		secret: HashLockPreImage,
+	) -> BridgeContractInitiatorResult<()>;
+
+	async fn refund_bridge_transfer(
+		&mut self,
+		bridge_transfer_id: BridgeTransferId<Self::Hash>,
+	) -> BridgeContractInitiatorResult<()>;
+
+	async fn get_bridge_transfer_details(
+		&mut self,
+		bridge_transfer_id: BridgeTransferId<Self::Hash>,
+	) -> BridgeContractInitiatorResult<Option<BridgeTransferDetails<Self::Hash, Self::Address>>>;
+}
+
+#[async_trait::async_trait]
+pub trait BridgeContractCounterparty: Clone + Unpin + Send + Sync {
+	type Address: BridgeAddressType;
+	type Hash: BridgeHashType;
+
+	async fn lock_bridge_transfer_assets(
+		&mut self,
+		bridge_transfer_id: BridgeTransferId<Self::Hash>,
+		hash_lock: HashLock<Self::Hash>,
+		time_lock: TimeLock,
+		recipient: RecipientAddress,
+		amount: Amount,
+	) -> BridgeContractCounterpartyResult<()>;
+
+	async fn complete_bridge_transfer(
+		&mut self,
+		bridge_transfer_id: BridgeTransferId<Self::Hash>,
+		secret: HashLockPreImage,
+	) -> BridgeContractCounterpartyResult<()>;
+
+	async fn abort_bridge_transfer(
+		&mut self,
+		bridge_transfer_id: BridgeTransferId<Self::Hash>,
+	) -> BridgeContractCounterpartyResult<()>;
+
+	async fn get_bridge_transfer_details(
+		&mut self,
+		bridge_transfer_id: BridgeTransferId<Self::Hash>,
+	) -> BridgeContractCounterpartyResult<Option<BridgeTransferDetails<Self::Hash, Self::Address>>>;
+}

--- a/protocol-units/bridge/shared/src/bridge_monitoring.rs
+++ b/protocol-units/bridge/shared/src/bridge_monitoring.rs
@@ -1,0 +1,39 @@
+use futures::Stream;
+
+use crate::types::{BridgeTransferDetails, BridgeTransferId, CompletedDetails, LockDetails};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum BridgeContractInitiatorEvent<A, H> {
+	Initiated(BridgeTransferDetails<A, H>),
+	Completed(BridgeTransferId<H>),
+	Refunded(BridgeTransferId<H>),
+}
+
+impl<A, H> BridgeContractInitiatorEvent<A, H> {
+	pub fn bridge_transfer_id(&self) -> &BridgeTransferId<H> {
+		match self {
+			Self::Initiated(details) => &details.bridge_transfer_id,
+			Self::Completed(id) | Self::Refunded(id) => id,
+		}
+	}
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum BridgeContractCounterpartyEvent<H> {
+	Locked(LockDetails<H>),
+	Completed(CompletedDetails<H>),
+}
+
+pub trait BridgeContractInitiatorMonitoring:
+	Stream<Item = BridgeContractInitiatorEvent<Self::Address, Self::Hash>> + Unpin
+{
+	type Address;
+	type Hash;
+}
+
+pub trait BridgeContractCounterpartyMonitoring:
+	Stream<Item = BridgeContractCounterpartyEvent<Self::Hash>> + Unpin
+{
+	type Address;
+	type Hash;
+}

--- a/protocol-units/bridge/shared/src/bridge_service.rs
+++ b/protocol-units/bridge/shared/src/bridge_service.rs
@@ -1,0 +1,326 @@
+use futures::{Stream, StreamExt};
+use std::task::{Context, Poll};
+use std::{convert::From, pin::Pin};
+use tracing::{trace, warn};
+
+use crate::{
+	blockchain_service::{BlockchainService, ContractEvent},
+	bridge_monitoring::{BridgeContractCounterpartyEvent, BridgeContractInitiatorEvent},
+	bridge_service::{
+		active_swap::ActiveSwapEvent,
+		events::{CEvent, CWarn, IEvent, IWarn},
+	},
+	types::BridgeTransferId,
+};
+
+pub mod active_swap;
+pub mod events;
+
+use self::{
+	active_swap::{ActiveSwapConfig, ActiveSwapMap},
+	events::Event,
+};
+
+pub struct BridgeServiceConfig {
+	pub active_swap: ActiveSwapConfig,
+}
+
+pub struct BridgeService<B1, B2>
+where
+	B1: BlockchainService,
+	B2: BlockchainService,
+{
+	pub blockchain_1: B1,
+	pub blockchain_2: B2,
+
+	pub active_swaps_b1_to_b2: ActiveSwapMap<B1, B2>,
+	pub active_swaps_b2_to_b1: ActiveSwapMap<B2, B1>,
+}
+
+impl<B1, B2> BridgeService<B1, B2>
+where
+	B1: BlockchainService + 'static,
+	B2: BlockchainService + 'static,
+{
+	pub fn new(blockchain_1: B1, blockchain_2: B2, config: BridgeServiceConfig) -> Self {
+		Self {
+			active_swaps_b1_to_b2: ActiveSwapMap::build(
+				blockchain_1.initiator_contract().clone(),
+				blockchain_2.counterparty_contract().clone(),
+				config.active_swap.clone(),
+			),
+			active_swaps_b2_to_b1: ActiveSwapMap::build(
+				blockchain_2.initiator_contract().clone(),
+				blockchain_1.counterparty_contract().clone(),
+				config.active_swap.clone(),
+			),
+			blockchain_1,
+			blockchain_2,
+		}
+	}
+}
+
+fn handle_initiator_event<BFrom, BTo>(
+	initiator_event: BridgeContractInitiatorEvent<BFrom::Address, BFrom::Hash>,
+	active_swaps: &mut ActiveSwapMap<BFrom, BTo>,
+) -> Option<IEvent<BFrom::Address, BFrom::Hash>>
+where
+	BFrom: BlockchainService + 'static,
+	BTo: BlockchainService + 'static,
+	BTo::Hash: From<BFrom::Hash>,
+{
+	match initiator_event {
+		BridgeContractInitiatorEvent::Initiated(ref details) => {
+			if active_swaps.already_executing(&details.bridge_transfer_id) {
+				warn!("BridgeService: Bridge transfer {:?} already present, monitoring should only return event once", details.bridge_transfer_id);
+				return Some(IEvent::Warn(IWarn::AlreadyPresent(details.clone())));
+			}
+			active_swaps.start_bridge_transfer(details.clone());
+			Some(IEvent::ContractEvent(initiator_event))
+		}
+		BridgeContractInitiatorEvent::Completed(_) => Some(IEvent::ContractEvent(initiator_event)),
+		BridgeContractInitiatorEvent::Refunded(_) => todo!(),
+	}
+}
+
+fn handle_counterparty_event<BFrom, BTo>(
+	event: BridgeContractCounterpartyEvent<BTo::Hash>,
+	active_swaps: &mut ActiveSwapMap<BFrom, BTo>,
+) -> Option<CEvent<BTo::Hash>>
+where
+	BFrom: BlockchainService + 'static,
+	BTo: BlockchainService + 'static,
+	BFrom::Hash: From<BTo::Hash>,
+{
+	use BridgeContractCounterpartyEvent::*;
+	match event {
+		Locked(ref _details) => Some(CEvent::ContractEvent(event)),
+		Completed(ref details) => match active_swaps.complete_bridge_transfer(details.clone()) {
+			Ok(_) => {
+				trace!("BridgeService: Bridge transfer completed successfully");
+				Some(CEvent::ContractEvent(event))
+			}
+			Err(error) => {
+				warn!("BridgeService: Error completing bridge transfer: {:?}", error);
+				match error {
+					active_swap::ActiveSwapMapError::NonExistingSwap => {
+						Some(CEvent::Warn(CWarn::CannotCompleteUnexistingSwap(details.clone())))
+					}
+				}
+			}
+		},
+	}
+}
+
+impl<B1, B2> Stream for BridgeService<B1, B2>
+where
+	B1: BlockchainService + 'static,
+	B2: BlockchainService + 'static,
+
+	B1::Hash: From<B2::Hash>,
+	B2::Hash: From<B1::Hash>,
+{
+	type Item = Event<B1, B2>;
+
+	fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		let this = self.get_mut();
+
+		// Poll the active swaps in both directions and return the appropriate events
+		{
+			use HandleActiveSwapEvent::*;
+
+			let active_swap_event = this.active_swaps_b1_to_b2.poll_next_unpin(cx);
+			if let Some(value) = handle_active_swap_event::<B1, B2>(active_swap_event) {
+				match value {
+					InitiatorEvent(event) => return Poll::Ready(Some(Event::B1I(event))),
+					CounterpartyEvent(event) => return Poll::Ready(Some(Event::B2C(event))),
+				}
+			}
+
+			let active_swap_event = this.active_swaps_b2_to_b1.poll_next_unpin(cx);
+			if let Some(value) = handle_active_swap_event::<B2, B1>(active_swap_event) {
+				match value {
+					InitiatorEvent(event) => return Poll::Ready(Some(Event::B2I(event))),
+					CounterpartyEvent(event) => return Poll::Ready(Some(Event::B1C(event))),
+				}
+			}
+		}
+
+		// Poll the bridge services, handle the appropriate events, and return
+		match this.blockchain_1.poll_next_unpin(cx) {
+			Poll::Ready(Some(blockchain_event)) => {
+				trace!(
+					"BridgeService: Received event from blockchain service 1: {:?}",
+					blockchain_event
+				);
+				match blockchain_event {
+					ContractEvent::InitiatorEvent(initiator_event) => {
+						trace!("BridgeService: Initiator event from blockchain service 1");
+						if let Some(propagate_event) = handle_initiator_event::<B1, B2>(
+							initiator_event,
+							&mut this.active_swaps_b1_to_b2,
+						) {
+							return Poll::Ready(Some(Event::B1I(propagate_event)));
+						}
+					}
+					ContractEvent::CounterpartyEvent(counterparty_event) => {
+						if let Some(propagate_event) = handle_counterparty_event::<B2, B1>(
+							counterparty_event,
+							&mut this.active_swaps_b2_to_b1,
+						) {
+							return Poll::Ready(Some(Event::B1C(propagate_event)));
+						}
+						trace!("BridgeService: Counterparty event from blockchain service 1");
+					}
+				}
+			}
+			Poll::Ready(None) => {
+				trace!("BridgeService: Blockchain service 1 has no more events");
+			}
+			Poll::Pending => {
+				trace!("BridgeService: Blockchain service 1 has no events at this time");
+			}
+		}
+
+		match this.blockchain_2.poll_next_unpin(cx) {
+			Poll::Ready(Some(blockchain_event)) => {
+				trace!(
+					"BridgeService: Received event from blockchain service 2: {:?}",
+					blockchain_event
+				);
+				match blockchain_event {
+					ContractEvent::InitiatorEvent(initiator_event) => {
+						trace!("BridgeService: Initiator event from blockchain service 2");
+						if let Some(propagate_event) = handle_initiator_event::<B2, B1>(
+							initiator_event,
+							&mut this.active_swaps_b2_to_b1,
+						) {
+							return Poll::Ready(Some(Event::B2I(propagate_event)));
+						}
+					}
+					ContractEvent::CounterpartyEvent(counterparty_event) => {
+						trace!("BridgeService: Counterparty event from blockchain service 2");
+						if let Some(propagate_event) = handle_counterparty_event::<B1, B2>(
+							counterparty_event,
+							&mut this.active_swaps_b1_to_b2,
+						) {
+							return Poll::Ready(Some(Event::B2C(propagate_event)));
+						}
+					}
+				}
+			}
+			Poll::Ready(None) => {
+				trace!("BridgeService: Blockchain service 2 has no more events");
+			}
+			Poll::Pending => {
+				trace!("BridgeService: Blockchain service 2 has no events at this time");
+			}
+		}
+
+		Poll::Pending
+	}
+}
+
+// Initiator events pertain to the initiator contract, while counterparty events are associated
+// with the counterparty contract.
+enum HandleActiveSwapEvent<A, H, H2> {
+	InitiatorEvent(IEvent<A, H>),
+	CounterpartyEvent(CEvent<H2>),
+}
+
+fn handle_active_swap_event<BFrom, BTo>(
+	active_swap_event: Poll<Option<ActiveSwapEvent<BFrom::Hash>>>,
+) -> Option<HandleActiveSwapEvent<BFrom::Address, BFrom::Hash, BTo::Hash>>
+where
+	BFrom: BlockchainService + 'static,
+	BTo: BlockchainService + 'static,
+	BTo::Hash: From<BFrom::Hash>,
+{
+	use ActiveSwapEvent::*;
+	match active_swap_event {
+		Poll::Ready(Some(event)) => {
+			trace!("BridgeService: Received event from active swaps: {:?}", event);
+			match event {
+				// Locking
+				BridgeAssetsLocked(bridge_transfer_id) => {
+					trace!(
+						"BridgeService: Bridge assets locked for transfer {:?}",
+						bridge_transfer_id
+					);
+				}
+				BridgeAssetsLockingError(error) => {
+					// The error in locking bridge assets occurs when transitioning from blockchain 1 to blockchain 2.
+					// This issue arises during the attempt to communicate with blockchain 2 for accessing the locked funds.
+					// Hence the Event::B2C
+					warn!("BridgeService: Error locking bridge assets: {:?}", error);
+					return Some(HandleActiveSwapEvent::CounterpartyEvent(CEvent::Warn(
+						CWarn::BridgeAssetsLockingError(error),
+					)));
+				}
+				BridgeAssetsRetryLocking(bridge_transfer_id) => {
+					warn!(
+						"BridgeService: Retrying to lock bridge assets for transfer {:?}",
+						bridge_transfer_id
+					);
+					return Some(HandleActiveSwapEvent::CounterpartyEvent(
+						CEvent::RetryLockingAssets(BridgeTransferId(From::from(
+							bridge_transfer_id.0,
+						))),
+					));
+				}
+				BridgeAssetsLockingAbortedTooManyAttempts(bride_transfer_id) => {
+					warn!(
+						"BridgeService: Aborted bridge transfer due to too many attempts: {:?}",
+						bride_transfer_id
+					);
+					return Some(HandleActiveSwapEvent::CounterpartyEvent(CEvent::Warn(
+						CWarn::LockingAbortedTooManyAttempts(BridgeTransferId(From::from(
+							bride_transfer_id.0,
+						))),
+					)));
+				}
+
+				// Completing
+				BridgeAssetsCompleted(bridge_transfer_id) => {
+					trace!(
+						"BridgeService: Bridge assets completed for transfer {:?}",
+						bridge_transfer_id
+					);
+				}
+				BridgeAssetsCompletingError(bridge_transfer_id, error) => {
+					warn!("BridgeService: Error completing bridge assets: {:?}", error);
+					return Some(HandleActiveSwapEvent::InitiatorEvent(IEvent::Warn(
+						IWarn::CompleteTransferError(bridge_transfer_id.clone()),
+					)));
+				}
+
+				BridgeAssetsRetryCompleting(bridge_transfer_id) => {
+					warn!(
+						"BridgeService: Retrying to complete bridge assets for transfer {:?}",
+						bridge_transfer_id
+					);
+					return Some(HandleActiveSwapEvent::InitiatorEvent(
+						IEvent::RetryCompletingTransfer(bridge_transfer_id),
+					));
+				}
+
+				BridgeAssetsCompletingAbortedTooManyAttempts(bridge_transfer_id) => {
+					warn!(
+						"BridgeService: Aborted bridge transfer completion due to too many errors: {:?}",
+						bridge_transfer_id
+					);
+					return Some(HandleActiveSwapEvent::InitiatorEvent(IEvent::Warn(
+						IWarn::CompletionAbortedTooManyAttempts(bridge_transfer_id),
+					)));
+				}
+			}
+		}
+		Poll::Ready(None) => {
+			trace!("BridgeService: Active swaps has no more events");
+		}
+		Poll::Pending => {
+			trace!("BridgeService: Active swaps has no events at this time");
+		}
+	}
+	None
+}

--- a/protocol-units/bridge/shared/src/bridge_service/active_swap.rs
+++ b/protocol-units/bridge/shared/src/bridge_service/active_swap.rs
@@ -1,0 +1,526 @@
+use std::{
+	collections::HashMap,
+	convert::From,
+	pin::Pin,
+	task::{Context, Poll},
+	time::Duration,
+};
+
+use futures::{task::AtomicWaker, Future, FutureExt, Stream};
+use futures_time::future::{FutureExt as TimeoutFutureExt, Timeout};
+use futures_timer::Delay;
+use thiserror::Error;
+
+use crate::bridge_contracts::{BridgeContractCounterparty, BridgeContractInitiator};
+use crate::{
+	blockchain_service::BlockchainService,
+	bridge_contracts::{BridgeContractCounterpartyError, BridgeContractInitiatorError},
+	types::{
+		convert_bridge_transfer_id, BridgeTransferDetails, BridgeTransferId, CompletedDetails,
+		HashLock,
+	},
+};
+
+pub type BoxedFuture<R, E> = Timeout<Pin<Box<dyn Future<Output = Result<R, E>> + Send>>, Delay>;
+
+pub struct ActiveSwap<BFrom, BTo>
+where
+	BFrom: BlockchainService,
+	BTo: BlockchainService,
+{
+	pub details: BridgeTransferDetails<BFrom::Address, BFrom::Hash>,
+	pub state: ActiveSwapState<BTo>,
+}
+
+impl<BFrom, BTo> std::fmt::Debug for ActiveSwap<BFrom, BTo>
+where
+	BFrom: BlockchainService,
+	BTo: BlockchainService,
+{
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ActiveSwap")
+			.field("details", &self.details)
+			.field("state", &self.state)
+			.finish()
+	}
+}
+
+type Attempts = usize;
+
+pub enum ActiveSwapState<BTo>
+where
+	BTo: BlockchainService,
+{
+	LockingTokens(BoxedFuture<(), LockBridgeTransferAssetsError>, Attempts),
+	LockingTokensError(Delay, Attempts),
+	WaitingForUnlockedEvent,
+	CompletingBridging(
+		BoxedFuture<(), CompleteBridgeTransferError>,
+		CompletedDetails<BTo::Hash>,
+		Attempts,
+	),
+	CompletingBridgingError(Delay, CompletedDetails<BTo::Hash>, Attempts),
+	Completed,
+	Aborted,
+}
+
+impl<BTo> std::fmt::Debug for ActiveSwapState<BTo>
+where
+	BTo: BlockchainService,
+{
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			ActiveSwapState::LockingTokens(_, attempts) => {
+				f.debug_struct("LockingTokens").field("attempts", attempts).finish()
+			}
+			ActiveSwapState::LockingTokensError(_, attempts) => {
+				f.debug_struct("LockingTokensError").field("attempts", attempts).finish()
+			}
+			ActiveSwapState::WaitingForUnlockedEvent => {
+				f.debug_tuple("WaitingForUnlockedEvent").finish()
+			}
+			ActiveSwapState::CompletingBridging(_, _, attempts) => {
+				f.debug_struct("CompletingBridging").field("attempts", attempts).finish()
+			}
+			ActiveSwapState::CompletingBridgingError(_, _, attempts) => {
+				f.debug_struct("CompletingBridgingError").field("attempts", attempts).finish()
+			}
+			ActiveSwapState::Completed => f.debug_tuple("Completed").finish(),
+			ActiveSwapState::Aborted => f.debug_tuple("Aborted").finish(),
+		}
+	}
+}
+
+#[derive(Debug, Clone)]
+pub struct ActiveSwapConfig {
+	pub error_attempts: usize,
+	pub error_delay: Duration,
+	pub contract_call_timeout: Duration,
+}
+impl Default for ActiveSwapConfig {
+	fn default() -> Self {
+		Self {
+			error_attempts: 3,
+			error_delay: Duration::from_secs(5),
+			contract_call_timeout: Duration::from_secs(30),
+		}
+	}
+}
+
+pub struct ActiveSwapMap<BFrom, BTo>
+where
+	BFrom: BlockchainService,
+	BTo: BlockchainService,
+{
+	pub config: ActiveSwapConfig,
+	pub initiator_contract: BFrom::InitiatorContract,
+	pub counterparty_contract: BTo::CounterpartyContract,
+	swaps: HashMap<BridgeTransferId<BFrom::Hash>, ActiveSwap<BFrom, BTo>>,
+	waker: AtomicWaker,
+}
+
+impl<BFrom, BTo> std::fmt::Debug for ActiveSwapMap<BFrom, BTo>
+where
+	BFrom: BlockchainService,
+	BTo: BlockchainService,
+{
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ActiveSwapMap")
+			.field("swaps", &self.swaps)
+			.field("config", &self.config)
+			.finish()
+	}
+}
+
+#[derive(Debug, Error)]
+pub enum ActiveSwapMapError {
+	#[error("Non existing swap")]
+	NonExistingSwap,
+}
+
+impl<BTo, BFrom> ActiveSwapMap<BFrom, BTo>
+where
+	BTo: BlockchainService + 'static,
+	BFrom: BlockchainService + 'static,
+{
+	pub fn build(
+		initiator_contract: BFrom::InitiatorContract,
+		counterparty_contract: BTo::CounterpartyContract,
+		config: ActiveSwapConfig,
+	) -> Self {
+		Self {
+			initiator_contract,
+			counterparty_contract,
+			swaps: HashMap::new(),
+			config,
+			waker: AtomicWaker::new(),
+		}
+	}
+
+	pub fn get(&self, key: &BridgeTransferId<BFrom::Hash>) -> Option<&ActiveSwap<BFrom, BTo>> {
+		self.swaps.get(key)
+	}
+
+	pub fn get_mut(
+		&mut self,
+		key: &BridgeTransferId<BFrom::Hash>,
+	) -> Option<&mut ActiveSwap<BFrom, BTo>> {
+		self.swaps.get_mut(key)
+	}
+
+	pub fn already_executing(&self, key: &BridgeTransferId<BFrom::Hash>) -> bool {
+		self.swaps.contains_key(key)
+	}
+
+	pub fn start_bridge_transfer(
+		&mut self,
+		details: BridgeTransferDetails<BFrom::Address, BFrom::Hash>,
+	) where
+		BTo::Hash: From<BFrom::Hash>,
+	{
+		assert!(self.swaps.get(&details.bridge_transfer_id).is_none());
+
+		let counterparty_contract = self.counterparty_contract.clone();
+		let bridge_transfer_id = details.bridge_transfer_id.clone();
+
+		tracing::trace!("Starting active swap for bridge transfer {:?}", bridge_transfer_id);
+
+		self.swaps.insert(
+			bridge_transfer_id,
+			ActiveSwap {
+				details: details.clone(),
+				state: ActiveSwapState::LockingTokens(
+					call_lock_bridge_transfer_assets::<BFrom, BTo>(counterparty_contract, details)
+						.boxed()
+						.timeout(Delay::new(self.config.contract_call_timeout)),
+					0,
+				),
+			},
+		);
+
+		self.waker.wake();
+	}
+
+	pub fn complete_bridge_transfer(
+		&mut self,
+		details: CompletedDetails<BTo::Hash>,
+	) -> Result<(), ActiveSwapMapError>
+	where
+		BFrom::Hash: From<BTo::Hash>,
+	{
+		let active_swap = self
+			.swaps
+			.get_mut(&convert_bridge_transfer_id(details.bridge_transfer_id.clone()))
+			.ok_or(ActiveSwapMapError::NonExistingSwap)?;
+
+		debug_assert!(matches!(active_swap.state, ActiveSwapState::WaitingForUnlockedEvent));
+
+		let initiator_contract = self.initiator_contract.clone();
+
+		tracing::trace!(
+			"Completing active swap for bridge transfer {:?}",
+			details.bridge_transfer_id
+		);
+
+		active_swap.state = ActiveSwapState::CompletingBridging(
+			call_complete_bridge_transfer::<BFrom, BTo>(initiator_contract, details.clone())
+				.boxed()
+				.timeout(Delay::new(self.config.contract_call_timeout)),
+			details.clone(),
+			0,
+		);
+
+		self.waker.wake();
+
+		Ok(())
+	}
+}
+
+#[derive(Debug)]
+pub enum ActiveSwapEvent<H> {
+	BridgeAssetsLocked(BridgeTransferId<H>),
+	BridgeAssetsLockingError(LockBridgeTransferAssetsError),
+	BridgeAssetsRetryLocking(BridgeTransferId<H>),
+	BridgeAssetsCompleted(BridgeTransferId<H>),
+	BridgeAssetsCompletingError(BridgeTransferId<H>, CompleteBridgeTransferError),
+	BridgeAssetsRetryCompleting(BridgeTransferId<H>),
+	BridgeAssetsLockingAbortedTooManyAttempts(BridgeTransferId<H>),
+	BridgeAssetsCompletingAbortedTooManyAttempts(BridgeTransferId<H>),
+}
+
+fn catch_timeout_error<T, E: HasTimeoutError>(
+	result: Poll<Result<Result<T, E>, std::io::Error>>,
+) -> Poll<Result<T, E>> {
+	match result {
+		Poll::Ready(Ok(result)) => Poll::Ready(result),
+		Poll::Ready(Err(_)) => Poll::Ready(Err(E::timeout_error())),
+		Poll::Pending => Poll::Pending,
+	}
+}
+
+impl<BFrom, BTo> Stream for ActiveSwapMap<BFrom, BTo>
+where
+	BFrom: BlockchainService + 'static,
+	BTo: BlockchainService + 'static,
+
+	BFrom::Hash: From<BTo::Hash>,
+	BTo::Hash: From<BFrom::Hash>,
+{
+	type Item = ActiveSwapEvent<BFrom::Hash>;
+
+	fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		let this = self.get_mut();
+
+		tracing::trace!("Polling active swap map");
+
+		// remove all swaps that are completed or aborted
+		this.swaps.retain(|_, swap| {
+			!matches!(swap.state, ActiveSwapState::Completed | ActiveSwapState::Aborted)
+		});
+
+		for (bridge_transfer_id, ActiveSwap { details: bridge_transfer, state, .. }) in
+			this.swaps.iter_mut()
+		{
+			use ActiveSwapState::*;
+			match state {
+				LockingTokens(future, attempts) => {
+					tracing::trace!("Polling locking_tokens {:?}", bridge_transfer_id);
+					match catch_timeout_error(future.poll_unpin(cx)) {
+						Poll::Ready(Ok(())) => {
+							*state = ActiveSwapState::WaitingForUnlockedEvent;
+
+							return Poll::Ready(Some(ActiveSwapEvent::BridgeAssetsLocked(
+								bridge_transfer_id.clone(),
+							)));
+						}
+						Poll::Ready(Err(error)) => {
+							tracing::trace!(
+								"Locking brige_transfer {:?} failed, error: {:?} attempts: {}",
+								bridge_transfer_id,
+								error,
+								attempts
+							);
+							if *attempts >= this.config.error_attempts {
+								*state = ActiveSwapState::Aborted;
+								return Poll::Ready(Some(
+									ActiveSwapEvent::BridgeAssetsLockingAbortedTooManyAttempts(
+										bridge_transfer_id.clone(),
+									),
+								));
+							}
+							// Locking tokens failed
+							// Transition to the next state
+							*state = ActiveSwapState::LockingTokensError(
+								Delay::new(this.config.error_delay),
+								*attempts,
+							);
+							return Poll::Ready(Some(ActiveSwapEvent::BridgeAssetsLockingError(
+								error,
+							)));
+						}
+						Poll::Pending => {}
+					}
+				}
+				LockingTokensError(delay, attempts) => {
+					// test if the delay has expired
+					// if it has, retry the lock
+					if let Poll::Ready(()) = delay.poll_unpin(cx) {
+						tracing::trace!(
+							"Retrying lock for bridge transfer {:?}",
+							bridge_transfer_id
+						);
+						*state = ActiveSwapState::LockingTokens(
+							call_lock_bridge_transfer_assets::<BFrom, BTo>(
+								this.counterparty_contract.clone(),
+								bridge_transfer.clone(),
+							)
+							.boxed()
+							.timeout(Delay::new(this.config.contract_call_timeout)),
+							*attempts + 1,
+						);
+						return Poll::Ready(Some(ActiveSwapEvent::BridgeAssetsRetryLocking(
+							bridge_transfer_id.clone(),
+						)));
+					}
+				}
+				WaitingForUnlockedEvent => {
+					continue;
+				}
+				CompletingBridging(future, details, attempts) => {
+					match catch_timeout_error(future.poll_unpin(cx)) {
+						Poll::Ready(Ok(())) => {
+							*state = ActiveSwapState::Completed;
+
+							return Poll::Ready(Some(ActiveSwapEvent::BridgeAssetsCompleted(
+								bridge_transfer_id.clone(),
+							)));
+						}
+						Poll::Ready(Err(error)) => {
+							tracing::trace!(
+								"Completing bridge transfer {:?} failed: {:?} attemtps: {}",
+								bridge_transfer_id,
+								error,
+								attempts
+							);
+							if *attempts >= this.config.error_attempts {
+								*state = ActiveSwapState::Aborted;
+								return Poll::Ready(Some(
+									ActiveSwapEvent::BridgeAssetsCompletingAbortedTooManyAttempts(
+										bridge_transfer_id.clone(),
+									),
+								));
+							}
+
+							// Completing bridging failed
+							// Transition to the next state
+							*state = ActiveSwapState::CompletingBridgingError(
+								Delay::new(this.config.error_delay),
+								details.clone(),
+								*attempts + 1,
+							);
+
+							return Poll::Ready(Some(
+								ActiveSwapEvent::BridgeAssetsCompletingError(
+									bridge_transfer_id.clone(),
+									error,
+								),
+							));
+						}
+						Poll::Pending => {}
+					}
+				}
+				CompletingBridgingError(delay, details, attempts) => {
+					tracing::trace!(
+						"Retrying completing of bridge transfer {:?}",
+						bridge_transfer_id
+					);
+
+					// test if the delay has expired
+					// if it has, retry the lock
+					if let Poll::Ready(()) = delay.poll_unpin(cx) {
+						*state = ActiveSwapState::CompletingBridging(
+							call_complete_bridge_transfer::<BFrom, BTo>(
+								this.initiator_contract.clone(),
+								details.clone(),
+							)
+							.boxed()
+							.timeout(Delay::new(this.config.contract_call_timeout)),
+							details.clone(),
+							*attempts + 1,
+						);
+						return Poll::Ready(Some(ActiveSwapEvent::BridgeAssetsRetryCompleting(
+							bridge_transfer_id.clone(),
+						)));
+					}
+				}
+				Completed => {
+					tracing::trace!(
+						"Bridge transfer {:?} completed, marked for cleanup",
+						bridge_transfer_id
+					);
+				}
+				Aborted => {
+					tracing::trace!(
+						"Bridge transfer {:?} aborted, marked for cleanup",
+						bridge_transfer_id
+					);
+				}
+			}
+		}
+
+		this.waker.register(cx.waker());
+
+		Poll::Pending
+	}
+}
+
+// Lock assets
+trait HasTimeoutError {
+	fn timeout_error() -> Self;
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum LockBridgeTransferAssetsError {
+	#[error("Failed to lock assets")]
+	LockingError,
+	#[error("Timeout while performing contract call")]
+	ContractCallTimeoutError,
+	#[error(transparent)]
+	ContractCallError(#[from] BridgeContractCounterpartyError),
+}
+
+impl HasTimeoutError for LockBridgeTransferAssetsError {
+	fn timeout_error() -> Self {
+		LockBridgeTransferAssetsError::ContractCallTimeoutError
+	}
+}
+
+async fn call_lock_bridge_transfer_assets<BFrom: BlockchainService, BTo: BlockchainService>(
+	mut counterparty_contract: BTo::CounterpartyContract,
+	BridgeTransferDetails {
+		bridge_transfer_id,
+		hash_lock,
+		time_lock,
+		recipient_address,
+		amount,
+		..
+	}: BridgeTransferDetails<BFrom::Address, BFrom::Hash>,
+) -> Result<(), LockBridgeTransferAssetsError>
+where
+	BTo::Hash: From<BFrom::Hash>,
+{
+	let bridge_transfer_id = BridgeTransferId(From::from(bridge_transfer_id.0));
+	let hash_lock = HashLock(From::from(hash_lock.0));
+
+	tracing::trace!(
+		"Calling lock_bridge_transfer_assets on counterparty contract for bridge transfer {:?}",
+		bridge_transfer_id
+	);
+
+	counterparty_contract
+		.lock_bridge_transfer_assets(
+			bridge_transfer_id,
+			hash_lock,
+			time_lock,
+			recipient_address,
+			amount,
+		)
+		.await?;
+
+	Ok(())
+}
+
+#[derive(Debug, Error)]
+pub enum CompleteBridgeTransferError {
+	#[error("Failed to complete bridge transfer")]
+	CompletingError,
+	#[error("Timeout while performing contract call")]
+	ContractCallTimeoutError,
+	#[error(transparent)]
+	ContractCallError(#[from] BridgeContractInitiatorError),
+}
+
+impl HasTimeoutError for CompleteBridgeTransferError {
+	fn timeout_error() -> Self {
+		CompleteBridgeTransferError::ContractCallTimeoutError
+	}
+}
+
+async fn call_complete_bridge_transfer<BFrom: BlockchainService, BTo: BlockchainService>(
+	mut initiator_contract: BFrom::InitiatorContract,
+	CompletedDetails { bridge_transfer_id, secret, .. }: CompletedDetails<BTo::Hash>,
+) -> Result<(), CompleteBridgeTransferError>
+where
+	BFrom::Hash: From<BTo::Hash>,
+{
+	tracing::trace!(
+		"Calling complete bridge transfer on initiator contract for bridge transfer {:?}",
+		bridge_transfer_id
+	);
+
+	initiator_contract
+		.complete_bridge_transfer(convert_bridge_transfer_id(bridge_transfer_id), secret)
+		.await?;
+
+	Ok(())
+}

--- a/protocol-units/bridge/shared/src/bridge_service/events.rs
+++ b/protocol-units/bridge/shared/src/bridge_service/events.rs
@@ -1,0 +1,127 @@
+use crate::{
+	blockchain_service::BlockchainService,
+	bridge_monitoring::{BridgeContractCounterpartyEvent, BridgeContractInitiatorEvent},
+	types::{BridgeTransferDetails, BridgeTransferId, CompletedDetails},
+};
+
+use super::active_swap::LockBridgeTransferAssetsError;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum IWarn<A, H> {
+	AlreadyPresent(BridgeTransferDetails<A, H>),
+	CompleteTransferError(BridgeTransferId<H>),
+	CompletionAbortedTooManyAttempts(BridgeTransferId<H>),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum IEvent<A, H> {
+	ContractEvent(BridgeContractInitiatorEvent<A, H>),
+	Warn(IWarn<A, H>),
+	RetryCompletingTransfer(BridgeTransferId<H>),
+}
+
+impl<A, H> IEvent<A, H> {
+	pub fn contract_event(&self) -> Option<&BridgeContractInitiatorEvent<A, H>> {
+		match self {
+			IEvent::ContractEvent(event) => Some(event),
+			_ => None,
+		}
+	}
+	pub fn warn(&self) -> Option<&IWarn<A, H>> {
+		match self {
+			IEvent::Warn(warn) => Some(warn),
+			_ => None,
+		}
+	}
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum CWarn<H> {
+	BridgeAssetsLockingError(LockBridgeTransferAssetsError),
+	CannotCompleteUnexistingSwap(CompletedDetails<H>),
+	LockingAbortedTooManyAttempts(BridgeTransferId<H>),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum CEvent<H> {
+	RetryLockingAssets(BridgeTransferId<H>),
+	ContractEvent(BridgeContractCounterpartyEvent<H>),
+	Warn(CWarn<H>),
+}
+
+impl<H> CEvent<H> {
+	pub fn contract_event(&self) -> Option<&BridgeContractCounterpartyEvent<H>> {
+		match self {
+			CEvent::ContractEvent(event) => Some(event),
+			_ => None,
+		}
+	}
+
+	pub fn warn(&self) -> Option<&CWarn<H>> {
+		match self {
+			CEvent::Warn(warn) => Some(warn),
+			_ => None,
+		}
+	}
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Event<B1, B2>
+where
+	B1: BlockchainService,
+	B2: BlockchainService,
+{
+	B1I(IEvent<B1::Address, B1::Hash>),
+	B1C(CEvent<B1::Hash>),
+	B2I(IEvent<B2::Address, B2::Hash>),
+	B2C(CEvent<B2::Hash>),
+}
+
+#[allow(non_snake_case)]
+impl<B1: BlockchainService, B2: BlockchainService> Event<B1, B2> {
+	pub fn B1I(&self) -> Option<&IEvent<B1::Address, B1::Hash>> {
+		match self {
+			Event::B1I(event) => Some(event),
+			_ => None,
+		}
+	}
+	pub fn B1I_ContractEvent(
+		&self,
+	) -> Option<&BridgeContractInitiatorEvent<B1::Address, B1::Hash>> {
+		self.B1I()?.contract_event()
+	}
+
+	pub fn B1C(&self) -> Option<&CEvent<B1::Hash>> {
+		match self {
+			Event::B1C(event) => Some(event),
+			_ => None,
+		}
+	}
+
+	pub fn B1C_ContractEvent(&self) -> Option<&BridgeContractCounterpartyEvent<B1::Hash>> {
+		self.B1C()?.contract_event()
+	}
+
+	pub fn B2I(&self) -> Option<&IEvent<B2::Address, B2::Hash>> {
+		match self {
+			Event::B2I(event) => Some(event),
+			_ => None,
+		}
+	}
+	pub fn B2I_ContractEvent(
+		&self,
+	) -> Option<&BridgeContractInitiatorEvent<B2::Address, B2::Hash>> {
+		self.B2I()?.contract_event()
+	}
+
+	pub fn B2C(&self) -> Option<&CEvent<B2::Hash>> {
+		match self {
+			Event::B2C(event) => Some(event),
+			_ => None,
+		}
+	}
+
+	pub fn B2C_ContractEvent(&self) -> Option<&BridgeContractCounterpartyEvent<B2::Hash>> {
+		self.B2C()?.contract_event()
+	}
+}

--- a/protocol-units/bridge/shared/src/lib.rs
+++ b/protocol-units/bridge/shared/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod blockchain_service;
+pub mod bridge_contracts;
+pub mod bridge_monitoring;
+pub mod bridge_service;
+pub mod types;

--- a/protocol-units/bridge/shared/src/types.rs
+++ b/protocol-units/bridge/shared/src/types.rs
@@ -1,0 +1,134 @@
+use std::{fmt::Debug, hash::Hash};
+
+use derive_more::{Deref, DerefMut};
+use rand::Rng;
+
+#[derive(Deref, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BridgeTransferId<H>(pub H);
+
+impl<H, O> Convert<BridgeTransferId<O>> for BridgeTransferId<H>
+where
+	H: Convert<O>,
+{
+	fn convert(me: &BridgeTransferId<H>) -> BridgeTransferId<O> {
+		BridgeTransferId(Convert::convert(&me.0))
+	}
+}
+
+impl<H> From<H> for BridgeTransferId<H> {
+	fn from(hash: H) -> Self {
+		BridgeTransferId(hash)
+	}
+}
+
+pub fn convert_bridge_transfer_id<H: From<O>, O>(
+	other: BridgeTransferId<O>,
+) -> BridgeTransferId<H> {
+	BridgeTransferId(From::from(other.0))
+}
+
+impl<H> GenUniqueHash for BridgeTransferId<H>
+where
+	H: GenUniqueHash,
+{
+	fn gen_unique_hash<R: Rng>(rng: &mut R) -> Self {
+		BridgeTransferId(H::gen_unique_hash(rng))
+	}
+}
+
+#[derive(Deref, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct InitiatorAddress<A>(pub A);
+
+#[derive(Deref, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RecipientAddress(pub Vec<u8>);
+
+impl From<&str> for RecipientAddress {
+	fn from(value: &str) -> Self {
+		RecipientAddress(value.as_bytes().to_vec())
+	}
+}
+
+#[derive(Deref, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct HashLock<H>(pub H);
+
+pub fn convert_hash_lock<H: From<O>, O>(other: HashLock<O>) -> HashLock<H> {
+	HashLock(From::from(other.0))
+}
+
+#[derive(Deref, Debug, Clone, PartialEq, Eq)]
+pub struct HashLockPreImage(pub Vec<u8>);
+
+#[derive(Deref, Debug, Clone, PartialEq, Eq)]
+pub struct TimeLock(pub u64);
+
+#[derive(Deref, DerefMut, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Amount(pub u64);
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct BridgeTransferDetails<A, H> {
+	pub bridge_transfer_id: BridgeTransferId<H>,
+	pub initiator_address: InitiatorAddress<A>,
+	pub recipient_address: RecipientAddress,
+	pub hash_lock: HashLock<H>,
+	pub time_lock: TimeLock,
+	pub amount: Amount,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct LockDetails<H> {
+	pub bridge_transfer_id: BridgeTransferId<H>,
+	pub recipient_address: RecipientAddress,
+	pub hash_lock: HashLock<H>,
+	pub time_lock: TimeLock,
+	pub amount: Amount,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct CompletedDetails<H> {
+	pub bridge_transfer_id: BridgeTransferId<H>,
+	pub recipient_address: RecipientAddress,
+	pub hash_lock: HashLock<H>,
+	pub secret: HashLockPreImage,
+	pub amount: Amount,
+}
+
+impl<H> CompletedDetails<H> {
+	pub fn from_bridge_transfer_details<A>(
+		bridge_transfer_details: BridgeTransferDetails<A, H>,
+		secret: HashLockPreImage,
+	) -> Self {
+		CompletedDetails {
+			bridge_transfer_id: bridge_transfer_details.bridge_transfer_id,
+			recipient_address: bridge_transfer_details.recipient_address,
+			hash_lock: bridge_transfer_details.hash_lock,
+			secret,
+			amount: bridge_transfer_details.amount,
+		}
+	}
+
+	pub fn from_lock_details(lock_details: LockDetails<H>, secret: HashLockPreImage) -> Self {
+		CompletedDetails {
+			bridge_transfer_id: lock_details.bridge_transfer_id,
+			recipient_address: lock_details.recipient_address,
+			hash_lock: lock_details.hash_lock,
+			secret,
+			amount: lock_details.amount,
+		}
+	}
+}
+
+// Types
+pub trait BridgeHashType: Debug + PartialEq + Eq + Hash + Unpin + Send + Sync + Clone {}
+pub trait BridgeAddressType: Debug + PartialEq + Eq + Hash + Unpin + Send + Sync + Clone {}
+
+pub trait Convert<O> {
+	fn convert(other: &Self) -> O;
+}
+
+// Blankets
+impl<T> BridgeHashType for T where T: Debug + PartialEq + Eq + Hash + Unpin + Send + Sync + Clone {}
+impl<T> BridgeAddressType for T where T: Debug + PartialEq + Eq + Hash + Unpin + Send + Sync + Clone {}
+
+pub trait GenUniqueHash {
+	fn gen_unique_hash<R: Rng>(rng: &mut R) -> Self;
+}

--- a/protocol-units/bridge/shared/tests/abstract_blockchain.rs
+++ b/protocol-units/bridge/shared/tests/abstract_blockchain.rs
@@ -1,0 +1,163 @@
+use bridge_shared::types::{
+	Amount, BridgeTransferDetails, BridgeTransferId, GenUniqueHash, HashLock, InitiatorAddress,
+	RecipientAddress, TimeLock,
+};
+use bridge_shared::types::{HashLockPreImage, LockDetails};
+use futures::StreamExt;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaChaRng;
+
+use test_log::test;
+
+mod shared;
+
+use shared::testing::blockchain::{
+	AbstractBlockchain, AbstractBlockchainEvent, CounterpartyCall, InitiatorCall, Transaction,
+};
+
+use crate::shared::testing::blockchain::{
+	counterparty_contract::SmartContractCounterpartyEvent,
+	initiator_contract::SmartContractInitiatorEvent,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TestAddress(pub &'static str);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TestHash(pub &'static str);
+
+impl From<TestAddress> for RecipientAddress {
+	fn from(value: TestAddress) -> Self {
+		RecipientAddress(value.0.as_bytes().to_vec())
+	}
+}
+
+impl From<RecipientAddress> for TestAddress {
+	fn from(value: RecipientAddress) -> Self {
+		Self(static_str_ops::staticize(&String::from_utf8(value.0).expect("Invalid UTF-8")))
+	}
+}
+
+impl From<HashLockPreImage> for TestHash {
+	fn from(_value: HashLockPreImage) -> Self {
+		todo!()
+	}
+}
+
+impl GenUniqueHash for TestHash {
+	fn gen_unique_hash<R: Rng>(_rng: &mut R) -> Self {
+		TestHash("unique_hash")
+	}
+}
+
+#[test(tokio::test)]
+async fn test_initiate_bridge_transfer() {
+	let rng = ChaChaRng::from_seed([0u8; 32]);
+	let mut blockchain = AbstractBlockchain::<TestAddress, TestHash, _>::new(rng, "TestBlockchain");
+
+	let mut monitor = blockchain.add_event_listener();
+
+	let initiator_address = InitiatorAddress(TestAddress("initiator"));
+	let recipient_address = RecipientAddress::from(TestAddress("recipient"));
+	let amount = Amount(1000);
+	let time_lock = TimeLock(100);
+	let hash_lock = HashLock(TestHash("hash_lock"));
+
+	let transaction = Transaction::Initiator(InitiatorCall::InitiateBridgeTransfer(
+		initiator_address.clone(),
+		recipient_address.clone(),
+		amount,
+		time_lock.clone(),
+		hash_lock.clone(),
+	));
+
+	blockchain.transaction_sender.unbounded_send(transaction).unwrap();
+
+	let event = blockchain.next().await;
+	let monitor_event = monitor.next().await;
+	assert!(event.is_some());
+	assert!(monitor_event.is_some());
+	assert_eq!(event, monitor_event);
+
+	let event = event.unwrap();
+	assert_eq!(
+		event,
+		AbstractBlockchainEvent::InitiatorContractEvent(Ok(
+			SmartContractInitiatorEvent::InitiatedBridgeTransfer(BridgeTransferDetails {
+				bridge_transfer_id: BridgeTransferId(TestHash("unique_hash")),
+				initiator_address: initiator_address.clone(),
+				recipient_address: recipient_address.clone(),
+				amount: amount.clone(),
+				time_lock: time_lock.clone(),
+				hash_lock: hash_lock.clone(),
+			})
+		))
+	);
+
+	let details = blockchain
+		.initiator_contract
+		.initiated_transfers
+		.get(&BridgeTransferId(TestHash("unique_hash")));
+	assert!(details.is_some());
+
+	let details = details.unwrap();
+	assert_eq!(details.initiator_address, initiator_address);
+	assert_eq!(details.recipient_address, recipient_address);
+	assert_eq!(details.amount, amount);
+	assert_eq!(details.time_lock, time_lock);
+	assert_eq!(details.hash_lock, hash_lock);
+}
+
+#[test(tokio::test)]
+async fn test_lock_bridge_transfer() {
+	let rng = ChaChaRng::from_seed([0u8; 32]);
+	let mut blockchain = AbstractBlockchain::<TestAddress, TestHash, _>::new(rng, "TestBlockchain");
+
+	let mut monitor = blockchain.add_event_listener();
+
+	let bridge_transfer_id = BridgeTransferId(TestHash("unique_hash"));
+	let hash_lock = HashLock(TestHash("hash_lock"));
+	let time_lock = TimeLock(100);
+	let recipient_address = RecipientAddress::from(TestAddress("recipient"));
+	let amount = Amount(1000);
+
+	let transaction = Transaction::Counterparty(CounterpartyCall::LockBridgeTransfer(
+		bridge_transfer_id.clone(),
+		hash_lock.clone(),
+		time_lock.clone(),
+		recipient_address.clone(),
+		amount,
+	));
+
+	blockchain.transaction_sender.unbounded_send(transaction).unwrap();
+
+	let event = blockchain.next().await;
+	let monitor_event = monitor.next().await;
+	assert!(monitor_event.is_some());
+	assert!(event.is_some());
+	assert_eq!(event, monitor_event);
+
+	let event = event.unwrap();
+	assert_eq!(
+		event,
+		AbstractBlockchainEvent::CounterpartyContractEvent(Ok(
+			SmartContractCounterpartyEvent::LockedBridgeTransfer(LockDetails {
+				bridge_transfer_id: bridge_transfer_id.clone(),
+				hash_lock: hash_lock.clone(),
+				time_lock: time_lock.clone(),
+				recipient_address: recipient_address.clone(),
+				amount,
+			})
+		))
+	);
+
+	let details = blockchain.counterparty_contract.locked_transfers.get(&bridge_transfer_id);
+	assert!(details.is_some());
+
+	let details = details.unwrap();
+	assert_eq!(details.bridge_transfer_id, bridge_transfer_id);
+	assert_eq!(details.recipient_address, recipient_address);
+	assert_eq!(details.hash_lock, hash_lock);
+	assert_eq!(details.time_lock, time_lock);
+	assert_eq!(details.amount, amount);
+}

--- a/protocol-units/bridge/shared/tests/blockchain_service.rs
+++ b/protocol-units/bridge/shared/tests/blockchain_service.rs
@@ -1,0 +1,47 @@
+use bridge_shared::bridge_monitoring::BridgeContractInitiatorEvent;
+use bridge_shared::types::{
+	Amount, BridgeTransferDetails, BridgeTransferId, HashLock, InitiatorAddress, RecipientAddress,
+	TimeLock,
+};
+use bridge_shared::{blockchain_service::ContractEvent, bridge_contracts::BridgeContractInitiator};
+use futures::StreamExt;
+use std::task::{Context, Poll};
+
+mod shared;
+
+use shared::testing::mocks::MockBlockchainService;
+
+#[tokio::test]
+async fn test_bridge_transfer_initiated() {
+	let mut blockchain_service = MockBlockchainService::build();
+
+	blockchain_service
+		.initiator_contract
+		.with_next_bridge_transfer_id("transfer_id")
+		.initiate_bridge_transfer(
+			InitiatorAddress("initiator"),
+			RecipientAddress::from("recipient"),
+			HashLock("hash_lock"),
+			TimeLock(100),
+			Amount(1000),
+		)
+		.await
+		.expect("initiate_bridge_transfer failed");
+
+	let mut cx = Context::from_waker(futures::task::noop_waker_ref());
+	let event = blockchain_service.poll_next_unpin(&mut cx);
+
+	assert_eq!(
+		event,
+		Poll::Ready(Some(ContractEvent::InitiatorEvent(BridgeContractInitiatorEvent::Initiated(
+			BridgeTransferDetails {
+				bridge_transfer_id: BridgeTransferId("transfer_id"),
+				initiator_address: InitiatorAddress("initiator"),
+				recipient_address: RecipientAddress::from("recipient"),
+				hash_lock: HashLock("hash_lock"),
+				time_lock: TimeLock(100),
+				amount: Amount(1000),
+			}
+		))))
+	);
+}

--- a/protocol-units/bridge/shared/tests/bridge_service.rs
+++ b/protocol-units/bridge/shared/tests/bridge_service.rs
@@ -1,0 +1,267 @@
+use std::time::Duration;
+
+use futures::StreamExt;
+use test_log::test;
+
+use bridge_shared::{
+	bridge_contracts::{BridgeContractCounterparty, BridgeContractInitiator},
+	bridge_monitoring::{BridgeContractCounterpartyEvent, BridgeContractInitiatorEvent},
+	bridge_service::{active_swap::ActiveSwapConfig, BridgeServiceConfig},
+	types::{
+		Amount, BridgeTransferDetails, CompletedDetails, Convert, HashLock, HashLockPreImage,
+		InitiatorAddress, LockDetails, RecipientAddress, TimeLock,
+	},
+};
+
+use crate::shared::{
+	setup_bridge_service, B1Client, B2Client, BC1Address, BC1Hash, BC2Address, BC2Hash,
+	SetupBridgeServiceResult,
+};
+
+mod shared;
+
+#[test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn test_bridge_service_integration_a_to_b() {
+	let SetupBridgeServiceResult(
+		mut bridge_service,
+		mut blockchain_1_client,
+		mut blockchain_2_client,
+		blockchain_1,
+		blockchain_2,
+	) = setup_bridge_service(BridgeServiceConfig {
+		active_swap: ActiveSwapConfig {
+			error_attempts: 3,
+			error_delay: Duration::from_secs(1),
+			contract_call_timeout: Duration::from_secs(5),
+		},
+	});
+
+	tokio::spawn(blockchain_1);
+	tokio::spawn(blockchain_2);
+
+	// Step 1: Initiating the swap on Blockchain 1
+
+	// The initiator of the swap triggers a bridge transfer, simultaneously time-locking the assets
+	// in the smart contract.
+	tracing::debug!("Initiating bridge transfer");
+	blockchain_1_client
+		.initiate_bridge_transfer(
+			InitiatorAddress(BC1Address("initiator")),
+			RecipientAddress::from(BC1Address("recipient")),
+			HashLock(BC1Hash::from("hash_lock")),
+			TimeLock(100),
+			Amount(1000),
+		)
+		.await
+		.expect("initiate_bridge_transfer failed");
+
+	// We expect the bridge to recognize the contract event and emit the appropriate message
+	let transfer_initiated_event = bridge_service.next().await.expect("No event");
+	let transfer_initiated_event =
+		transfer_initiated_event.B1I_ContractEvent().expect("Not a B1I event");
+	tracing::debug!(?transfer_initiated_event);
+	assert_eq!(
+		transfer_initiated_event,
+		&BridgeContractInitiatorEvent::Initiated(BridgeTransferDetails {
+			bridge_transfer_id: transfer_initiated_event.bridge_transfer_id().clone(),
+			initiator_address: InitiatorAddress(BC1Address("initiator")),
+			recipient_address: RecipientAddress::from(BC1Address("recipient")),
+			hash_lock: HashLock(BC1Hash::from("hash_lock")),
+			time_lock: TimeLock(100),
+			amount: Amount(1000)
+		})
+	);
+
+	// Step 2: Locking the assets on the Blockchain 2
+
+	// Upon recognizing the event, our bridge server has invoked the counterparty
+	// contract on blockchain 2 to initiate asset locking within the smart contract.
+	tracing::debug!("Locking assets on Blockchain 2");
+
+	let counterparty_locked_event = bridge_service.next().await.expect("No event");
+	let counterparty_locked_event =
+		counterparty_locked_event.B2C_ContractEvent().expect("Not a B2C event");
+	tracing::debug!(?counterparty_locked_event);
+	assert_eq!(
+		counterparty_locked_event,
+		&BridgeContractCounterpartyEvent::Locked(LockDetails {
+			bridge_transfer_id: Convert::convert(transfer_initiated_event.bridge_transfer_id()),
+			hash_lock: HashLock(BC2Hash::from("hash_lock")),
+			time_lock: TimeLock(100),
+			recipient_address: RecipientAddress::from(BC2Address("recipient")),
+			amount: Amount(1000),
+		})
+	);
+
+	// Step 3: Client completes the swap on Blockchain 2, revealing the pre_image of the hash lock
+
+	// Once the assets are secured within the counterparty smart contract, the initiator is able
+	// to execute the complete bridge transfer by disclosing the secret key required to unlock the assets.
+	tracing::debug!("Client completing bridge transfer on Blockchain 2");
+
+	<B2Client as BridgeContractCounterparty>::complete_bridge_transfer(
+		&mut blockchain_2_client,
+		Convert::convert(transfer_initiated_event.bridge_transfer_id()),
+		HashLockPreImage(b"hash_lock".to_vec()),
+	)
+	.await
+	.expect("complete_bridge_transfer failed");
+
+	// As the claim was made by the counterparty, we anticipate the bridge to generate a bridge
+	// contract counterpart event.
+	let completed_event_counterparty = bridge_service.next().await.expect("No event");
+	let completed_event_counterparty =
+		completed_event_counterparty.B2C_ContractEvent().expect("Not a B2C event");
+	tracing::debug!(?completed_event_counterparty);
+	assert_eq!(
+		completed_event_counterparty,
+		&BridgeContractCounterpartyEvent::Completed(CompletedDetails {
+			bridge_transfer_id: Convert::convert(transfer_initiated_event.bridge_transfer_id()),
+			recipient_address: RecipientAddress::from(BC2Address("recipient")),
+			hash_lock: HashLock(BC2Hash::from("hash_lock")),
+			secret: HashLockPreImage(b"hash_lock".to_vec()),
+			amount: Amount(1000),
+		})
+	);
+
+	// Step 4: Bridge service completes the swap, using the secret to claim the funds on Blockchain 1
+
+	// As the initiator has successfully claimed the funds on the Counterparty blockchain, the bridge
+	// is now expected to finalize the swap by completing the necessary tasks on the initiator
+	// blockchain.
+	tracing::debug!("Bridge service completing bridge transfer on Blockchain 1");
+
+	let completed_event_initiator = bridge_service.next().await.expect("No event");
+	let completed_event_initiator =
+		completed_event_initiator.B1I_ContractEvent().expect("Not a B1I event");
+	tracing::debug!(?completed_event_initiator);
+	assert_eq!(
+		completed_event_initiator,
+		&BridgeContractInitiatorEvent::Completed(
+			transfer_initiated_event.bridge_transfer_id().clone()
+		)
+	);
+}
+
+#[test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn test_bridge_service_integration_b_to_a() {
+	let SetupBridgeServiceResult(
+		mut bridge_service,
+		mut blockchain_1_client,
+		mut blockchain_2_client,
+		blockchain_1,
+		blockchain_2,
+	) = setup_bridge_service(BridgeServiceConfig {
+		active_swap: ActiveSwapConfig {
+			error_attempts: 3,
+			error_delay: Duration::from_secs(1),
+			contract_call_timeout: Duration::from_secs(5),
+		},
+	});
+
+	tokio::spawn(blockchain_1);
+	tokio::spawn(blockchain_2);
+
+	// Step 1: Initiating the swap on Blockchain 2
+
+	// The initiator of the swap triggers a bridge transfer, simultaneously time-locking the assets
+	// in the smart contract.
+	tracing::debug!("Initiating bridge transfer on Blockchain 2");
+	blockchain_2_client
+		.initiate_bridge_transfer(
+			InitiatorAddress(BC2Address("initiator")),
+			RecipientAddress::from(BC2Address("recipient")),
+			HashLock(BC2Hash::from("hash_lock")),
+			TimeLock(100),
+			Amount(1000),
+		)
+		.await
+		.expect("initiate_bridge_transfer failed");
+
+	// We expect the bridge to recognize the contract event and emit the appropriate message
+	let transfer_initiated_event = bridge_service.next().await.expect("No event");
+	let transfer_initiated_event =
+		transfer_initiated_event.B2I_ContractEvent().expect("Not a B2I event");
+	tracing::debug!(?transfer_initiated_event);
+	assert_eq!(
+		transfer_initiated_event,
+		&BridgeContractInitiatorEvent::Initiated(BridgeTransferDetails {
+			bridge_transfer_id: transfer_initiated_event.bridge_transfer_id().clone(),
+			initiator_address: InitiatorAddress(BC2Address("initiator")),
+			recipient_address: RecipientAddress::from(BC2Address("recipient")),
+			hash_lock: HashLock(BC2Hash::from("hash_lock")),
+			time_lock: TimeLock(100),
+			amount: Amount(1000)
+		})
+	);
+
+	// Step 2: Locking the assets on the Blockchain 1
+
+	// Upon recognizing the event, our bridge server has invoked the counterparty
+	// contract on blockchain 1 to initiate asset locking within the smart contract.
+	tracing::debug!("Locking assets on Blockchain 1");
+
+	let counterparty_locked_event = bridge_service.next().await.expect("No event");
+	let counterparty_locked_event =
+		counterparty_locked_event.B1C_ContractEvent().expect("Not a B1C event");
+	tracing::debug!(?counterparty_locked_event);
+	assert_eq!(
+		counterparty_locked_event,
+		&BridgeContractCounterpartyEvent::Locked(LockDetails {
+			bridge_transfer_id: Convert::convert(transfer_initiated_event.bridge_transfer_id()),
+			hash_lock: HashLock(BC1Hash::from("hash_lock")),
+			time_lock: TimeLock(100),
+			recipient_address: RecipientAddress::from(BC1Address("recipient")),
+			amount: Amount(1000),
+		})
+	);
+
+	// Step 3: Client completes the swap on Blockchain 1, revealing the pre_image of the hash lock
+
+	// Once the assets are secured within the counterparty smart contract, the initiator is able
+	// to execute the complete bridge transfer by disclosing the secret key required to unlock the assets.
+	tracing::debug!("Client completing bridge transfer on Blockchain 1");
+
+	<B1Client as BridgeContractCounterparty>::complete_bridge_transfer(
+		&mut blockchain_1_client,
+		Convert::convert(transfer_initiated_event.bridge_transfer_id()),
+		HashLockPreImage(b"hash_lock".to_vec()),
+	)
+	.await
+	.expect("complete_bridge_transfer failed");
+
+	// As the claim was made by the counterparty, we anticipate the bridge to generate a bridge
+	// contract counterpart event.
+	let completed_event_counterparty = bridge_service.next().await.expect("No event");
+	let completed_event_counterparty =
+		completed_event_counterparty.B1C_ContractEvent().expect("Not a B1C event");
+	tracing::debug!(?completed_event_counterparty);
+	assert_eq!(
+		completed_event_counterparty,
+		&BridgeContractCounterpartyEvent::Completed(CompletedDetails {
+			bridge_transfer_id: Convert::convert(transfer_initiated_event.bridge_transfer_id()),
+			recipient_address: RecipientAddress::from(BC1Address("recipient")),
+			hash_lock: HashLock(BC1Hash::from("hash_lock")),
+			secret: HashLockPreImage(b"hash_lock".to_vec()),
+			amount: Amount(1000),
+		})
+	);
+
+	// Step 4: Bridge service completes the swap, using the secret to claim the funds on Blockchain 2
+
+	// As the initiator has successfully claimed the funds on the Counterparty blockchain, the bridge
+	// is now expected to finalize the swap by completing the necessary tasks on the initiator
+	// blockchain.
+	tracing::debug!("Bridge service completing bridge transfer on Blockchain 2");
+
+	let completed_event_initiator = bridge_service.next().await.expect("No event");
+	let completed_event_initiator =
+		completed_event_initiator.B2I_ContractEvent().expect("Not a B2I event");
+	tracing::debug!(?completed_event_initiator);
+	assert_eq!(
+		completed_event_initiator,
+		&BridgeContractInitiatorEvent::Completed(
+			transfer_initiated_event.bridge_transfer_id().clone()
+		)
+	);
+}

--- a/protocol-units/bridge/shared/tests/bridge_service_error_handling.rs
+++ b/protocol-units/bridge/shared/tests/bridge_service_error_handling.rs
@@ -1,0 +1,488 @@
+use std::time::Duration;
+
+use futures::StreamExt;
+use test_log::test;
+
+use bridge_shared::{
+	bridge_contracts::{
+		BridgeContractCounterparty, BridgeContractCounterpartyError, BridgeContractInitiator,
+		BridgeContractInitiatorError,
+	},
+	bridge_monitoring::{BridgeContractCounterpartyEvent, BridgeContractInitiatorEvent},
+	bridge_service::{
+		active_swap::{ActiveSwapConfig, LockBridgeTransferAssetsError},
+		events::{CEvent, CWarn, Event, IEvent, IWarn},
+		BridgeServiceConfig,
+	},
+	types::{
+		Amount, BridgeTransferDetails, CompletedDetails, Convert, HashLock, HashLockPreImage,
+		InitiatorAddress, RecipientAddress, TimeLock,
+	},
+};
+
+mod shared;
+
+use crate::shared::{
+	setup_bridge_service, testing::blockchain::client::MethodName, B2Client, BC1Address, BC1Hash,
+	BC2Address, BC2Hash, SetupBridgeServiceResult,
+};
+
+use self::shared::testing::blockchain::client::{CallConfig, ErrorConfig};
+
+#[test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn test_bridge_service_error_handling() {
+	let SetupBridgeServiceResult(
+		mut bridge_service,
+		mut blockchain_1_client,
+		mut blockchain_2_client,
+		blockchain_1,
+		blockchain_2,
+	) = setup_bridge_service(BridgeServiceConfig {
+		active_swap: ActiveSwapConfig {
+			error_attempts: 3,
+			error_delay: Duration::from_secs(1),
+			contract_call_timeout: Duration::from_secs(5),
+		},
+	});
+
+	tokio::spawn(blockchain_1);
+	tokio::spawn(blockchain_2);
+
+	// Lets make the blockchain_2_client fail on the locking of assets
+	blockchain_2_client.set_call_config(
+		MethodName::LockBridgeTransferAssets,
+		1,
+		CallConfig {
+			error: ErrorConfig::CounterpartyError(
+				BridgeContractCounterpartyError::LockTransferAssetsError,
+			),
+			delay: None,
+		},
+	);
+
+	// Step 1: Initiating the swap on Blockchain 1 with an invalid hash lock
+
+	tracing::debug!("Initiating bridge transfer with invalid hash lock");
+	blockchain_1_client
+		.initiate_bridge_transfer(
+			InitiatorAddress(BC1Address("initiator")),
+			RecipientAddress::from(BC1Address("recipient")),
+			HashLock(BC1Hash::from("hash_lock")),
+			TimeLock(100),
+			Amount(1000),
+		)
+		.await
+		.expect("initiate_bridge_transfer failed");
+
+	// B1I Initiated
+	let transfer_initiated_event = bridge_service.next().await.expect("No event");
+	let transfer_initiated_event =
+		transfer_initiated_event.B1I_ContractEvent().expect("Not a B1I event");
+	tracing::debug!(?transfer_initiated_event);
+	assert_eq!(
+		transfer_initiated_event,
+		&BridgeContractInitiatorEvent::Initiated(BridgeTransferDetails {
+			bridge_transfer_id: transfer_initiated_event.bridge_transfer_id().clone(),
+			initiator_address: InitiatorAddress(BC1Address("initiator")),
+			recipient_address: RecipientAddress::from(BC1Address("recipient")),
+			hash_lock: HashLock(BC1Hash::from("hash_lock")),
+			time_lock: TimeLock(100),
+			amount: Amount(1000)
+		})
+	);
+
+	// B2C Locking call failed due to mock above
+	let event = bridge_service.next().await.expect("No event");
+	tracing::debug!(?event);
+	assert!(matches!(
+		event.B2C().and_then(CEvent::warn).expect("not a b2c warn event"),
+		CWarn::BridgeAssetsLockingError(_)
+	));
+
+	// dbg!(&bridge_service.active_swaps_b1_to_b2);
+
+	// The Bridge is expected to retry the operation after the configured delay in case of an error.
+	let event = bridge_service.next().await.expect("No event");
+	tracing::debug!(?event);
+	assert!(matches!(event, Event::B2C(CEvent::RetryLockingAssets(_))));
+
+	// Post-retry, the client is expected to successfully invoke the contract and return a Locked
+	// event.
+	let event = bridge_service.next().await.expect("No event");
+	let event = event.B2C_ContractEvent().expect("Not a B2C event");
+	tracing::debug!(?event);
+	assert!(matches!(event, BridgeContractCounterpartyEvent::Locked(_)));
+
+	// Bridge gracefully recovered from an error
+
+	// Step 2: Attempting to complete the swap on Blockchain 2
+	tracing::debug!("Attempting to complete bridge transfer with invalid secret");
+
+	<B2Client as BridgeContractCounterparty>::complete_bridge_transfer(
+		&mut blockchain_2_client,
+		Convert::convert(transfer_initiated_event.bridge_transfer_id()),
+		HashLockPreImage(b"hash_lock".to_vec()),
+	)
+	.await
+	.expect("complete_bridge_transfer failed");
+
+	// Expecting the bridge to detect the initiator's completion of the swap and reveal the secret
+	let completed_event_counterparty = bridge_service.next().await.expect("No event");
+	let completed_event_counterparty =
+		completed_event_counterparty.B2C_ContractEvent().expect("Not a B2C event");
+	tracing::debug!(?completed_event_counterparty);
+	assert_eq!(
+		completed_event_counterparty,
+		&BridgeContractCounterpartyEvent::Completed(CompletedDetails {
+			bridge_transfer_id: Convert::convert(transfer_initiated_event.bridge_transfer_id()),
+			recipient_address: RecipientAddress::from(BC2Address("recipient")),
+			hash_lock: HashLock(BC2Hash::from("hash_lock")),
+			secret: HashLockPreImage(b"hash_lock".to_vec()),
+			amount: Amount(1000),
+		})
+	);
+
+	// Subsequently, the bridge service has successfully detected the secret and is now attempting to finalize
+	// the swap on blockchain 1. It is imperative for this process to succeed; otherwise, funds may be irretrievably
+	// lost, necessitating manual intervention to resolve the issue.
+
+	// Intentionally causing the blockchain_1_client to fail during the asset locking process to
+	// simulate various failure scenarios.
+	blockchain_1_client.set_call_config(
+		MethodName::CompleteBridgeTransferInitiator,
+		1,
+		CallConfig {
+			error: ErrorConfig::InitiatorError(BridgeContractInitiatorError::CompleteTransferError),
+			delay: None,
+		},
+	);
+
+	// B1C Locking call failed due to mock above
+	let event = bridge_service.next().await.expect("No event");
+	tracing::debug!(?event);
+	assert!(matches!(
+		event.B1I().and_then(IEvent::warn).expect("not a b2c warn event"),
+		IWarn::CompleteTransferError(_)
+	));
+
+	// The Bridge is expected to retry the operation after the configured delay in case of an error.
+	let event = bridge_service.next().await.expect("No event");
+	tracing::debug!(?event);
+	assert!(matches!(event, Event::B1I(IEvent::RetryCompletingTransfer(_))));
+
+	// Bridge service completes the swap using the secret to claim the funds on Blockchain 1
+	// Since the mock passes.
+
+	tracing::debug!("Bridge service completing bridge transfer on Blockchain 1");
+
+	let completed_event_initiator = bridge_service.next().await.expect("No event");
+	let completed_event_initiator =
+		completed_event_initiator.B1I_ContractEvent().expect("Not a B1I event");
+	tracing::debug!(?completed_event_initiator);
+	assert_eq!(
+		completed_event_initiator,
+		&BridgeContractInitiatorEvent::Completed(
+			transfer_initiated_event.bridge_transfer_id().clone()
+		)
+	);
+}
+
+#[test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn test_bridge_service_locking_termination_after_errors() {
+	let SetupBridgeServiceResult(
+		mut bridge_service,
+		mut blockchain_1_client,
+		mut blockchain_2_client,
+		blockchain_1,
+		blockchain_2,
+	) = setup_bridge_service(BridgeServiceConfig {
+		active_swap: ActiveSwapConfig {
+			error_attempts: 3,
+			error_delay: Duration::from_secs(1),
+			contract_call_timeout: Duration::from_secs(5),
+		},
+	});
+
+	tokio::spawn(blockchain_1);
+	tokio::spawn(blockchain_2);
+
+	// Configure blockchain_2_client to fail 3 times on locking assets
+	for n in 1..5 {
+		blockchain_2_client.set_call_config(
+			MethodName::LockBridgeTransferAssets,
+			n,
+			CallConfig {
+				error: ErrorConfig::CounterpartyError(
+					BridgeContractCounterpartyError::LockTransferAssetsError,
+				),
+				delay: None,
+			},
+		);
+	}
+
+	// Step 1: Initiating the swap on Blockchain 1
+	tracing::debug!("Initiating bridge transfer with error configuration");
+	blockchain_1_client
+		.initiate_bridge_transfer(
+			InitiatorAddress(BC1Address("initiator")),
+			RecipientAddress::from(BC1Address("recipient")),
+			HashLock(BC1Hash::from("hash_lock")),
+			TimeLock(100),
+			Amount(1000),
+		)
+		.await
+		.expect("initiate_bridge_transfer failed");
+
+	// B1I Initiated
+	let transfer_initiated_event = bridge_service.next().await.expect("No event");
+	let transfer_initiated_event =
+		transfer_initiated_event.B1I_ContractEvent().expect("Not a B1I event");
+	tracing::debug!(?transfer_initiated_event);
+	assert_eq!(
+		transfer_initiated_event,
+		&BridgeContractInitiatorEvent::Initiated(BridgeTransferDetails {
+			bridge_transfer_id: transfer_initiated_event.bridge_transfer_id().clone(),
+			initiator_address: InitiatorAddress(BC1Address("initiator")),
+			recipient_address: RecipientAddress::from(BC1Address("recipient")),
+			hash_lock: HashLock(BC1Hash::from("hash_lock")),
+			time_lock: TimeLock(100),
+			amount: Amount(1000)
+		})
+	);
+
+	// B2C Locking call failed due to mock above
+	for _ in 0..3 {
+		let event = bridge_service.next().await.expect("No event");
+		tracing::debug!(?event);
+		assert!(matches!(
+			event.B2C().and_then(CEvent::warn).expect("not a b2c warn event"),
+			CWarn::BridgeAssetsLockingError(_)
+		));
+
+		// The Bridge is expected to retry the operation after the configured delay in case of an error.
+		let event = bridge_service.next().await.expect("No event");
+		tracing::debug!(?event);
+		assert!(matches!(event, Event::B2C(CEvent::RetryLockingAssets(_))));
+	}
+
+	// After 3 errors, the active swap should be terminated
+	// The Bridge is expected to retry the operation after the configured delay in case of an error.
+	let event = bridge_service.next().await.expect("No event");
+	tracing::debug!(?event);
+	assert!(matches!(event, Event::B2C(CEvent::Warn(CWarn::LockingAbortedTooManyAttempts(_)))));
+
+	// Call the poll method on the active_swaps_b1_to_b2 to ensure that
+	// the swap will be removed form he active swaps list
+	let cx = &mut std::task::Context::from_waker(futures::task::noop_waker_ref());
+	let _ = bridge_service.active_swaps_b1_to_b2.poll_next_unpin(cx);
+
+	assert!(bridge_service
+		.active_swaps_b1_to_b2
+		.get(transfer_initiated_event.bridge_transfer_id())
+		.is_none());
+}
+
+#[test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn test_bridge_service_completion_abort_after_errors() {
+	let SetupBridgeServiceResult(
+		mut bridge_service,
+		mut blockchain_1_client,
+		mut blockchain_2_client,
+		blockchain_1,
+		blockchain_2,
+	) = setup_bridge_service(BridgeServiceConfig {
+		active_swap: ActiveSwapConfig {
+			error_attempts: 3,
+			error_delay: Duration::from_secs(1),
+			contract_call_timeout: Duration::from_secs(5),
+		},
+	});
+
+	tokio::spawn(blockchain_1);
+	tokio::spawn(blockchain_2);
+
+	// Step 1: Initiating the swap on Blockchain 1
+	tracing::debug!("Initiating bridge transfer with error configuration");
+	blockchain_1_client
+		.initiate_bridge_transfer(
+			InitiatorAddress(BC1Address("initiator")),
+			RecipientAddress::from(BC1Address("recipient")),
+			HashLock(BC1Hash::from("hash_lock")),
+			TimeLock(100),
+			Amount(1000),
+		)
+		.await
+		.expect("initiate_bridge_transfer failed");
+
+	// B1I Initiated
+	let transfer_initiated_event = bridge_service.next().await.expect("No event");
+	let transfer_initiated_event =
+		transfer_initiated_event.B1I_ContractEvent().expect("Not a B1I event");
+	tracing::debug!(?transfer_initiated_event);
+	assert_eq!(
+		transfer_initiated_event,
+		&BridgeContractInitiatorEvent::Initiated(BridgeTransferDetails {
+			bridge_transfer_id: transfer_initiated_event.bridge_transfer_id().clone(),
+			initiator_address: InitiatorAddress(BC1Address("initiator")),
+			recipient_address: RecipientAddress::from(BC1Address("recipient")),
+			hash_lock: HashLock(BC1Hash::from("hash_lock")),
+			time_lock: TimeLock(100),
+			amount: Amount(1000)
+		})
+	);
+
+	// Simulate successful locking on Blockchain 2
+	let event = bridge_service.next().await.expect("No event");
+	let event = event.B2C_ContractEvent().expect("Not a B2C event");
+	tracing::debug!(?event);
+	assert!(matches!(event, BridgeContractCounterpartyEvent::Locked(_)));
+
+	// Step 2: Attempting to complete the swap on Blockchain 2
+	tracing::debug!("Attempting to complete bridge transfer with valid secret");
+
+	// Configure blockchain_1_client to fail 3 times on completing the transfer
+	for n in 1..5 {
+		blockchain_1_client.set_call_config(
+			MethodName::CompleteBridgeTransferInitiator,
+			n,
+			CallConfig {
+				error: ErrorConfig::InitiatorError(
+					BridgeContractInitiatorError::CompleteTransferError,
+				),
+				delay: None,
+			},
+		);
+	}
+
+	<B2Client as BridgeContractCounterparty>::complete_bridge_transfer(
+		&mut blockchain_2_client,
+		Convert::convert(transfer_initiated_event.bridge_transfer_id()),
+		HashLockPreImage(b"hash_lock".to_vec()),
+	)
+	.await
+	.expect("complete_bridge_transfer failed");
+
+	// Frist we get a completed event from the counterparty
+	let completed_event_counterparty = bridge_service.next().await.expect("No event");
+	let completed_event_counterparty =
+		completed_event_counterparty.B2C_ContractEvent().expect("Not a B2C event");
+	tracing::debug!(?completed_event_counterparty);
+	assert_eq!(
+		completed_event_counterparty,
+		&BridgeContractCounterpartyEvent::Completed(CompletedDetails {
+			bridge_transfer_id: Convert::convert(transfer_initiated_event.bridge_transfer_id()),
+			recipient_address: RecipientAddress::from(BC2Address("recipient")),
+			hash_lock: HashLock(BC2Hash::from("hash_lock")),
+			secret: HashLockPreImage(b"hash_lock".to_vec()),
+			amount: Amount(1000),
+		})
+	);
+
+	// B1C Completing call failed due to mock above
+	for _ in 0..2 {
+		let event = bridge_service.next().await.expect("No event");
+		tracing::debug!(?event);
+		assert!(matches!(
+			event.B1I().and_then(IEvent::warn).expect("not a b1i warn event"),
+			IWarn::CompleteTransferError(_)
+		));
+
+		// The Bridge is expected to retry the operation after the configured delay in case of an error.
+		let event = bridge_service.next().await.expect("No event");
+		tracing::debug!(?event);
+		assert!(matches!(event, Event::B1I(IEvent::RetryCompletingTransfer(_))));
+	}
+
+	// After 3 errors, the active swap should be terminated
+	let event = bridge_service.next().await.expect("No event");
+	tracing::debug!(?event);
+	assert!(matches!(event, Event::B1I(IEvent::Warn(IWarn::CompletionAbortedTooManyAttempts(_)))));
+
+	// Call the poll method on the active_swaps_b1_to_b2 to ensure that
+	// the swap will be removed from the active swaps list
+	let cx = &mut std::task::Context::from_waker(futures::task::noop_waker_ref());
+	let _ = bridge_service.active_swaps_b1_to_b2.poll_next_unpin(cx);
+
+	assert!(bridge_service
+		.active_swaps_b1_to_b2
+		.get(transfer_initiated_event.bridge_transfer_id())
+		.is_none());
+}
+
+#[test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn test_bridge_service_timeout_error_handling() {
+	let SetupBridgeServiceResult(
+		mut bridge_service,
+		mut blockchain_1_client,
+		mut blockchain_2_client,
+		blockchain_1,
+		blockchain_2,
+	) = setup_bridge_service(BridgeServiceConfig {
+		active_swap: ActiveSwapConfig {
+			error_attempts: 1,
+			error_delay: Duration::from_secs(1),
+			contract_call_timeout: Duration::from_millis(100), // Set a short timeout for testing
+		},
+	});
+
+	tokio::spawn(blockchain_1);
+	tokio::spawn(blockchain_2);
+
+	// Lets make the blockchain_2_client fail on the locking of assets
+	blockchain_2_client.set_call_config(
+		MethodName::LockBridgeTransferAssets,
+		1,
+		// Longer delay than the timeout, to trigger timeout
+		CallConfig { error: ErrorConfig::None, delay: Some(Duration::from_secs(1)) },
+	);
+
+	// Step 1: Initiating the swap on Blockchain 1
+	tracing::debug!("Initiating bridge transfer with short timeout");
+	blockchain_1_client
+		.initiate_bridge_transfer(
+			InitiatorAddress(BC1Address("initiator")),
+			RecipientAddress::from(BC1Address("recipient")),
+			HashLock(BC1Hash::from("hash_lock")),
+			TimeLock(100),
+			Amount(1000),
+		)
+		.await
+		.expect("initiate_bridge_transfer failed");
+
+	// B1I Initiated
+	let transfer_initiated_event = bridge_service.next().await.expect("No event");
+	let transfer_initiated_event =
+		transfer_initiated_event.B1I_ContractEvent().expect("Not a B1I event");
+	tracing::debug!(?transfer_initiated_event);
+	assert_eq!(
+		transfer_initiated_event,
+		&BridgeContractInitiatorEvent::Initiated(BridgeTransferDetails {
+			bridge_transfer_id: transfer_initiated_event.bridge_transfer_id().clone(),
+			initiator_address: InitiatorAddress(BC1Address("initiator")),
+			recipient_address: RecipientAddress::from(BC1Address("recipient")),
+			hash_lock: HashLock(BC1Hash::from("hash_lock")),
+			time_lock: TimeLock(100),
+			amount: Amount(1000)
+		})
+	);
+
+	// B2C Locking call should timeout
+	let event = bridge_service.next().await.expect("No event");
+	tracing::debug!(?event);
+	assert!(matches!(
+		event.B2C().and_then(CEvent::warn).expect("not a b2c warn event"),
+		CWarn::BridgeAssetsLockingError(LockBridgeTransferAssetsError::ContractCallTimeoutError)
+	));
+
+	// The Bridge is expected to retry the operation after the configured delay in case of an error.
+	let event = bridge_service.next().await.expect("No event");
+	tracing::debug!(?event);
+	assert!(matches!(event, Event::B2C(CEvent::RetryLockingAssets(_))));
+
+	// Post-retry, the client is expected to successfully invoke the contract and return a Locked
+	// event.
+	let event = bridge_service.next().await.expect("No event");
+	let event = event.B2C_ContractEvent().expect("Not a B2C event");
+	tracing::debug!(?event);
+	assert!(matches!(event, BridgeContractCounterpartyEvent::Locked(_)));
+}

--- a/protocol-units/bridge/shared/tests/shared/mod.rs
+++ b/protocol-units/bridge/shared/tests/shared/mod.rs
@@ -1,0 +1,348 @@
+#![allow(dead_code)] // TODO: Remove this line once the code is complete
+
+use bridge_shared::{
+	blockchain_service::AbstractBlockchainService,
+	bridge_monitoring::{
+		BridgeContractCounterpartyEvent, BridgeContractCounterpartyMonitoring,
+		BridgeContractInitiatorEvent, BridgeContractInitiatorMonitoring,
+	},
+	bridge_service::{BridgeService, BridgeServiceConfig},
+	types::{Convert, GenUniqueHash, HashLockPreImage, RecipientAddress},
+};
+
+use futures::{channel::mpsc::UnboundedReceiver, Stream, StreamExt};
+use rand::Rng;
+use rand::SeedableRng;
+use std::{
+	fmt::{Debug, Formatter},
+	hash::{DefaultHasher, Hash, Hasher},
+	pin::Pin,
+	task::{Context, Poll},
+};
+
+pub mod testing;
+
+use testing::{
+	blockchain::AbstractBlockchainEvent,
+	blockchain::{AbstractBlockchain, AbstractBlockchainClient},
+	rng::{RngSeededClone, TestRng},
+};
+
+use crate::shared::testing::blockchain::{
+	counterparty_contract::SmartContractCounterpartyEvent,
+	initiator_contract::SmartContractInitiatorEvent,
+};
+
+pub fn hash_static_string(pre_image: &'static str) -> [u8; 8] {
+	hash_vec_u8(pre_image.as_bytes())
+}
+
+pub fn hash_vec_u8(data: &[u8]) -> [u8; 8] {
+	let mut hasher = DefaultHasher::new();
+	data.hash(&mut hasher);
+	hasher.finish().to_be_bytes()
+}
+
+#[derive(Clone, Eq, PartialEq, Hash)]
+pub struct BC1Hash([u8; 8]);
+
+impl From<HashLockPreImage> for BC1Hash {
+	fn from(value: HashLockPreImage) -> Self {
+		Self(hash_vec_u8(&value.0))
+	}
+}
+
+impl From<&'static str> for BC1Hash {
+	fn from(pre_image: &'static str) -> Self {
+		Self(hash_static_string(pre_image))
+	}
+}
+
+impl GenUniqueHash for BC1Hash {
+	fn gen_unique_hash<R: Rng>(rng: &mut R) -> Self {
+		Self(rng.gen())
+	}
+}
+
+impl Debug for BC1Hash {
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		write!(f, "Bc1Hash({:02x})", u64::from_be_bytes(self.0))
+	}
+}
+
+#[derive(Clone, Eq, PartialEq, Hash)]
+pub struct BC2Hash([u8; 8]);
+
+impl From<HashLockPreImage> for BC2Hash {
+	fn from(value: HashLockPreImage) -> Self {
+		Self(hash_vec_u8(&value.0))
+	}
+}
+
+impl GenUniqueHash for BC2Hash {
+	fn gen_unique_hash<R: Rng>(rng: &mut R) -> Self {
+		Self(rng.gen())
+	}
+}
+
+impl From<&'static str> for BC2Hash {
+	fn from(pre_image: &'static str) -> Self {
+		Self(hash_static_string(pre_image))
+	}
+}
+
+impl Debug for BC2Hash {
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		write!(f, "BC2Hash({:02x})", u64::from_be_bytes(self.0))
+	}
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct BC1Address(pub &'static str);
+
+impl From<RecipientAddress> for BC1Address {
+	fn from(value: RecipientAddress) -> Self {
+		Self(static_str_ops::staticize(&String::from_utf8(value.0).expect("Invalid UTF-8")))
+	}
+}
+
+impl From<BC1Address> for RecipientAddress {
+	fn from(value: BC1Address) -> Self {
+		RecipientAddress(value.0.as_bytes().to_vec())
+	}
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct BC2Address(pub &'static str);
+
+impl From<RecipientAddress> for BC2Address {
+	fn from(value: RecipientAddress) -> Self {
+		Self(static_str_ops::staticize(&String::from_utf8(value.0).expect("Invalid UTF-8")))
+	}
+}
+
+impl From<BC2Address> for RecipientAddress {
+	fn from(value: BC2Address) -> Self {
+		RecipientAddress(value.0.as_bytes().to_vec())
+	}
+}
+
+impl From<BC1Address> for BC2Address {
+	fn from(address: BC1Address) -> Self {
+		Self(address.0)
+	}
+}
+
+impl From<BC2Address> for BC1Address {
+	fn from(address: BC2Address) -> Self {
+		Self(address.0)
+	}
+}
+
+impl Convert<BC1Hash> for BC2Hash {
+	fn convert(me: &BC2Hash) -> BC1Hash {
+		BC1Hash(me.0)
+	}
+}
+
+impl Convert<BC2Hash> for BC1Hash {
+	fn convert(me: &BC1Hash) -> BC2Hash {
+		BC2Hash(me.0)
+	}
+}
+
+impl From<BC1Hash> for BC2Hash {
+	fn from(hash: BC1Hash) -> Self {
+		Self(hash.0)
+	}
+}
+
+impl From<BC2Hash> for BC1Hash {
+	fn from(hash: BC2Hash) -> Self {
+		Self(hash.0)
+	}
+}
+
+pub struct InitiatorContractMonitoring<A, H> {
+	listener: UnboundedReceiver<AbstractBlockchainEvent<A, H>>,
+}
+
+impl<A, H> InitiatorContractMonitoring<A, H> {
+	pub fn build(listener: UnboundedReceiver<AbstractBlockchainEvent<A, H>>) -> Self {
+		Self { listener }
+	}
+}
+
+impl<A: Debug, H: Debug> BridgeContractInitiatorMonitoring for InitiatorContractMonitoring<A, H> {
+	type Address = A;
+	type Hash = H;
+}
+
+impl<A: Debug, H: Debug> Stream for InitiatorContractMonitoring<A, H> {
+	type Item = BridgeContractInitiatorEvent<
+		<Self as BridgeContractInitiatorMonitoring>::Address,
+		<Self as BridgeContractInitiatorMonitoring>::Hash,
+	>;
+
+	fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+		let this = self.get_mut();
+		if let Poll::Ready(Some(AbstractBlockchainEvent::InitiatorContractEvent(contract_result))) =
+			this.listener.poll_next_unpin(cx)
+		{
+			tracing::trace!(
+				"InitiatorContractMonitoring: Received contract event: {:?}",
+				contract_result
+			);
+			// Only listen to the initiator contract events
+			use SmartContractInitiatorEvent::*;
+			match contract_result {
+				Ok(contract_event) => match contract_event {
+					InitiatedBridgeTransfer(details) => {
+						return Poll::Ready(Some(BridgeContractInitiatorEvent::Initiated(details)))
+					}
+					CompletedBridgeTransfer(bridge_transfer_id, _) => {
+						return Poll::Ready(Some(BridgeContractInitiatorEvent::Completed(
+							bridge_transfer_id,
+						)))
+					}
+				},
+				Err(_) => {
+					// Handle error
+				}
+			}
+		}
+		Poll::Pending
+	}
+}
+
+pub struct CounterpartyContractMonitoring<A, H> {
+	listener: UnboundedReceiver<AbstractBlockchainEvent<A, H>>,
+}
+
+impl<A, H> CounterpartyContractMonitoring<A, H> {
+	pub fn build(listener: UnboundedReceiver<AbstractBlockchainEvent<A, H>>) -> Self {
+		Self { listener }
+	}
+}
+
+impl<A: Debug, H: Debug> BridgeContractCounterpartyMonitoring
+	for CounterpartyContractMonitoring<A, H>
+{
+	type Address = A;
+	type Hash = H;
+}
+
+impl<A: Debug, H: Debug> Stream for CounterpartyContractMonitoring<A, H> {
+	type Item = BridgeContractCounterpartyEvent<H>;
+
+	fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+		let this = self.get_mut();
+		if let Poll::Ready(Some(AbstractBlockchainEvent::CounterpartyContractEvent(
+			contract_result,
+		))) = this.listener.poll_next_unpin(cx)
+		{
+			tracing::trace!(
+				"CounterpartyContractMonitoring: Received contract event: {:?}",
+				contract_result
+			);
+			use SmartContractCounterpartyEvent::*;
+			match contract_result {
+				Ok(contract_event) => match contract_event {
+					LockedBridgeTransfer(details) => {
+						return Poll::Ready(Some(BridgeContractCounterpartyEvent::Locked(details)))
+					}
+					CompletedBridgeTransfer(details) => {
+						return Poll::Ready(Some(BridgeContractCounterpartyEvent::Completed(
+							details,
+						)))
+					}
+				},
+				Err(_) => {
+					// Handle error
+				}
+			}
+		}
+		Poll::Pending
+	}
+}
+
+pub type B1Client = AbstractBlockchainClient<BC1Address, BC1Hash, TestRng>;
+pub type B2Client = AbstractBlockchainClient<BC2Address, BC2Hash, TestRng>;
+
+// Setup the BlockchainService
+pub type B1Service = AbstractBlockchainService<
+	AbstractBlockchainClient<BC1Address, BC1Hash, TestRng>,
+	InitiatorContractMonitoring<BC1Address, BC1Hash>,
+	AbstractBlockchainClient<BC1Address, BC1Hash, TestRng>,
+	CounterpartyContractMonitoring<BC1Address, BC1Hash>,
+	BC1Address,
+	BC1Hash,
+>;
+
+pub type B2Service = AbstractBlockchainService<
+	AbstractBlockchainClient<BC2Address, BC2Hash, TestRng>,
+	InitiatorContractMonitoring<BC2Address, BC2Hash>,
+	AbstractBlockchainClient<BC2Address, BC2Hash, TestRng>,
+	CounterpartyContractMonitoring<BC2Address, BC2Hash>,
+	BC2Address,
+	BC2Hash,
+>;
+
+pub struct SetupBridgeServiceResult(
+	pub BridgeService<B1Service, B2Service>,
+	pub AbstractBlockchainClient<BC1Address, BC1Hash, TestRng>,
+	pub AbstractBlockchainClient<BC2Address, BC2Hash, TestRng>,
+	pub AbstractBlockchain<BC1Address, BC1Hash, TestRng>,
+	pub AbstractBlockchain<BC2Address, BC2Hash, TestRng>,
+);
+
+pub fn setup_bridge_service(config: BridgeServiceConfig) -> SetupBridgeServiceResult {
+	let mut rng = TestRng::from_seed([0u8; 32]);
+
+	let mut blockchain_1 =
+		AbstractBlockchain::<BC1Address, BC1Hash, _>::new(rng.seeded_clone(), "Blockchain1");
+	let mut blockchain_2 =
+		AbstractBlockchain::<BC2Address, BC2Hash, _>::new(rng.seeded_clone(), "Blockchain2");
+
+	// Contracts and monitors for blockchain 1
+	let client_1 =
+		AbstractBlockchainClient::new(blockchain_1.connection(), rng.seeded_clone(), 0.0, 0.00);
+	let monitor_1_initiator = InitiatorContractMonitoring::build(blockchain_1.add_event_listener());
+	let monitor_1_counterparty =
+		CounterpartyContractMonitoring::build(blockchain_1.add_event_listener());
+
+	// Contracts and monitors for blockchain 2
+	let client_2 =
+		AbstractBlockchainClient::new(blockchain_2.connection(), rng.seeded_clone(), 0.0, 0.00);
+	let monitor_2_initiator = InitiatorContractMonitoring::build(blockchain_2.add_event_listener());
+	let monitor_2_counterparty =
+		CounterpartyContractMonitoring::build(blockchain_2.add_event_listener());
+
+	let blockchain_1_client = client_1.clone();
+	let blockchain_1_service = AbstractBlockchainService {
+		initiator_contract: blockchain_1_client.clone(),
+		initiator_monitoring: monitor_1_initiator,
+		counterparty_contract: blockchain_1_client.clone(),
+		counterparty_monitoring: monitor_1_counterparty,
+		_phantom: Default::default(),
+	};
+
+	let blockchain_2_client = client_2.clone();
+	let blockchain_2_service = AbstractBlockchainService {
+		initiator_contract: blockchain_2_client.clone(),
+		initiator_monitoring: monitor_2_initiator,
+		counterparty_contract: blockchain_2_client.clone(),
+		counterparty_monitoring: monitor_2_counterparty,
+		_phantom: Default::default(),
+	};
+
+	let bridge_service = BridgeService::new(blockchain_1_service, blockchain_2_service, config);
+
+	SetupBridgeServiceResult(
+		bridge_service,
+		blockchain_1_client,
+		blockchain_2_client,
+		blockchain_1,
+		blockchain_2,
+	)
+}

--- a/protocol-units/bridge/shared/tests/shared/testing/blockchain.rs
+++ b/protocol-units/bridge/shared/tests/shared/testing/blockchain.rs
@@ -1,0 +1,257 @@
+use futures::{channel::mpsc, task::AtomicWaker, Future, Stream, StreamExt};
+use rand::Rng;
+use std::{
+	collections::HashMap,
+	pin::Pin,
+	task::{Context, Poll},
+};
+
+pub use self::{
+	client::AbstractBlockchainClient,
+	counterparty_contract::{CounterpartyCall, SmartContractCounterparty},
+	initiator_contract::{InitiatorCall, SmartContractInitiator},
+};
+use self::{counterparty_contract::SCCResult, initiator_contract::SCIResult};
+
+use super::rng::RngSeededClone;
+use bridge_shared::types::{
+	Amount, BridgeAddressType, BridgeHashType, GenUniqueHash, HashLockPreImage, RecipientAddress,
+};
+
+pub mod client;
+pub mod counterparty_contract;
+pub mod hasher;
+pub mod initiator_contract;
+
+pub enum SmartContractCall<H> {
+	Initiator(),
+	Counterparty(CounterpartyCall<H>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AbstractBlockchainEvent<A, H> {
+	InitiatorContractEvent(SCIResult<A, H>),
+	CounterpartyContractEvent(SCCResult<H>),
+	Noop,
+}
+
+#[derive(Debug)]
+pub enum Transaction<A, H> {
+	Initiator(InitiatorCall<A, H>),
+	Counterparty(CounterpartyCall<H>),
+}
+
+#[derive(Debug)]
+pub struct AbstractBlockchain<A, H, R> {
+	pub name: String,
+	pub time: u64,
+	pub accounts: HashMap<A, Amount>,
+	pub events: Vec<AbstractBlockchainEvent<A, H>>,
+	pub rng: R,
+
+	pub initiator_contract: SmartContractInitiator<A, H, R>,
+	pub counterparty_contract: SmartContractCounterparty<A, H>,
+
+	pub transaction_sender: mpsc::UnboundedSender<Transaction<A, H>>,
+	pub transaction_receiver: mpsc::UnboundedReceiver<Transaction<A, H>>,
+
+	pub event_listeners: Vec<mpsc::UnboundedSender<AbstractBlockchainEvent<A, H>>>,
+
+	waker: AtomicWaker,
+
+	pub _phantom: std::marker::PhantomData<H>,
+}
+
+impl<A, H, R> AbstractBlockchain<A, H, R>
+where
+	A: BridgeAddressType + From<RecipientAddress>,
+	H: BridgeHashType + GenUniqueHash,
+	R: RngSeededClone,
+	H: From<HashLockPreImage>,
+{
+	pub fn new(mut rng: R, name: impl Into<String>) -> Self {
+		let accounts = HashMap::new();
+		let events = Vec::new();
+		let (event_sender, event_receiver) = mpsc::unbounded();
+		let event_listeners = Vec::new();
+
+		Self {
+			name: name.into(),
+			time: 0,
+			accounts,
+			events,
+			initiator_contract: SmartContractInitiator::new(rng.seeded_clone()),
+			rng,
+			counterparty_contract: SmartContractCounterparty::new(),
+			transaction_sender: event_sender,
+			transaction_receiver: event_receiver,
+			event_listeners,
+			waker: AtomicWaker::new(),
+			_phantom: std::marker::PhantomData,
+		}
+	}
+
+	pub fn add_event_listener(&mut self) -> mpsc::UnboundedReceiver<AbstractBlockchainEvent<A, H>> {
+		let (sender, receiver) = mpsc::unbounded();
+		self.event_listeners.push(sender);
+		receiver
+	}
+
+	pub fn forward_time(&mut self, duration: u64) {
+		self.time += duration;
+	}
+
+	pub fn add_account(&mut self, address: A, amount: Amount) {
+		self.accounts.insert(address, amount);
+	}
+
+	pub fn get_balance(&mut self, address: &A) -> Option<&Amount> {
+		self.accounts.get(address)
+	}
+
+	pub fn connection(&self) -> mpsc::UnboundedSender<Transaction<A, H>> {
+		self.transaction_sender.clone()
+	}
+
+	pub fn client(
+		&mut self,
+		failure_rate: f64,
+		false_positive_rate: f64,
+	) -> AbstractBlockchainClient<A, H, R> {
+		AbstractBlockchainClient::new(
+			self.transaction_sender.clone(),
+			self.rng.seeded_clone(),
+			failure_rate,
+			false_positive_rate,
+		) // Example rates: 10% failure, 5% false positive
+	}
+}
+
+impl<A, H, R> Future for AbstractBlockchain<A, H, R>
+where
+	A: BridgeAddressType + From<RecipientAddress>,
+	H: BridgeHashType + GenUniqueHash,
+	R: Rng + Unpin,
+	H: From<HashLockPreImage>,
+{
+	type Output = ();
+
+	fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+		let this = self.get_mut();
+
+		// This simulates
+		// async move { while (blockchain_1.next().await).is_some() {} }
+		while let Poll::Ready(event) = this.poll_next_unpin(cx) {
+			match event {
+				Some(_) => {}
+				None => return Poll::Ready(()),
+			}
+		}
+		Poll::Pending
+	}
+}
+
+impl<A, H, R> Stream for AbstractBlockchain<A, H, R>
+where
+	A: BridgeAddressType + From<RecipientAddress>,
+	H: BridgeHashType + GenUniqueHash,
+	R: Rng + Unpin,
+	H: From<HashLockPreImage>,
+{
+	type Item = AbstractBlockchainEvent<A, H>;
+
+	fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		tracing::trace!("AbstractBlockchain[{}]: Polling for events", self.name);
+		let this = self.get_mut();
+
+		match this.transaction_receiver.poll_next_unpin(cx) {
+			Poll::Ready(Some(transaction)) => {
+				tracing::trace!(
+					"AbstractBlockchain[{}]: Received transaction: {:?}",
+					this.name,
+					transaction
+				);
+				match transaction {
+					Transaction::Initiator(call) => match call {
+						InitiatorCall::InitiateBridgeTransfer(
+							initiator_address,
+							recipient_address,
+							amount,
+							time_lock,
+							hash_lock,
+						) => {
+							this.events.push(AbstractBlockchainEvent::InitiatorContractEvent(
+								this.initiator_contract.initiate_bridge_transfer(
+									initiator_address.clone(),
+									recipient_address.clone(),
+									amount,
+									time_lock.clone(),
+									hash_lock.clone(),
+								),
+							));
+						}
+						InitiatorCall::CompleteBridgeTransfer(bridge_transfer_id, secret) => {
+							this.events.push(AbstractBlockchainEvent::InitiatorContractEvent(
+								this.initiator_contract.complete_bridge_transfer(
+									&mut this.accounts,
+									bridge_transfer_id.clone(),
+									secret.clone(),
+								),
+							));
+						}
+					},
+					Transaction::Counterparty(call) => match call {
+						CounterpartyCall::LockBridgeTransfer(
+							bridge_transfer_id,
+							hash_lock,
+							time_lock,
+							recipient_address,
+							amount,
+						) => {
+							this.events.push(AbstractBlockchainEvent::CounterpartyContractEvent(
+								this.counterparty_contract.lock_bridge_transfer(
+									bridge_transfer_id.clone(),
+									hash_lock.clone(),
+									time_lock.clone(),
+									recipient_address.clone(),
+									amount,
+								),
+							));
+						}
+						CounterpartyCall::CompleteBridgeTransfer(bridge_transfer_id, pre_image) => {
+							this.events.push(AbstractBlockchainEvent::CounterpartyContractEvent(
+								this.counterparty_contract.complete_bridge_transfer(
+									&mut this.accounts,
+									&bridge_transfer_id,
+									pre_image,
+								),
+							));
+						}
+					},
+				}
+			}
+			Poll::Ready(None) => {
+				tracing::warn!("AbstractBlockchain[{}]: Transaction receiver dropped", this.name);
+			}
+			Poll::Pending => {
+				tracing::trace!(
+					"AbstractBlockchain[{}]: No events in transaction_receiver",
+					this.name
+				);
+			}
+		}
+
+		if let Some(event) = this.events.pop() {
+			for listener in &mut this.event_listeners {
+				tracing::trace!("AbstractBlockchain[{}]: Sending event to listener", this.name);
+				listener.unbounded_send(event.clone()).expect("listener dropped");
+			}
+
+			tracing::trace!("AbstractBlockchain[{}]: Poll::Ready({:?})", this.name, event);
+			return Poll::Ready(Some(event));
+		}
+
+		tracing::trace!("AbstractBlockchain[{}]: Poll::Pending", this.name);
+		Poll::Pending
+	}
+}

--- a/protocol-units/bridge/shared/tests/shared/testing/blockchain/client.rs
+++ b/protocol-units/bridge/shared/tests/shared/testing/blockchain/client.rs
@@ -1,0 +1,346 @@
+use async_trait::async_trait;
+use bridge_shared::{
+	bridge_contracts::{
+		BridgeContractCounterparty, BridgeContractCounterpartyError,
+		BridgeContractCounterpartyResult, BridgeContractInitiator, BridgeContractInitiatorError,
+		BridgeContractInitiatorResult,
+	},
+	types::{
+		Amount, BridgeAddressType, BridgeHashType, BridgeTransferDetails, BridgeTransferId,
+		HashLock, HashLockPreImage, InitiatorAddress, RecipientAddress, TimeLock,
+	},
+};
+use dashmap::DashMap;
+use futures::channel::mpsc;
+use std::sync::Arc;
+use thiserror::Error;
+
+use crate::shared::testing::rng::RngSeededClone;
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone)]
+pub enum MethodName {
+	InitiateBridgeTransfer,
+	CompleteBridgeTransferInitiator,
+	CompleteBridgeTransferCounterparty,
+	RefundBridgeTransfer,
+	GetBridgeTransferDetails,
+	LockBridgeTransferAssets,
+	AbortBridgeTransfer,
+}
+
+impl CallConfig {
+	pub fn get_initiator_error(&self) -> Result<(), BridgeContractInitiatorError> {
+		match &self.error {
+			ErrorConfig::None => Ok(()),
+			ErrorConfig::InitiatorError(e) => Err(e.clone()),
+			ErrorConfig::CounterpartyError(_) => {
+				panic!("Unexpected CounterpartyError for Initiator method")
+			}
+			ErrorConfig::CustomError(e) => {
+				Err(BridgeContractInitiatorError::GenericError(format!("Custom error: {}", e)))
+			}
+		}
+	}
+
+	pub fn get_counterparty_error(&self) -> Result<(), BridgeContractCounterpartyError> {
+		match &self.error {
+			ErrorConfig::None => Ok(()),
+			ErrorConfig::CounterpartyError(e) => Err(e.clone()),
+			ErrorConfig::InitiatorError(_) => {
+				panic!("Unexpected InitiatorError for Counterparty method")
+			}
+			ErrorConfig::CustomError(e) => {
+				Err(BridgeContractCounterpartyError::GenericError(format!("Custom error: {}", e)))
+			}
+		}
+	}
+}
+
+use super::{CounterpartyCall, InitiatorCall, Transaction};
+
+#[derive(Debug, Error, Clone)]
+pub enum AbstractBlockchainClientError {
+	#[error("Failed to send transaction")]
+	SendError,
+	#[error("Random failure occurred")]
+	RandomFailure,
+}
+
+#[derive(Clone, Debug)]
+pub enum ErrorConfig {
+	None,
+	InitiatorError(BridgeContractInitiatorError),
+	CounterpartyError(BridgeContractCounterpartyError),
+	CustomError(AbstractBlockchainClientError),
+}
+
+#[derive(Debug, Clone)]
+pub struct CallConfig {
+	pub error: ErrorConfig,
+	pub delay: Option<std::time::Duration>,
+}
+
+impl Default for CallConfig {
+	fn default() -> Self {
+		Self { error: ErrorConfig::None, delay: None }
+	}
+}
+
+impl<A, H, R> AbstractBlockchainClient<A, H, R>
+where
+	A: std::fmt::Debug,
+	H: std::fmt::Debug,
+	R: RngSeededClone,
+{
+	pub fn set_call_config(&mut self, method: MethodName, call_index: usize, config: CallConfig) {
+		assert!(call_index > 0, "call_index must be greater than 0");
+		if let Some(mut call_list) = self.call_configs.get_mut(&method) {
+			if call_list.iter().any(|(idx, _)| *idx == call_index) {
+				// Handle the case of duplicate entry here if needed
+				panic!(
+					"Duplicate entry found for method '{:?}' and call_index {}",
+					method, call_index
+				);
+			} else {
+				call_list.push((call_index, config));
+			}
+		} else {
+			self.call_configs.entry(method).or_default().push((call_index, config));
+		}
+	}
+
+	pub fn clear_call_configs(&mut self) {
+		self.call_configs.clear();
+	}
+
+	fn register_call(&mut self, method: MethodName) {
+		if let Some(mut call_list) = self.call_configs.get_mut(&method) {
+			call_list.retain_mut(|(call_index, _)| {
+				if *call_index == 0 {
+					false
+				} else {
+					*call_index -= 1;
+					true
+				}
+			});
+		}
+	}
+
+	fn have_call_config(&self, method: MethodName) -> Option<CallConfig> {
+		self.call_configs.get(&method).and_then(|configs| {
+			configs
+				.iter()
+				.find(|config| config.0 == 0)
+				.map(|found_config| &found_config.1)
+				.cloned()
+		})
+	}
+}
+
+#[derive(Clone)]
+pub struct AbstractBlockchainClient<A, H, R> {
+	pub transaction_sender: mpsc::UnboundedSender<Transaction<A, H>>,
+	pub rng: R,
+	pub failure_rate: f64,
+	pub false_positive_rate: f64,
+	pub call_configs: Arc<DashMap<MethodName, Vec<(usize, CallConfig)>>>,
+}
+
+impl<A, H, R> AbstractBlockchainClient<A, H, R>
+where
+	A: std::fmt::Debug,
+	H: std::fmt::Debug,
+	R: RngSeededClone,
+{
+	pub fn new(
+		transaction_sender: mpsc::UnboundedSender<Transaction<A, H>>,
+		rng: R,
+		failure_rate: f64,
+		false_positive_rate: f64,
+	) -> Self {
+		Self {
+			transaction_sender,
+			rng,
+			failure_rate,
+			false_positive_rate,
+			call_configs: Default::default(),
+		}
+	}
+
+	pub fn send_transaction(
+		&mut self,
+		transaction: Transaction<A, H>,
+	) -> Result<(), AbstractBlockchainClientError> {
+		let random_value: f64 = self.rng.gen();
+
+		if random_value < self.failure_rate {
+			tracing::trace!("AbstractBlockchainClient: Sending RANDOM_FAILURE {:?}", transaction);
+			return Err(AbstractBlockchainClientError::RandomFailure);
+		}
+
+		if random_value < self.false_positive_rate {
+			tracing::trace!("AbstractBlockchainClient: Sending FALSE_POSITIVE {:?}", transaction);
+			return Ok(());
+		}
+
+		tracing::trace!("AbstractBlockchainClient: Sending transaction: {:?}", transaction);
+		self.transaction_sender
+			.unbounded_send(transaction)
+			.map_err(|_| AbstractBlockchainClientError::SendError)
+	}
+}
+
+#[async_trait]
+impl<A, H, R> BridgeContractInitiator for AbstractBlockchainClient<A, H, R>
+where
+	A: BridgeAddressType,
+	H: BridgeHashType,
+	R: RngSeededClone + Send + Sync + Unpin + Clone,
+{
+	type Address = A;
+	type Hash = H;
+
+	async fn initiate_bridge_transfer(
+		&mut self,
+		initiator_address: InitiatorAddress<Self::Address>,
+		recipient_address: RecipientAddress,
+		hash_lock: HashLock<Self::Hash>,
+		time_lock: TimeLock,
+		amount: Amount,
+	) -> BridgeContractInitiatorResult<()> {
+		let transaction = Transaction::Initiator(InitiatorCall::InitiateBridgeTransfer(
+			initiator_address,
+			recipient_address,
+			amount,
+			time_lock,
+			hash_lock,
+		));
+		self.register_call(MethodName::InitiateBridgeTransfer);
+		if let Some(config) = self.have_call_config(MethodName::InitiateBridgeTransfer) {
+			if let Some(delay) = config.delay {
+				tokio::time::sleep(delay).await;
+			}
+			config.get_initiator_error()?;
+		}
+
+		self.send_transaction(transaction)
+			.map_err(BridgeContractInitiatorError::generic)
+	}
+
+	async fn complete_bridge_transfer(
+		&mut self,
+		bridge_transfer_id: BridgeTransferId<Self::Hash>,
+		secret: HashLockPreImage,
+	) -> BridgeContractInitiatorResult<()> {
+		tracing::error!(
+			"Intitiator complete_bridge_transfer {:?} {:?}",
+			bridge_transfer_id,
+			secret
+		);
+		self.register_call(MethodName::CompleteBridgeTransferInitiator);
+		if let Some(config) = self.have_call_config(MethodName::CompleteBridgeTransferInitiator) {
+			if let Some(delay) = config.delay {
+				tokio::time::sleep(delay).await;
+			}
+			config.get_initiator_error()?;
+		}
+
+		let transaction = Transaction::Initiator(InitiatorCall::CompleteBridgeTransfer(
+			bridge_transfer_id,
+			secret,
+		));
+		self.send_transaction(transaction)
+			.map_err(BridgeContractInitiatorError::generic)
+	}
+
+	async fn refund_bridge_transfer(
+		&mut self,
+		_bridge_transfer_id: BridgeTransferId<Self::Hash>,
+	) -> BridgeContractInitiatorResult<()> {
+		unimplemented!()
+	}
+
+	async fn get_bridge_transfer_details(
+		&mut self,
+		_bridge_transfer_id: BridgeTransferId<Self::Hash>,
+	) -> BridgeContractInitiatorResult<Option<BridgeTransferDetails<Self::Hash, Self::Address>>> {
+		unimplemented!()
+	}
+}
+
+#[async_trait]
+impl<A, H, R> BridgeContractCounterparty for AbstractBlockchainClient<A, H, R>
+where
+	A: BridgeAddressType,
+	H: BridgeHashType,
+	R: RngSeededClone + Send + Sync + Unpin + Clone,
+{
+	type Address = A;
+	type Hash = H;
+
+	async fn lock_bridge_transfer_assets(
+		&mut self,
+		bridge_transfer_id: BridgeTransferId<Self::Hash>,
+		hash_lock: HashLock<Self::Hash>,
+		time_lock: TimeLock,
+		recipient: RecipientAddress,
+		amount: Amount,
+	) -> BridgeContractCounterpartyResult<()> {
+		self.register_call(MethodName::LockBridgeTransferAssets);
+		if let Some(config) = self.have_call_config(MethodName::LockBridgeTransferAssets) {
+			tracing::error!("lock_bridge_transfer_assets {:?}", config);
+			if let Some(delay) = config.delay {
+				tokio::time::sleep(delay).await;
+			}
+			config.get_counterparty_error()?;
+		}
+
+		let transaction = Transaction::Counterparty(CounterpartyCall::LockBridgeTransfer(
+			bridge_transfer_id,
+			hash_lock,
+			time_lock,
+			recipient,
+			amount,
+		));
+		self.send_transaction(transaction)
+			.map_err(BridgeContractCounterpartyError::generic)
+	}
+
+	async fn complete_bridge_transfer(
+		&mut self,
+		bridge_transfer_id: BridgeTransferId<Self::Hash>,
+		secret: HashLockPreImage,
+	) -> BridgeContractCounterpartyResult<()> {
+		self.register_call(MethodName::CompleteBridgeTransferCounterparty);
+		if let Some(config) = self.have_call_config(MethodName::CompleteBridgeTransferCounterparty)
+		{
+			tracing::error!("complete_bridge_transfer {:?}", config);
+			if let Some(delay) = config.delay {
+				tokio::time::sleep(delay).await;
+			}
+			config.get_counterparty_error()?;
+		}
+
+		let transaction = Transaction::Counterparty(CounterpartyCall::CompleteBridgeTransfer(
+			bridge_transfer_id,
+			secret,
+		));
+		self.send_transaction(transaction)
+			.map_err(BridgeContractCounterpartyError::generic)
+	}
+
+	async fn abort_bridge_transfer(
+		&mut self,
+		_bridge_transfer_id: BridgeTransferId<Self::Hash>,
+	) -> BridgeContractCounterpartyResult<()> {
+		unimplemented!()
+	}
+
+	async fn get_bridge_transfer_details(
+		&mut self,
+		_bridge_transfer_id: BridgeTransferId<Self::Hash>,
+	) -> BridgeContractCounterpartyResult<Option<BridgeTransferDetails<Self::Hash, Self::Address>>>
+	{
+		unimplemented!()
+	}
+}

--- a/protocol-units/bridge/shared/tests/shared/testing/blockchain/counterparty_contract.rs
+++ b/protocol-units/bridge/shared/tests/shared/testing/blockchain/counterparty_contract.rs
@@ -1,0 +1,112 @@
+use std::collections::HashMap;
+
+use bridge_shared::types::{
+	Amount, BridgeAddressType, BridgeHashType, BridgeTransferId, CompletedDetails, GenUniqueHash,
+	HashLock, HashLockPreImage, LockDetails, RecipientAddress, TimeLock,
+};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SmartContractCounterpartyEvent<H> {
+	LockedBridgeTransfer(LockDetails<H>),
+	CompletedBridgeTransfer(CompletedDetails<H>),
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum SmartContractCounterpartyError {
+	#[error("Transfer not found")]
+	TransferNotFound,
+	#[error("Invalid hash lock pre image (secret)")]
+	InvalidHashLockPreImage,
+}
+
+#[derive(Debug)]
+pub enum CounterpartyCall<H> {
+	CompleteBridgeTransfer(BridgeTransferId<H>, HashLockPreImage),
+	LockBridgeTransfer(BridgeTransferId<H>, HashLock<H>, TimeLock, RecipientAddress, Amount),
+}
+
+#[derive(Debug)]
+pub struct SmartContractCounterparty<A, H> {
+	pub locked_transfers: HashMap<BridgeTransferId<H>, LockDetails<H>>,
+	pub _phantom: std::marker::PhantomData<A>,
+}
+
+pub type SCCResult<H> = Result<SmartContractCounterpartyEvent<H>, SmartContractCounterpartyError>;
+
+impl<A, H> SmartContractCounterparty<A, H>
+where
+	A: BridgeAddressType + From<RecipientAddress>,
+	H: BridgeHashType + GenUniqueHash,
+	H: From<HashLockPreImage>,
+{
+	pub fn new() -> Self {
+		Self { locked_transfers: HashMap::new(), _phantom: std::marker::PhantomData }
+	}
+
+	pub fn lock_bridge_transfer(
+		&mut self,
+
+		bridge_transfer_id: BridgeTransferId<H>,
+		hash_lock: HashLock<H>,
+		time_lock: TimeLock,
+		recipient_address: RecipientAddress,
+		amount: Amount,
+	) -> SCCResult<H> {
+		tracing::trace!(
+			"SmartContractCounterparty: Locking bridge transfer: {:?}",
+			bridge_transfer_id
+		);
+		self.locked_transfers.insert(
+			bridge_transfer_id.clone(),
+			LockDetails {
+				bridge_transfer_id: bridge_transfer_id.clone(),
+				recipient_address: recipient_address.clone(),
+				hash_lock: hash_lock.clone(),
+				time_lock: time_lock.clone(),
+				amount,
+			},
+		);
+
+		Ok(SmartContractCounterpartyEvent::LockedBridgeTransfer(LockDetails {
+			bridge_transfer_id,
+			recipient_address,
+			hash_lock,
+			time_lock,
+			amount,
+		}))
+	}
+
+	pub fn complete_bridge_transfer(
+		&mut self,
+		accounts: &mut HashMap<A, Amount>,
+		bridge_transfer_id: &BridgeTransferId<H>,
+		pre_image: HashLockPreImage,
+	) -> SCCResult<H> {
+		let transfer = self
+			.locked_transfers
+			.remove(bridge_transfer_id)
+			.ok_or(SmartContractCounterpartyError::TransferNotFound)?;
+
+		tracing::trace!("SmartContractCounterparty: Completing bridge transfer: {:?}", transfer);
+
+		// check if the secret is correct
+		let secret_hash = H::from(pre_image.clone());
+		if transfer.hash_lock.0 != secret_hash {
+			tracing::warn!(
+				"Invalid hash lock pre image {pre_image:?} hash {secret_hash:?} != hash_lock {:?}",
+				transfer.hash_lock.0
+			);
+			return Err(SmartContractCounterpartyError::InvalidHashLockPreImage);
+		}
+
+		// TODO: fix this
+		let account = A::from(transfer.recipient_address.clone());
+		let balance = accounts.entry(account).or_insert(Amount(0));
+		**balance += *transfer.amount;
+
+		Ok(SmartContractCounterpartyEvent::CompletedBridgeTransfer(
+			CompletedDetails::from_lock_details(transfer, pre_image),
+		))
+	}
+}

--- a/protocol-units/bridge/shared/tests/shared/testing/blockchain/hasher.rs
+++ b/protocol-units/bridge/shared/tests/shared/testing/blockchain/hasher.rs
@@ -1,0 +1,18 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+pub fn calculate_hash<T: Hash>(t: &T) -> u64 {
+	let mut s = DefaultHasher::new();
+	t.hash(&mut s);
+	s.finish()
+}
+
+#[test]
+fn test_calculate_hash() {
+	let a = "hash";
+	let b = "hash";
+	let c = "other";
+
+	assert_eq!(calculate_hash(&a), calculate_hash(&b));
+	assert_ne!(calculate_hash(&a), calculate_hash(&c));
+}

--- a/protocol-units/bridge/shared/tests/shared/testing/blockchain/initiator_contract.rs
+++ b/protocol-units/bridge/shared/tests/shared/testing/blockchain/initiator_contract.rs
@@ -1,0 +1,121 @@
+use std::collections::HashMap;
+
+use rand::Rng;
+use thiserror::Error;
+
+use bridge_shared::types::{
+	Amount, BridgeAddressType, BridgeHashType, BridgeTransferDetails, BridgeTransferId,
+	GenUniqueHash, HashLock, HashLockPreImage, InitiatorAddress, RecipientAddress, TimeLock,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SmartContractInitiatorEvent<A, H> {
+	InitiatedBridgeTransfer(BridgeTransferDetails<A, H>),
+	CompletedBridgeTransfer(BridgeTransferId<H>, HashLockPreImage),
+}
+
+#[derive(Debug)]
+pub enum InitiatorCall<A, H> {
+	InitiateBridgeTransfer(InitiatorAddress<A>, RecipientAddress, Amount, TimeLock, HashLock<H>),
+	CompleteBridgeTransfer(BridgeTransferId<H>, HashLockPreImage),
+}
+
+#[derive(Debug)]
+pub struct SmartContractInitiator<A, H, R> {
+	pub initiated_transfers: HashMap<BridgeTransferId<H>, BridgeTransferDetails<A, H>>,
+	pub accounts: HashMap<A, Amount>,
+	pub rng: R,
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum SmartContractInitiatorError {
+	#[error("Failed to initiate bridge transfer")]
+	InitiateTransferError,
+	#[error("Transfer not found")]
+	TransferNotFound,
+	#[error("Invalid hash lock pre image (secret)")]
+	InvalidHashLockPreImage,
+}
+
+pub type SCIResult<A, H> = Result<SmartContractInitiatorEvent<A, H>, SmartContractInitiatorError>;
+
+impl<A, H, R> SmartContractInitiator<A, H, R>
+where
+	A: BridgeAddressType,
+	H: BridgeHashType + GenUniqueHash,
+	R: Rng,
+	H: From<HashLockPreImage>,
+{
+	pub fn new(rng: R) -> Self {
+		Self { initiated_transfers: HashMap::new(), accounts: HashMap::default(), rng }
+	}
+
+	pub fn initiate_bridge_transfer(
+		&mut self,
+		initiator: InitiatorAddress<A>,
+		recipient: RecipientAddress,
+		amount: Amount,
+		time_lock: TimeLock,
+		hash_lock: HashLock<H>,
+	) -> SCIResult<A, H> {
+		let bridge_transfer_id = BridgeTransferId::<H>::gen_unique_hash(&mut self.rng);
+
+		tracing::trace!(
+			"SmartContractInitiator: Initiating bridge transfer: {:?}",
+			bridge_transfer_id
+		);
+
+		// // TODO: fix this
+		// let balance = self.accounts.entry(initiator.0.clone()).or_insert(Amount(0));
+		// **balance -= amount.0;
+
+		// initiate bridge transfer
+		self.initiated_transfers.insert(
+			bridge_transfer_id.clone(),
+			BridgeTransferDetails {
+				bridge_transfer_id: bridge_transfer_id.clone(),
+				initiator_address: initiator.clone(),
+				recipient_address: recipient.clone(),
+				hash_lock: hash_lock.clone(),
+				time_lock: time_lock.clone(),
+				amount,
+			},
+		);
+
+		Ok(SmartContractInitiatorEvent::InitiatedBridgeTransfer(BridgeTransferDetails {
+			bridge_transfer_id,
+			initiator_address: initiator,
+			recipient_address: recipient,
+			hash_lock,
+			time_lock,
+			amount,
+		}))
+	}
+
+	pub fn complete_bridge_transfer(
+		&mut self,
+		accounts: &mut HashMap<A, Amount>,
+		transfer_id: BridgeTransferId<H>,
+		pre_image: HashLockPreImage,
+	) -> SCIResult<A, H> {
+		tracing::trace!("SmartContractInitiator: Completing bridge transfer: {:?}", transfer_id);
+
+		// complete bridge transfer
+		let transfer = self
+			.initiated_transfers
+			.get(&transfer_id)
+			.ok_or(SmartContractInitiatorError::TransferNotFound)?;
+
+		// check if the secret is correct
+		let secret_hash = H::from(pre_image.clone());
+		if transfer.hash_lock.0 != secret_hash {
+			tracing::warn!(
+				"Invalid hash lock pre image {pre_image:?} hash {secret_hash:?} != hash_lock {:?}",
+				transfer.hash_lock.0
+			);
+			return Err(SmartContractInitiatorError::InvalidHashLockPreImage);
+		}
+
+		Ok(SmartContractInitiatorEvent::CompletedBridgeTransfer(transfer_id, pre_image))
+	}
+}

--- a/protocol-units/bridge/shared/tests/shared/testing/mocks.rs
+++ b/protocol-units/bridge/shared/tests/shared/testing/mocks.rs
@@ -1,0 +1,350 @@
+use delegate::delegate;
+use futures::{Stream, StreamExt};
+use std::{pin::Pin, sync::Arc};
+use std::{
+	sync::Mutex,
+	task::{Context, Poll},
+};
+
+use bridge_shared::{
+	blockchain_service::{BlockchainService, ContractEvent},
+	bridge_contracts::BridgeContractCounterpartyResult,
+	types::{HashLock, InitiatorAddress, RecipientAddress, TimeLock},
+};
+use bridge_shared::{
+	bridge_contracts::BridgeContractInitiatorResult,
+	types::{BridgeAddressType, BridgeHashType, BridgeTransferDetails, BridgeTransferId},
+};
+use bridge_shared::{
+	bridge_contracts::{BridgeContractCounterparty, BridgeContractInitiator},
+	types::Amount,
+};
+use bridge_shared::{
+	bridge_monitoring::{
+		BridgeContractCounterpartyEvent, BridgeContractCounterpartyMonitoring,
+		BridgeContractInitiatorEvent, BridgeContractInitiatorMonitoring,
+	},
+	types::HashLockPreImage,
+};
+
+pub struct MockBlockchainService<A, H> {
+	pub initiator_contract: MockInitiatorContract<A, H>,
+	pub initiator_monitoring: MockInitiatorMonitoring<A, H>,
+	pub counterparty_contract: MockCounterpartyContract<A, H>,
+	pub counterparty_monitoring: MockCounterpartyMonitoring<A, H>,
+}
+
+impl<A, H> MockBlockchainService<A, H> {
+	pub fn build() -> Self {
+		Self {
+			initiator_contract: MockInitiatorContract::build(),
+			initiator_monitoring: MockInitiatorMonitoring::build(),
+			counterparty_contract: MockCounterpartyContract::build(),
+			counterparty_monitoring: MockCounterpartyMonitoring::build(),
+		}
+	}
+}
+
+impl<A, H> BlockchainService for MockBlockchainService<A, H>
+where
+	A: BridgeAddressType,
+	H: BridgeHashType,
+{
+	type Address = A;
+	type Hash = H;
+
+	type InitiatorContract = MockInitiatorContract<A, H>;
+	type InitiatorMonitoring = MockInitiatorMonitoring<A, H>;
+
+	type CounterpartyContract = MockCounterpartyContract<A, H>;
+	type CounterpartyMonitoring = MockCounterpartyMonitoring<A, H>;
+
+	fn initiator_contract(&self) -> &Self::InitiatorContract {
+		&self.initiator_contract
+	}
+
+	fn initiator_monitoring(&mut self) -> &mut Self::InitiatorMonitoring {
+		&mut self.initiator_monitoring
+	}
+
+	fn counterparty_contract(&self) -> &Self::CounterpartyContract {
+		&self.counterparty_contract
+	}
+
+	fn counterparty_monitoring(&mut self) -> &mut Self::CounterpartyMonitoring {
+		&mut self.counterparty_monitoring
+	}
+}
+
+impl<A, H> Stream for MockBlockchainService<A, H>
+where
+	A: BridgeAddressType,
+	H: BridgeHashType,
+{
+	type Item =
+		ContractEvent<<Self as BlockchainService>::Address, <Self as BlockchainService>::Hash>;
+
+	fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		let this = self.get_mut();
+
+		if let Poll::Ready(Some(event)) = this.poll_next_event(cx) {
+			return Poll::Ready(Some(event));
+		}
+
+		// poll the events from the contracts and forward them
+		if let Poll::Ready(Some(event)) = this.initiator_contract.poll_next_unpin(cx) {
+			return Poll::Ready(Some(ContractEvent::InitiatorEvent(event)));
+		}
+
+		Poll::Pending
+	}
+}
+
+pub struct MockInitiatorMonitoring<A, H> {
+	pub events: Vec<BridgeContractInitiatorEvent<A, H>>,
+}
+
+impl<A, H> MockInitiatorMonitoring<A, H> {
+	pub fn build() -> Self {
+		Self { events: Default::default() }
+	}
+}
+
+impl<A, H> BridgeContractInitiatorMonitoring for MockInitiatorMonitoring<A, H>
+where
+	A: std::fmt::Debug + Unpin,
+	H: std::fmt::Debug + Unpin,
+{
+	type Address = A;
+	type Hash = H;
+}
+
+impl<A, H> Stream for MockInitiatorMonitoring<A, H>
+where
+	A: std::fmt::Debug + Unpin,
+	H: std::fmt::Debug + Unpin,
+{
+	type Item = BridgeContractInitiatorEvent<A, H>;
+
+	fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		let this = self.get_mut();
+		if let Some(event) = this.events.pop() {
+			Poll::Ready(Some(event))
+		} else {
+			Poll::Pending
+		}
+	}
+}
+
+pub struct MockCounterpartyMonitoring<A, H> {
+	pub events: Vec<BridgeContractCounterpartyEvent<H>>,
+	pub _phantom: std::marker::PhantomData<A>,
+}
+
+impl<A, H> MockCounterpartyMonitoring<A, H> {
+	pub fn build() -> Self {
+		Self { events: Default::default(), _phantom: Default::default() }
+	}
+}
+
+impl<A, H> BridgeContractCounterpartyMonitoring for MockCounterpartyMonitoring<A, H>
+where
+	A: std::fmt::Debug + Unpin,
+	H: std::fmt::Debug + Unpin,
+{
+	type Address = A;
+	type Hash = H;
+}
+
+impl<A, H> Stream for MockCounterpartyMonitoring<A, H>
+where
+	A: std::fmt::Debug + Unpin,
+	H: std::fmt::Debug + Unpin,
+{
+	type Item = BridgeContractCounterpartyEvent<H>;
+
+	fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		let this = self.get_mut();
+		if let Some(event) = this.events.pop() {
+			Poll::Ready(Some(event))
+		} else {
+			Poll::Pending
+		}
+	}
+}
+
+#[derive(Debug)]
+pub struct MockInitiatorContractState<A, H> {
+	events: Vec<BridgeContractInitiatorEvent<A, H>>,
+	mock_next_bridge_transfer_id: Option<BridgeTransferId<H>>,
+	_phantom: std::marker::PhantomData<(A, H)>,
+}
+
+impl<A, H> Default for MockInitiatorContractState<A, H> {
+	fn default() -> Self {
+		Self {
+			events: Default::default(),
+			mock_next_bridge_transfer_id: Default::default(),
+			_phantom: Default::default(),
+		}
+	}
+}
+
+impl<A, H> MockInitiatorContractState<A, H> {
+	pub fn with_next_bridge_transfer_id(&mut self, id: H) -> &mut Self {
+		self.mock_next_bridge_transfer_id = Some(BridgeTransferId(id));
+		self
+	}
+}
+
+#[derive(Debug, Clone)]
+pub struct MockInitiatorContract<A, H> {
+	state: Arc<Mutex<MockInitiatorContractState<A, H>>>,
+}
+
+impl<A, H> MockInitiatorContract<A, H> {
+	pub fn build() -> Self {
+		Self { state: Arc::new(Mutex::new(MockInitiatorContractState::default())) }
+	}
+
+	pub fn with_next_bridge_transfer_id(&mut self, id: H) -> &mut Self {
+		self.state.lock().expect("lock poisoned").with_next_bridge_transfer_id(id);
+		self
+	}
+
+	delegate! {
+			to self.state.lock().expect("lock poisoned") {
+					// to be delegated
+			}
+
+	}
+}
+
+impl<A, H> Stream for MockInitiatorContract<A, H>
+where
+	A: Unpin,
+	H: Unpin,
+{
+	type Item = BridgeContractInitiatorEvent<A, H>;
+
+	fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		let this = self.get_mut();
+		let mut state = this.state.lock().expect("lock poisoned");
+		if let Some(event) = state.events.pop() {
+			Poll::Ready(Some(event))
+		} else {
+			Poll::Pending
+		}
+	}
+}
+
+#[async_trait::async_trait]
+impl<A, H> BridgeContractInitiator for MockInitiatorContract<A, H>
+where
+	A: BridgeAddressType,
+	H: BridgeHashType,
+{
+	type Address = A;
+	type Hash = H;
+
+	async fn initiate_bridge_transfer(
+		&mut self,
+		initiator_address: InitiatorAddress<Self::Address>,
+		recipient_address: RecipientAddress,
+		hash_lock: HashLock<Self::Hash>,
+		time_lock: TimeLock,
+		amount: Amount,
+	) -> BridgeContractInitiatorResult<()> {
+		let mut state = self.state.lock().expect("lock poisoned");
+		let next_bridge_transfer_id =
+			state.mock_next_bridge_transfer_id.take().expect("no next bridge transfer id");
+		state
+			.events
+			.push(BridgeContractInitiatorEvent::Initiated(BridgeTransferDetails {
+				bridge_transfer_id: next_bridge_transfer_id,
+				initiator_address,
+				recipient_address,
+				hash_lock,
+				time_lock,
+				amount,
+			}));
+		Ok(())
+	}
+
+	async fn complete_bridge_transfer(
+		&mut self,
+		_bridge_transfer_id: BridgeTransferId<Self::Hash>,
+		_secret: HashLockPreImage,
+	) -> BridgeContractInitiatorResult<()> {
+		Ok(())
+	}
+
+	async fn refund_bridge_transfer(
+		&mut self,
+		_bridge_transfer_id: BridgeTransferId<Self::Hash>,
+	) -> BridgeContractInitiatorResult<()> {
+		Ok(())
+	}
+
+	async fn get_bridge_transfer_details(
+		&mut self,
+		_bridge_transfer_id: BridgeTransferId<Self::Hash>,
+	) -> BridgeContractInitiatorResult<Option<BridgeTransferDetails<Self::Hash, Self::Address>>> {
+		Ok(None)
+	}
+}
+
+#[derive(Debug, Clone)]
+pub struct MockCounterpartyContract<A, H> {
+	_phantom: std::marker::PhantomData<(A, H)>,
+}
+
+impl<A, H> MockCounterpartyContract<A, H> {
+	pub fn build() -> Self {
+		Self { _phantom: std::marker::PhantomData }
+	}
+}
+
+#[async_trait::async_trait]
+impl<A, H> BridgeContractCounterparty for MockCounterpartyContract<A, H>
+where
+	A: BridgeAddressType,
+	H: BridgeHashType,
+{
+	type Address = A;
+	type Hash = H;
+
+	async fn lock_bridge_transfer_assets(
+		&mut self,
+		_bridge_transfer_id: BridgeTransferId<Self::Hash>,
+		_hash_lock: HashLock<Self::Hash>,
+		_time_lock: TimeLock,
+		_recipient: RecipientAddress,
+		_amount: Amount,
+	) -> BridgeContractCounterpartyResult<()> {
+		Ok(())
+	}
+
+	async fn complete_bridge_transfer(
+		&mut self,
+		_bridge_transfer_id: BridgeTransferId<Self::Hash>,
+		_secret: HashLockPreImage,
+	) -> BridgeContractCounterpartyResult<()> {
+		Ok(())
+	}
+
+	async fn abort_bridge_transfer(
+		&mut self,
+		_bridge_transfer_id: BridgeTransferId<Self::Hash>,
+	) -> BridgeContractCounterpartyResult<()> {
+		Ok(())
+	}
+
+	async fn get_bridge_transfer_details(
+		&mut self,
+		_bridge_transfer_id: BridgeTransferId<Self::Hash>,
+	) -> BridgeContractCounterpartyResult<Option<BridgeTransferDetails<Self::Hash, Self::Address>>>
+	{
+		Ok(None)
+	}
+}

--- a/protocol-units/bridge/shared/tests/shared/testing/mod.rs
+++ b/protocol-units/bridge/shared/tests/shared/testing/mod.rs
@@ -1,0 +1,5 @@
+#![allow(dead_code)]
+
+pub mod blockchain;
+pub mod mocks;
+pub mod rng;

--- a/protocol-units/bridge/shared/tests/shared/testing/rng.rs
+++ b/protocol-units/bridge/shared/tests/shared/testing/rng.rs
@@ -1,0 +1,23 @@
+use rand::{rngs::StdRng, SeedableRng};
+use rand::{Rng, RngCore};
+use rand_chacha::ChaChaRng;
+
+pub type TestRng = StdRng;
+
+pub trait RngSeededClone: Rng + SeedableRng {
+	fn seeded_clone(&mut self) -> Self;
+}
+
+impl RngSeededClone for StdRng {
+	fn seeded_clone(&mut self) -> Self {
+		self.clone()
+	}
+}
+
+impl RngSeededClone for ChaChaRng {
+	fn seeded_clone(&mut self) -> Self {
+		let mut seed = [0u8; 32];
+		self.fill_bytes(&mut seed);
+		ChaChaRng::from_seed(seed)
+	}
+}

--- a/protocol-units/cryptography/tentacles/proptest-regressions/tests/jellyfish_merkle.txt
+++ b/protocol-units/cryptography/tentacles/proptest-regressions/tests/jellyfish_merkle.txt
@@ -1,4 +1,4 @@
-# Seeds for failure cases proptest has generated in the past. It is
+# Seeds for failure cases proptest has been generated in the past. It is
 # automatically read and these particular cases re-run before any
 # novel cases are generated.
 #

--- a/protocol-units/execution/dof/src/v1.rs
+++ b/protocol-units/execution/dof/src/v1.rs
@@ -368,7 +368,7 @@ mod tests {
 
 		let latest_version = {
 			let db_reader = executor.executor.db.reader.clone();
-			db_reader.get_latest_version()?
+			db_reader.get_synced_version()?
 		};
 		assert_eq!(latest_version, version_to_revert_to);
 

--- a/protocol-units/execution/dof/src/v1.rs
+++ b/protocol-units/execution/dof/src/v1.rs
@@ -3,6 +3,7 @@ use aptos_api::runtime::Apis;
 use maptos_fin_view::FinalityView;
 use maptos_opt_executor::Executor as OptExecutor;
 use movement_types::BlockCommitment;
+use maptos_opt_executor::transaction_pipe::TransactionPipeError;
 
 use async_channel::Sender;
 use async_trait::async_trait;
@@ -50,7 +51,17 @@ impl DynOptFinExecutor for Executor {
 	async fn run_background_tasks(&self) -> Result<(), anyhow::Error> {
 		loop {
 			// readers should be able to run concurrently
-			self.executor.tick_transaction_pipe(self.transaction_channel.clone()).await?;
+			match self.executor.tick_transaction_pipe(self.transaction_channel.clone()).await {
+				Ok(_) => {}
+				Err(e) => match e {
+					TransactionPipeError::TransactionNotAccepted(e) => {
+						// allow the transaction not to be accepted by the mempool
+						// because the client may have sent a bad sequence number
+						tracing::error!("Transaction not accepted: {:?}", e);
+					}
+					_ => anyhow::bail!("Server error: {:?}", e),
+				}, 
+			}
 		}
 	}
 

--- a/protocol-units/execution/dof/src/v1.rs
+++ b/protocol-units/execution/dof/src/v1.rs
@@ -57,7 +57,7 @@ impl DynOptFinExecutor for Executor {
 					TransactionPipeError::TransactionNotAccepted(e) => {
 						// allow the transaction not to be accepted by the mempool
 						// because the client may have sent a bad sequence number
-						tracing::error!("Transaction not accepted: {:?}", e);
+						tracing::warn!("Transaction not accepted: {:?}", e);
 					}
 					_ => anyhow::bail!("Server error: {:?}", e),
 				}, 

--- a/protocol-units/execution/fin-view/src/fin_view.rs
+++ b/protocol-units/execution/fin-view/src/fin_view.rs
@@ -15,18 +15,14 @@ use std::sync::Arc;
 #[derive(Clone)]
 /// The API view into the finalized state of the chain.
 pub struct FinalityView {
-	inner: Arc<AptosFinalityView<Arc<dyn DbReader>>>,
+	inner: Arc<AptosFinalityView>,
 	context: Arc<Context>,
 	listen_url: String,
 }
 
 impl FinalityView {
 	/// Create a new `FinalityView` instance.
-	pub fn new(
-		inner: Arc<AptosFinalityView<Arc<dyn DbReader>>>,
-		context: Arc<Context>,
-		listen_url: String,
-	) -> Self {
+	pub fn new(inner: Arc<AptosFinalityView>, context: Arc<Context>, listen_url: String) -> Self {
 		Self { inner, context, listen_url }
 	}
 

--- a/protocol-units/execution/opt-executor/Cargo.toml
+++ b/protocol-units/execution/opt-executor/Cargo.toml
@@ -38,6 +38,7 @@ futures = { workspace = true }
 async-channel = { workspace = true }
 
 aptos-vm = { workspace = true }
+aptos-vm-validator = { workspace = true }
 aptos-config = { workspace = true }
 aptos-sdk = { workspace = true }
 aptos-crypto = { workspace = true }

--- a/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
+++ b/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
@@ -3,7 +3,10 @@ use aptos_mempool::SubmissionStatus;
 use aptos_mempool::{core_mempool::TimelineState, MempoolClientRequest};
 use aptos_sdk::types::mempool_status::{MempoolStatus, MempoolStatusCode};
 use aptos_types::transaction::SignedTransaction;
+use aptos_vm_validator::vm_validator::TransactionValidation;
+use aptos_vm_validator::vm_validator::VMValidator;
 use futures::StreamExt;
+use std::sync::Arc;
 
 use thiserror::Error;
 
@@ -38,6 +41,20 @@ impl Executor {
 						Some(request) => {
 							match request {
 								MempoolClientRequest::SubmitTransaction(transaction, callback) => {
+									// Pre-execute Tx to validate its content.
+									// Re-create the validator for each Tx because it uses a frozen version of the ledger.
+									let vm_validator = VMValidator::new(Arc::clone(&self.db.reader));
+									let tx_result = vm_validator.validate_transaction(transaction.clone())?;
+									// If the verification failed return the error status.
+									if let Some(vm_status) = tx_result.status() {
+										let ms = MempoolStatus::new(MempoolStatusCode::VmError);
+										let status: SubmissionStatus = (ms, Some(vm_status));
+										callback.send(Ok(status)).map_err(
+											|e| anyhow::anyhow!("Error sending callback: {:?}", e)
+										)?;
+										continue;
+									}
+
 									// add to the mempool
 									{
 
@@ -150,10 +167,8 @@ mod tests {
 	async fn test_pipe_mempool() -> Result<(), anyhow::Error> {
 		// header
 		let mut executor = Executor::try_test_default()?;
-		let user_transaction = create_signed_transaction(
-			0, 
-			executor.maptos_config.chain.maptos_chain_id.clone()
-		);
+		let user_transaction =
+			create_signed_transaction(0, executor.maptos_config.chain.maptos_chain_id.clone());
 
 		// send transaction to mempool
 		let (req_sender, callback) = oneshot::channel();
@@ -241,7 +256,8 @@ mod tests {
 		});
 
 		let api = executor.get_apis();
-		let user_transaction = create_signed_transaction(0, executor.maptos_config.chain.maptos_chain_id.clone());
+		let user_transaction =
+			create_signed_transaction(0, executor.maptos_config.chain.maptos_chain_id.clone());
 		let comparison_user_transaction = user_transaction.clone();
 		let bcs_user_transaction = bcs::to_bytes(&user_transaction)?;
 		let request = SubmitTransactionPost::Bcs(aptos_api::bcs_payload::Bcs(bcs_user_transaction));
@@ -272,7 +288,8 @@ mod tests {
 		let mut user_transactions = BTreeSet::new();
 		let mut comparison_user_transactions = BTreeSet::new();
 		for _ in 0..25 {
-			let user_transaction = create_signed_transaction(0, executor.maptos_config.chain.maptos_chain_id.clone());
+			let user_transaction =
+				create_signed_transaction(0, executor.maptos_config.chain.maptos_chain_id.clone());
 			let bcs_user_transaction = bcs::to_bytes(&user_transaction)?;
 			user_transactions.insert(bcs_user_transaction.clone());
 

--- a/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
+++ b/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
@@ -100,7 +100,7 @@ impl Executor {
 	pub async fn tick_transaction_pipe(
 		&self,
 		transaction_channel: async_channel::Sender<SignedTransaction>,
-	) -> Result<(), anyhow::Error> {
+	) -> Result<(), TransactionPipeError> {
 		self.tick_transaction_reader(transaction_channel.clone()).await?;
 
 		Ok(())

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.76"
+channel = "1.78"
 components = [ "rustfmt", "rust-src", "clippy" ]
 profile = "minimal"


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$
- **Categories**: `protocol-units`

Updates sequence number handling in mempool to not panic executor thread. 

# Changelog

1. Introduces `thiserror` enum for `transaction_pipe`.
2. Catches `MempoolStatus::NotAccepted` in `dof-executor`. 

# Testing

1. e2e tests. 

# Outstanding issues
1. Error types should be introduced elsewhere. 