### PR TITLE
Improvements to complete_bridge_transfer flow, additional test added

### DIFF
--- a/protocol-units/bridge/move-modules/sources/MOVETH.move
+++ b/protocol-units/bridge/move-modules/sources/MOVETH.move
@@ -321,6 +321,15 @@ module moveth::moveth {
         vector::push_back(&mut roles.minters, minter);
     }
 
+    /// Remove the minter at the end of roles.minters. This checks that the caller is the master minter and the account is the most recently added minter.
+    public entry fun remove_minter(admin: &signer, minter: address) acquires Roles, State {
+        assert_not_paused();
+        let roles = borrow_global_mut<Roles>(moveth_address());
+        assert!(signer::address_of(admin) == roles.admin || signer::address_of(admin) == roles.master_minter, EUNAUTHORIZED);
+        assert!(vector::contains(&roles.minters, &minter), ENOT_MINTER);
+        vector::pop_back(&mut roles.minters);
+    }
+
     fun assert_is_minter(minter: &signer) acquires Roles {
         if (exists<Roles>(moveth_address())) {
         let roles = borrow_global<Roles>(moveth_address());

--- a/protocol-units/bridge/move-modules/sources/atomic_bridge.move
+++ b/protocol-units/bridge/move-modules/sources/atomic_bridge.move
@@ -184,15 +184,6 @@ module atomic_bridge::atomic_bridge_counterparty {
         let recipient = @0xface; 
         let asset = moveth::metadata();
 
-        // the master minter sets client to be a minter
-        // moveth::add_minter(master_minter, signer::address_of(client));
-
-        //client now mints themselves 100 moveth
-        // moveth::mint(client, signer::address_of(client), 100);
-        // assert!(primary_fungible_store::balance(signer::address_of(client), asset) == 100, 0);
-
-
-        // In this case the moveth_minter (2nd param) is also the creator.
         init_module(creator);
 
         let bridge_transfer_id = b"transfer1";
@@ -259,15 +250,6 @@ module atomic_bridge::atomic_bridge_counterparty {
         let recipient = @0xface; 
         let asset = moveth::metadata();
 
-        // the master minter sets client to be a minter
-        // moveth::add_minter(master_minter, signer::address_of(client));
-
-        //client now mints themselves 100 moveth
-        // moveth::mint(client, signer::address_of(client), 100);
-        // assert!(primary_fungible_store::balance(signer::address_of(client), asset) == 100, 0);
-
-
-        // In this case the moveth_minter (2nd param) is also the creator.
         init_module(creator);
 
         let bridge_transfer_id = b"transfer1";

--- a/protocol-units/bridge/move-modules/sources/atomic_bridge.move
+++ b/protocol-units/bridge/move-modules/sources/atomic_bridge.move
@@ -115,6 +115,9 @@ module atomic_bridge::atomic_bridge_counterparty {
         // Mint moveth tokens to the recipient
         moveth::mint(caller, details.recipient, details.amount);
 
+        // Remove caller from the minter list, now that minting is complete
+        moveth::remove_minter(master_minter, signer::address_of(caller));
+
         smart_table::add(&mut bridge_store.completed_transfers, bridge_transfer_id, details);
         event::emit(
             BridgeTransferCompletedEvent {
@@ -167,7 +170,82 @@ module atomic_bridge::atomic_bridge_counterparty {
     use aptos_framework::primary_fungible_store;
 
     #[test(aptos_framework = @0x1, creator = @atomic_bridge, moveth = @moveth, admin = @admin, client = @0xdca, master_minter = @master_minter)]
-    fun test_complete_transfer_assets(
+    fun test_complete_transfer_assets_non_minter(
+        client: &signer,
+        aptos_framework: &signer,
+        master_minter: &signer, 
+        creator: &signer,
+        moveth: &signer,
+    ) acquires BridgeTransferStore, BridgeConfig {
+        timestamp::set_time_has_started_for_testing(aptos_framework);
+        moveth::init_for_test(moveth);
+        let receiver_address = @0xcafe1;
+        let initiator = b"0x123"; //In real world this would be an ethereum address
+        let recipient = @0xface; 
+        let asset = moveth::metadata();
+
+        // the master minter sets client to be a minter
+        // moveth::add_minter(master_minter, signer::address_of(client));
+
+        //client now mints themselves 100 moveth
+        // moveth::mint(client, signer::address_of(client), 100);
+        // assert!(primary_fungible_store::balance(signer::address_of(client), asset) == 100, 0);
+
+
+        // In this case the moveth_minter (2nd param) is also the creator.
+        init_module(creator);
+
+        let bridge_transfer_id = b"transfer1";
+        let pre_image = b"secret";
+        let hash_lock = keccak256(pre_image); // Compute the hash lock using keccak256
+        let time_lock = 3600;
+        let amount = 100;
+
+        let result = lock_bridge_transfer_assets(
+            creator,
+            initiator,
+            bridge_transfer_id,
+            hash_lock,
+            time_lock,
+            recipient,
+            amount
+        );
+
+        assert!(result, 1);
+
+        // Verify that the transfer is stored in pending_transfers
+        let bridge_store = borrow_global<BridgeTransferStore>(signer::address_of(creator));
+        let transfer_details: &BridgeTransferDetails = smart_table::borrow(&bridge_store.pending_transfers, bridge_transfer_id);
+        assert!(transfer_details.recipient == recipient, 2);
+        assert!(transfer_details.initiator == initiator, 3);
+        assert!(transfer_details.amount == amount, 5);
+        assert!(transfer_details.hash_lock == hash_lock, 5);
+
+       let pre_image = b"secret"; 
+       let msg:vector<u8> = b"secret";
+        debug::print(&utf8(msg));
+
+       complete_bridge_transfer(
+           client,
+           bridge_transfer_id,
+           pre_image,
+           master_minter 
+       );
+
+        debug::print(&utf8(msg));
+
+        // Verify that the transfer is stored in completed_transfers
+        let bridge_store = borrow_global<BridgeTransferStore>(signer::address_of(creator));
+        let transfer_details: &BridgeTransferDetails = smart_table::borrow(&bridge_store.completed_transfers, bridge_transfer_id);
+        assert!(transfer_details.recipient == recipient, 1);
+        assert!(transfer_details.amount == amount, 2);
+        assert!(transfer_details.hash_lock == hash_lock, 3);
+        assert!(transfer_details.initiator == initiator, 4);
+    }
+
+        #[test(aptos_framework = @0x1, creator = @atomic_bridge, moveth = @moveth, admin = @admin, client = @minter, master_minter = @master_minter)]
+        #[expected_failure]
+    fun test_complete_transfer_assets_minter(
         client: &signer,
         aptos_framework: &signer,
         master_minter: &signer, 


### PR DESCRIPTION
# Summary

Made it so minter role is removed after minting, so there doesn't accumulate an unneeded list of minters

# Changelog

* Added `remove_minter` function to `moveth` module
* Call `remove_minter` in `complete_bridge_transfer` after minting 
* Wrote test for someone already a minter calling `complete_bridge_transfer` (expected failure)


# Testing

All unit tests pass.

# Outstanding issues
Should be integration-tested with full concrete bridge implementation as we put it all together.