### PR TITLE
Update aptos-core, use 0 as the reward percentage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -721,7 +721,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -734,7 +734,7 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -744,7 +744,7 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-logger",
  "aptos-types",
@@ -758,7 +758,7 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "hex",
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -848,7 +848,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -904,7 +904,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "futures",
  "rustversion",
@@ -914,7 +914,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "shadow-rs",
 ]
@@ -922,7 +922,7 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -947,7 +947,7 @@ dependencies = [
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -959,7 +959,7 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -990,7 +990,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1017,7 +1017,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1070,7 +1070,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1080,7 +1080,7 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
@@ -1127,7 +1127,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1147,7 +1147,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer-schemas"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-schemadb",
@@ -1161,7 +1161,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1192,7 +1192,7 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-infallible",
  "aptos-metrics-core",
@@ -1203,7 +1203,7 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -1219,7 +1219,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-consensus-types",
@@ -1251,7 +1251,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-block-partitioner",
  "aptos-config",
@@ -1281,7 +1281,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -1303,7 +1303,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1323,7 +1323,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-runtimes",
  "core_affinity",
@@ -1336,7 +1336,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1370,7 +1370,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -1384,7 +1384,7 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -1452,7 +1452,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "either",
  "move-core-types",
@@ -1461,7 +1461,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -1476,7 +1476,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -1496,7 +1496,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
@@ -1509,22 +1509,22 @@ dependencies = [
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1552,7 +1552,7 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1562,7 +1562,7 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
@@ -1606,7 +1606,7 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1619,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1629,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-infallible",
  "aptos-log-derive",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
@@ -1666,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -1706,7 +1706,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-types",
  "async-trait",
@@ -1719,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-infallible",
  "bytes 1.6.0",
@@ -1730,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -1739,7 +1739,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -1775,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -1792,7 +1792,7 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1854,7 +1854,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -1865,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-build-info",
  "aptos-infallible",
@@ -1881,7 +1881,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1891,7 +1891,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -1904,7 +1904,7 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-config",
  "aptos-types",
@@ -1929,7 +1929,7 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -1939,7 +1939,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -1951,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "ipnet",
 ]
@@ -1959,7 +1959,7 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -1970,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "aptos-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -1984,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -2007,7 +2007,7 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-config",
  "rocksdb",
@@ -2016,7 +2016,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "rayon",
  "tokio",
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-crypto",
  "aptos-drop-helper",
@@ -2061,7 +2061,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -2083,7 +2083,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2101,7 +2101,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -2119,7 +2119,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-crypto",
  "aptos-infallible",
@@ -2140,7 +2140,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -2151,7 +2151,7 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2162,7 +2162,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2190,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -2208,7 +2208,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -2217,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -2230,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2287,12 +2287,12 @@ dependencies = [
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
@@ -2308,7 +2308,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2358,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-cached-packages",
  "aptos-crypto",
@@ -2379,7 +2379,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -2394,7 +2394,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2416,7 +2416,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -7419,7 +7419,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7436,7 +7436,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -7451,12 +7451,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7471,7 +7471,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-spec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "once_cell",
  "quote",
@@ -7481,7 +7481,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7493,7 +7493,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "fail",
  "move-binary-format",
@@ -7507,7 +7507,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "clap 4.5.9",
@@ -7522,7 +7522,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "clap 4.5.9",
@@ -7552,7 +7552,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "difference",
@@ -7569,7 +7569,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7595,7 +7595,7 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -7626,7 +7626,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -7651,7 +7651,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7670,7 +7670,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "clap 4.5.9",
@@ -7687,7 +7687,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "clap 4.5.9",
@@ -7706,7 +7706,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7734,7 +7734,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -7752,7 +7752,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "hex",
@@ -7765,7 +7765,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -7778,7 +7778,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "codespan",
@@ -7804,7 +7804,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "clap 4.5.9",
@@ -7838,7 +7838,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "atty",
@@ -7865,7 +7865,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7894,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -7911,7 +7911,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "hex",
@@ -7937,7 +7937,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "abstract-domain-derive",
  "codespan-reporting",
@@ -7956,7 +7956,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "hex",
@@ -7979,7 +7979,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "once_cell",
  "serde",
@@ -7988,7 +7988,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "better_any",
  "bytes 1.6.0",
@@ -8003,7 +8003,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "better_any",
@@ -8031,7 +8031,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "better_any",
  "bytes 1.6.0",
@@ -8055,7 +8055,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "anyhow",
  "bytes 1.6.0",
@@ -8070,7 +8070,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b54d443967ff4ce621a84f7c09f9a59a0b03e01c#b54d443967ff4ce621a84f7c09f9a59a0b03e01c"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "bcs 0.1.4",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,36 +93,36 @@ serde_yaml = "0.9.34"
 ## Aptos dependencies
 ### We use a forked version so that we can override dependency versions. This is required
 ### to be avoid dependency conflicts with other Sovereign Labs crates.
-aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c", features = [
+aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77", features = [
     "cloneable-private-keys",
 ] }
-aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
-aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b54d443967ff4ce621a84f7c09f9a59a0b03e01c" }
+aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
 ethereum-types = "0.14.1"
 ethers = "=2.0.10"
@@ -252,7 +252,7 @@ url = "2.2.2"
 x25519-dalek = "1.0.1"
 zstd-sys = "2.0.9"
 inotify = "0.10.2"
-rustix = "0.38.34" 
+rustix = "0.38.34"
 paste = "1.0.15"
 
 

--- a/protocol-units/execution/opt-executor/src/executor/initialization.rs
+++ b/protocol-units/execution/opt-executor/src/executor/initialization.rs
@@ -58,7 +58,7 @@ impl Executor {
 				max_stake: 100_000_000_000_000,
 				recurring_lockup_duration_secs: EPOCH_DURATION_SECS * 2,
 				required_proposer_stake: 0,
-				rewards_apy_percentage: 10,
+				rewards_apy_percentage: 0,
 				voting_duration_secs: EPOCH_DURATION_SECS,
 				voting_power_increase_limit: 50,
 				employee_vesting_start: 1663456089,
@@ -80,7 +80,6 @@ impl Executor {
 		chain_id: ChainId,
 		public_key: &Ed25519PublicKey,
 	) -> Result<(DbReaderWriter, ValidatorSigner), anyhow::Error> {
-
 		let db_rw = DbReaderWriter::new(AptosDB::new_for_test(db_dir));
 		let (genesis, validators) =
 			Self::genesis_change_set_and_validators(chain_id, Some(1), public_key);
@@ -91,15 +90,12 @@ impl Executor {
 		);
 
 		// check for context
-		
+
 		match db_rw.reader.get_latest_ledger_info_option()? {
 			Some(ledger_info) => {
 				// context exists
-				tracing::info!(
-					"Ledger info found, not bootstrapping DB: {:?}",
-					ledger_info
-				);
-			},
+				tracing::info!("Ledger info found, not bootstrapping DB: {:?}", ledger_info);
+			}
 			None => {
 				// context does not exist
 				// simply continue
@@ -112,7 +108,6 @@ impl Executor {
 		}
 
 		Ok((db_rw, validator_signer))
-
 	}
 
 	pub fn bootstrap(
@@ -138,7 +133,7 @@ impl Executor {
 			mempool_client_receiver: Arc::new(RwLock::new(mempool_client_receiver)),
 			node_config: node_config.clone(),
 			context: Arc::new(Context::new(
-				maptos_config.chain.maptos_chain_id.clone(),	
+				maptos_config.chain.maptos_chain_id.clone(),
 				reader,
 				mempool_client_sender,
 				node_config,
@@ -149,7 +144,7 @@ impl Executor {
 				maptos_config.chain.maptos_rest_listen_hostname,
 				maptos_config.chain.maptos_rest_listen_port
 			),
-			maptos_config : maptos_config.clone()
+			maptos_config: maptos_config.clone(),
 		})
 	}
 
@@ -169,5 +164,4 @@ impl Executor {
 		maptos_config.chain.maptos_db_path.replace(value);
 		Self::try_from_config(&maptos_config)
 	}
-
 }


### PR DESCRIPTION
# Summary
- **Categories**: `protocol-units`.

After https://github.com/movementlabsxyz/aptos-core/pull/45, the `rewards_apy_percentage` field in the genesis configuration is used to calculate the rewards without Movement-specific hacks, but this means it has to be set to 0 for our purposes.

# Changelog

* In the Aptos genesis configuration, the `rewards_apy_percentage` parameter is set to 0 to represent the reality of not using rewards on Aptos blockchain level.

# Testing

Currently run tests should pass.