### PR TITLE
add Tx pre execution when submited

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7145,6 +7145,7 @@ dependencies = [
  "aptos-vm-genesis",
  "aptos-vm-logging",
  "aptos-vm-types",
+ "aptos-vm-validator",
  "async-channel 2.3.1",
  "async-trait",
  "bcs 0.1.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b5
 aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
 aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
 aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
 aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
 aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }

--- a/protocol-units/execution/opt-executor/Cargo.toml
+++ b/protocol-units/execution/opt-executor/Cargo.toml
@@ -38,6 +38,7 @@ futures = { workspace = true }
 async-channel = { workspace = true }
 
 aptos-vm = { workspace = true }
+aptos-vm-validator = { workspace = true }
 aptos-config = { workspace = true }
 aptos-sdk = { workspace = true }
 aptos-crypto = { workspace = true }

--- a/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
+++ b/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
@@ -25,11 +25,11 @@ impl Executor {
 						Some(request) => {
 							match request {
 								MempoolClientRequest::SubmitTransaction(transaction, callback) => {
-									//preexecute Tx to validate its content.
-									//re create the validator for each Tx because it use a frozen version.
+									// Pre-execute Tx to validate its content.
+									// Re-create the validator for each Tx because it uses a frozen version of the ledger.
 									let vm_validator = VMValidator::new(Arc::clone(&self.db.reader));
 									let tx_result = vm_validator.validate_transaction(transaction.clone())?;
-									//if the verification failed return the error status
+									// If the verification failed return the error status.
 									if let Some(vm_status) = tx_result.status() {
 										let ms = MempoolStatus::new(MempoolStatusCode::VmError);
 										let status: SubmissionStatus = (ms, Some(vm_status));


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

<!--
Add your summary text here. 
 -->
When executing the malicious Test, the Suzuka behavior was different from the Aptos node. Some Tx issues were not detected during submission and the client was waiting indefinitely because the execution error weren't seen.
This PR add Tx pre execution when the Tx is submitted.
From the test I've done, the node behavior is the same as the Aptos node.
For example: 
 * INVALID_AUTH_KEY and BAD_CHAIN_ID return during the Tx submission.
 * INSUFFICIENT_BALANCE and WRONG ARGUMENTS return during the Tx waiting.

# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->
# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->
To run the Suzuka node use:
```
CELESTIA_LOG_LEVEL=FATAL nix develop --extra-experimental-features nix-command --extra-experimental-features flakes --command bash  -c "just suzuka-full-node native build.setup.local --keep-tui"
```
Malicious Test can be executed using the branch `eng-442/malicious_load_soak_test`

# Outstanding issues 
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->