### PR TITLE
update with last version of the load and soak fwk

### DIFF
--- a/networks/suzuka/suzuka-client/src/load_soak_testing/mod.rs
+++ b/networks/suzuka/suzuka-client/src/load_soak_testing/mod.rs
@@ -70,7 +70,7 @@ impl ExecutionConfig {
 			TestKind::Load { number_scenarios } => {
 				assert!(
 					number_scenarios >= self.number_scenario_per_client,
-					"Number of running scenario less than the number if scenario per client."
+					"Number of running scenario less than the number of scenario per client."
 				);
 			}
 			TestKind::Soak { min_scenarios, max_scenarios, .. } => {

--- a/networks/suzuka/suzuka-client/src/load_soak_testing/mod.rs
+++ b/networks/suzuka/suzuka-client/src/load_soak_testing/mod.rs
@@ -77,7 +77,7 @@ impl ExecutionConfig {
 				assert!(max_scenarios >= min_scenarios, "max scenarios less than min scenarios");
 				assert!(
 					min_scenarios >= self.number_scenario_per_client,
-					"Number of min running scenario less than the number if scenario per client."
+					"Number of min running scenario less than the number of scenario per client."
 				);
 			}
 		}

--- a/networks/suzuka/suzuka-client/src/load_soak_testing/scenario.rs
+++ b/networks/suzuka/suzuka-client/src/load_soak_testing/scenario.rs
@@ -2,7 +2,7 @@ use super::EXEC_LOG_FILTER;
 
 /// A scenario is any struct that implements the Scenario trait.
 /// To ease scenario execution and logs, an id (usize) is provided during creation.
-/// This id is only used by teh runtime to identify scenario execution is the logs.
+/// This id is only used by the runtime to identify scenario execution is the logs.
 
 /// Implements this trait to develop a scenario.
 /// How logs works during scenario execution:


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

<!--
Add your summary text here. 
 -->
I've integrated the last modification of the load and soak FWk in one PR.

# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->
In suzuka-client/bin the demoscenario.rs file propose an example of soak test. To define a load test, remove the `config.kind = TestKind::Soak` config modification.
For load test, you can use the `LOADTEST_NUMBER_SCENARIO` and `LOADTEST_NUMBER_SCENARIO_PER_CLIENT` env var to define the load test configuration.

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->
The soak test doesn't vary between min/max concurrent scenario but stay at the min level.