### PR TITLE
Make cancellation of mempool request callbacks non-fatal

### DIFF
--- a/protocol-units/execution/opt-executor/Cargo.toml
+++ b/protocol-units/execution/opt-executor/Cargo.toml
@@ -67,6 +67,7 @@ aptos-logger = { workspace = true }
 
 movement-rest = { workspace = true }
 
+[dev-dependencies]
 dirs = { workspace = true }
 tempfile = { workspace = true }
 tracing-test = { workspace = true }

--- a/protocol-units/execution/opt-executor/src/executor/mod.rs
+++ b/protocol-units/execution/opt-executor/src/executor/mod.rs
@@ -4,6 +4,7 @@ pub mod initialization;
 pub mod services;
 pub mod transaction_pipe;
 use anyhow::Context as _;
+use aptos_api::context::Context;
 use aptos_config::config::NodeConfig;
 use aptos_db::AptosDB;
 use aptos_executor::block_executor::BlockExecutor;
@@ -14,7 +15,6 @@ use aptos_vm::AptosVM;
 use futures::channel::mpsc as futures_mpsc;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use aptos_api::context::Context;
 
 /// The `Executor` is responsible for executing blocks and managing the state of the execution
 /// against the `AptosVM`.
@@ -52,8 +52,9 @@ impl Executor {
 		node_config: NodeConfig,
 		maptos_config: maptos_execution_util::config::Config,
 	) -> Result<Self, anyhow::Error> {
-		let (_aptos_db, reader_writer) =
-			DbReaderWriter::wrap(AptosDB::new_for_test(&maptos_config.chain.maptos_db_path.clone().context("No db path provided.")?));
+		let (_aptos_db, reader_writer) = DbReaderWriter::wrap(AptosDB::new_for_test(
+			&maptos_config.chain.maptos_db_path.clone().context("No db path provided.")?,
+		));
 		let core_mempool = Arc::new(RwLock::new(CoreMempool::new(&node_config)));
 		let reader = reader_writer.reader.clone();
 		Ok(Self {

--- a/protocol-units/execution/opt-executor/src/lib.rs
+++ b/protocol-units/execution/opt-executor/src/lib.rs
@@ -1,4 +1,3 @@
 #[warn(unused_imports)]
 pub mod executor;
 pub use executor::*;
- 


### PR DESCRIPTION
# Summary
- **Categories**: `protocol-units`.

When a mempool client request get passed with a oneshot callback,
the recipient of the callback may be dropped if the client
has cancelled the request. This condition should not be fatal
for the executor's transaction pipe.

# Testing

`cargo test -p maptos-opt-executor`

Will add a test to exercise the non-fatal handling specifically.
