### PR TITLE
ENG-671 Multiple Sources of Truth

### DIFF
--- a/protocol-units/bridge/shared/README.mkd
+++ b/protocol-units/bridge/shared/README.mkd
@@ -1,0 +1,55 @@
+# Bridge Service Based on Atomic Swaps
+
+This repository provides an abstract implementation of a bridge service designed to facilitate atomic swaps between two blockchains. This implementation can serve as the foundation for developing a robust bridge application for cross-chain asset transfers.
+
+## What is an Atomic Swap?
+
+An atomic swap, or cross-chain atomic swap, is a decentralized method of exchanging cryptocurrencies from different blockchains without relying on a trusted third party or centralized exchange. The term "atomic" signifies that the transaction is indivisible: it either completes entirely or not at all, ensuring both parties can securely exchange assets without the risk of fraud.
+
+### Key Concepts of Atomic Swaps:
+1. **Hash Time-Locked Contracts (HTLCs)**: A smart contract mechanism that requires the recipient to acknowledge receiving a payment before a deadline by generating cryptographic proof (hash lock). If the recipient fails to provide this proof, the funds are returned to the sender.
+2. **Hash Locks**: A cryptographic lock that requires a secret (pre-image) to unlock.
+3. **Time Locks**: A condition that defines the time frame in which the cryptographic proof must be provided.
+
+## Overview of the Implementation
+
+This implementation sets up a bridge service that handles the process of initiating and completing atomic swaps between two blockchains. The code is designed to be modular and extensible, allowing for easy integration with various blockchain clients and smart contracts.
+
+### Key Components:
+1. **BridgeServiceConfig**: Configuration for the bridge service, including settings for error handling and contract call timeouts.
+2. **ActiveSwapConfig**: Configuration for active swaps, defining the number of error attempts, delay between attempts, and contract call timeout duration.
+3. **BridgeContractInitiator & BridgeContractCounterparty**: Interfaces for the bridge contracts on the initiating and counterparty blockchains.
+4. **Event Handling**: The bridge service listens for specific contract events to progress through the stages of the swap.
+5. **Swap Stages**:
+   - **Initiation**: The initiator locks assets in a smart contract on Blockchain 1.
+   - **Locking on Counterparty**: The bridge service recognizes the initiation event and locks corresponding assets on Blockchain 2.
+   - **Completion by Client**: The client reveals the hash lock pre-image to complete the swap on Blockchain 2.
+   - **Completion by Bridge Service**: The bridge service completes the swap on Blockchain 1 using the revealed pre-image.
+
+### Usage
+
+To use this implementation, follow these steps:
+
+1. **Set Up Configuration**: Define the configurations for the bridge service and active swaps in `BridgeServiceConfig` and `ActiveSwapConfig`.
+2. **Implement Blockchain Clients**: Create implementations for the blockchain clients (`B1Client` and `B2Client`) to interact with the respective blockchains.
+3. **Deploy Smart Contracts**: Deploy the necessary HTLC smart contracts on both blockchains.
+4. **Run the Bridge Service**: Initialize and run the bridge service to start listening for events and handling swaps.
+
+### Example
+
+The provided integration tests demonstrate the complete workflow of an atomic swap between two blockchains. These tests can be used as a reference for implementing and testing your bridge service.
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_bridge_service_integration_a_to_b() {
+    // Setup and test the bridge service for a swap from Blockchain A to Blockchain B
+}
+```
+
+## Contributing
+
+Contributions to enhance the functionality and compatibility of this bridge service are welcome. Please submit pull requests with clear descriptions and test cases.
+
+## License
+
+This project is licensed under the MIT License. See the LICENSE file for details.

--- a/protocol-units/bridge/shared/src/lib.rs
+++ b/protocol-units/bridge/shared/src/lib.rs
@@ -2,4 +2,6 @@ pub mod blockchain_service;
 pub mod bridge_contracts;
 pub mod bridge_monitoring;
 pub mod bridge_service;
+pub mod multiple_sources_of_truth;
 pub mod types;
+

--- a/protocol-units/bridge/shared/src/multiple_sources_of_truth.rs
+++ b/protocol-units/bridge/shared/src/multiple_sources_of_truth.rs
@@ -1,0 +1,94 @@
+use futures::task::{Context, Poll};
+use futures::{stream::Stream, FutureExt, StreamExt};
+use futures_timer::Delay;
+use std::{
+	cmp::Eq,
+	collections::{HashMap, HashSet},
+	hash::{DefaultHasher, Hash, Hasher},
+	pin::Pin,
+	time::Duration,
+};
+
+struct EventInfo {
+	sources: HashSet<u64>,
+	timestamp: Delay,
+}
+
+pub struct MultipleSourceOfTruth<S, E> {
+	sources: Vec<S>,
+	emitted_events: HashMap<E, EventInfo>,
+	threshold: usize,
+	processed: HashSet<E>,
+	timeout: Duration,
+}
+
+impl<S, E> MultipleSourceOfTruth<S, E>
+where
+	S: Stream<Item = E> + Unpin + Hash,
+	E: Eq + Hash + Clone,
+{
+	pub fn new(sources: Vec<S>, threshold: usize, timeout: Duration) -> Self {
+		Self {
+			sources,
+			emitted_events: HashMap::new(),
+			threshold,
+			processed: HashSet::new(),
+			timeout,
+		}
+	}
+}
+
+pub fn hash_of_source<S: Hash>(source: &S) -> u64 {
+	let mut hasher = DefaultHasher::new();
+	source.hash(&mut hasher);
+	hasher.finish()
+}
+
+impl<S, E> Stream for MultipleSourceOfTruth<S, E>
+where
+	S: Stream<Item = E> + Hash + Unpin,
+	E: Eq + Hash + Clone + Unpin,
+{
+	type Item = E;
+
+	fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		let this = self.get_mut();
+		let mut emitted_event = None;
+
+		// Verwijder verlopen events
+		this.emitted_events.retain(|event, info| match info.timestamp.poll_unpin(cx) {
+			Poll::Ready(()) => {
+				this.processed.insert(event.clone());
+				false
+			}
+			Poll::Pending => true,
+		});
+
+		for source in &mut this.sources {
+			match source.poll_next_unpin(cx) {
+				Poll::Ready(Some(event)) => {
+					if !this.processed.contains(&event) {
+						let info = this.emitted_events.entry(event.clone()).or_insert(EventInfo {
+							sources: HashSet::new(),
+							timestamp: Delay::new(this.timeout),
+						});
+						info.sources.insert(hash_of_source(source));
+						if info.sources.len() >= this.threshold {
+							emitted_event = Some(event.clone());
+							this.processed.insert(event.clone());
+							break;
+						}
+					}
+				}
+				Poll::Ready(None) | Poll::Pending => continue,
+			}
+		}
+
+		if let Some(event) = emitted_event.clone() {
+			this.emitted_events.remove(&event);
+			this.processed.insert(event.clone());
+			return Poll::Ready(Some(event));
+		}
+		Poll::Pending
+	}
+}

--- a/protocol-units/bridge/shared/src/multiple_sources_of_truth.rs
+++ b/protocol-units/bridge/shared/src/multiple_sources_of_truth.rs
@@ -9,6 +9,7 @@ use std::{
 	time::Duration,
 };
 
+#[derive(Debug)]
 struct EventInfo {
 	sources: HashSet<u64>,
 	timestamp: Delay,
@@ -47,48 +48,153 @@ pub fn hash_of_source<S: Hash>(source: &S) -> u64 {
 impl<S, E> Stream for MultipleSourceOfTruth<S, E>
 where
 	S: Stream<Item = E> + Hash + Unpin,
-	E: Eq + Hash + Clone + Unpin,
+	E: Eq + Hash + Clone + Unpin + std::fmt::Debug,
 {
 	type Item = E;
 
+	#[tracing::instrument(skip_all)]
 	fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		tracing::trace!("poll_next called");
 		let this = self.get_mut();
+		tracing::trace!("Current state: {:?}", this.emitted_events);
 		let mut emitted_event = None;
 
-		// Verwijder verlopen events
-		this.emitted_events.retain(|event, info| match info.timestamp.poll_unpin(cx) {
-			Poll::Ready(()) => {
-				this.processed.insert(event.clone());
-				false
+		// Remove expired events
+		this.emitted_events.retain(|event, info| {
+			tracing::trace!("Checking event: {:?}", event);
+			match info.timestamp.poll_unpin(cx) {
+				Poll::Ready(()) => {
+					tracing::trace!("Event expired: {:?}", event);
+					this.processed.insert(event.clone());
+					false
+				}
+				Poll::Pending => true,
 			}
-			Poll::Pending => true,
 		});
 
-		for source in &mut this.sources {
+		for (i, source) in this.sources.iter_mut().enumerate() {
+			let source_span = tracing::trace_span!("source",  i=i, hash=?hash_of_source(source));
+			let _enter_source = source_span.enter();
+			tracing::trace!("polling source");
 			match source.poll_next_unpin(cx) {
 				Poll::Ready(Some(event)) => {
+					let event_span = tracing::trace_span!("event", event=?event);
+					let _enter_event = event_span.enter();
+					tracing::trace!("received event");
 					if !this.processed.contains(&event) {
-						let info = this.emitted_events.entry(event.clone()).or_insert(EventInfo {
-							sources: HashSet::new(),
-							timestamp: Delay::new(this.timeout),
-						});
-						info.sources.insert(hash_of_source(source));
-						if info.sources.len() >= this.threshold {
-							emitted_event = Some(event.clone());
-							this.processed.insert(event.clone());
-							break;
-						}
+						tracing::trace!("already processed");
+						continue;
+					}
+
+					let info = this.emitted_events.entry(event.clone()).or_insert_with(|| {
+						tracing::trace!("new event, initiatlizing event info");
+						EventInfo { sources: HashSet::new(), timestamp: Delay::new(this.timeout) }
+					});
+					info.sources.insert(hash_of_source(source));
+					tracing::trace!("event info: {:?}", info);
+					if info.sources.len() >= this.threshold {
+						tracing::trace!("threshold reached for event, emitting");
+						emitted_event = Some(event.clone());
+						this.processed.insert(event.clone());
+						break;
 					}
 				}
 				Poll::Ready(None) | Poll::Pending => continue,
 			}
 		}
 
-		if let Some(event) = emitted_event.clone() {
+		if let Some(event) = emitted_event {
+			tracing::trace!("Emitting event: {:?}", event);
 			this.emitted_events.remove(&event);
 			this.processed.insert(event.clone());
 			return Poll::Ready(Some(event));
 		}
+		tracing::trace!("No event emitted, returning Poll::Pending");
 		Poll::Pending
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::time::Duration;
+
+	use futures::stream::Stream;
+	use futures::task::{Context, Poll};
+	use std::collections::VecDeque;
+	use std::pin::Pin;
+
+	struct TestSource {
+		name: String,
+		events: VecDeque<(usize, usize)>,
+		event: Option<usize>,
+		delay: Option<Delay>,
+	}
+
+	impl TestSource {
+		fn new(name: &str, events: Vec<(usize, usize)>) -> Self {
+			Self {
+				name: name.to_string(),
+				events: VecDeque::from(events),
+				event: None,
+				delay: None,
+			}
+		}
+	}
+
+	impl Stream for TestSource {
+		type Item = usize;
+
+		#[tracing::instrument(skip_all, fields(name = self.name.as_str()))]
+		fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+			let this = self.get_mut();
+
+			loop {
+				tracing::trace!("poll_next loop");
+				if let Some(delay) = &mut this.delay {
+					match delay.poll_unpin(_cx) {
+						Poll::Ready(()) => {
+							tracing::trace!("emitting event: {:?}", this.event);
+							this.delay = None;
+							return Poll::Ready(this.event.take());
+						}
+						Poll::Pending => return Poll::Pending,
+					}
+				}
+
+				if let Some((event, delay)) = this.events.pop_front() {
+					tracing::trace!("Setting event: {} with delay: {}", event, delay);
+					this.delay = Some(Delay::new(Duration::from_millis(delay as u64)));
+					this.event = Some(event);
+					continue;
+				} else {
+					return Poll::Ready(None);
+				}
+			}
+		}
+	}
+
+	impl std::hash::Hash for TestSource {
+		fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+			self.name.hash(state);
+		}
+	}
+
+	#[test_log::test(tokio::test)]
+	async fn test_multiple_sources_of_truth() {
+		tracing::trace!("test_multiple_sources_of_truth");
+		let source1 = TestSource::new("source1", vec![(1, 100), (2, 100), (3, 100)]);
+		let source2 = TestSource::new("source2", vec![(1, 150), (2, 150), (3, 150)]);
+		let source3 = TestSource::new("source3", vec![(1, 200), (2, 50), (3, 300)]);
+		let sources = vec![source1, source2, source3];
+		let mut msot = MultipleSourceOfTruth::new(sources, 2, Duration::from_secs(5));
+
+		let mut events = Vec::new();
+		while let Some(event) = msot.next().await {
+			tracing::trace!("event: {:?}", event);
+			events.push(event);
+		}
+
+		assert_eq!(events, vec![1, 2, 3]);
 	}
 }


### PR DESCRIPTION
# Summary
- **RFCs**: RFC040
- **Categories**: `protocol-units`.

This pull request introduces a new module `multiple_sources_of_truth` within the `bridge` component of the protocol units. This module is designed to manage multiple streams of input data, ensuring that event handling is based on consensus from multiple sources before considering the data as valid.

# Changelog
- Added a new module `multiple_sources_of_truth.rs` which encapsulates functionality for handling multiple sources of input.
- Updated `lib.rs` in the bridge component to include the new module.

# Testing
The new module needs to be tested for:
1. Correct handling of events from multiple sources.
2. Event consensus mechanism validation.
3. Timeout and flush handling for unconfirmed events.


# Outstanding issues
- Integration of the `multiple_sources_of_truth` module with other parts of the bridge component needs thorough testing.
- Performance implications of the new module on the overall bridge system.
- Further optimizations may be required based on initial testing results.
