### PR TITLE
correct spelling atomic_bridge.move

### DIFF
--- a/protocol-units/bridge/move-modules/sources/atomic_bridge.move
+++ b/protocol-units/bridge/move-modules/sources/atomic_bridge.move
@@ -45,7 +45,7 @@ module atomic_bridge::atomic_bridge_counterparty {
     }
 
     #[event]
-    /// An event triggered upon cancelling a bridge transfer
+    /// An event triggered upon canceling a bridge transfer
     struct BridgeTransferCancelledEvent has store, drop {
         bridge_transfer_id: vector<u8>,
     }


### PR DESCRIPTION
Hello
I fixed some minor spelling issues.
Hope it helps.