### PR TITLE
Make maptos-opt-executor tick better

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,7 +1582,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tonic 0.11.0",
+ "tonic",
  "tonic-reflection",
 ]
 
@@ -1614,7 +1614,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]
@@ -1636,7 +1636,7 @@ dependencies = [
  "lz4",
  "once_cell",
  "prometheus",
- "prost 0.12.6",
+ "prost",
  "redis",
  "redis-test",
  "ripemd",
@@ -1644,7 +1644,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
- "tonic 0.11.0",
+ "tonic",
  "tracing",
  "url",
 ]
@@ -2084,9 +2084,9 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929
 dependencies = [
  "futures-core",
  "pbjson",
- "prost 0.12.6",
+ "prost",
  "serde",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]
@@ -2253,7 +2253,7 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio",
- "tonic 0.11.0",
+ "tonic",
  "tonic-reflection",
 ]
 
@@ -3033,7 +3033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core 0.3.4",
+ "axum-core",
  "bitflags 1.3.2",
  "bytes 1.6.1",
  "futures-util",
@@ -3055,33 +3055,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
-dependencies = [
- "async-trait",
- "axum-core 0.4.3",
- "bytes 1.6.1",
- "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 1.0.1",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "axum-core"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3094,26 +3067,6 @@ dependencies = [
  "http-body 0.4.6",
  "mime",
  "rustversion",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
-dependencies = [
- "async-trait",
- "bytes 1.6.1",
- "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper 0.1.2",
  "tower-layer",
  "tower-service",
 ]
@@ -3831,7 +3784,7 @@ source = "git+https://github.com/eigerco/lumina#4f2bbc602d9c8921b0d2054af751ed97
 dependencies = [
  "anyhow",
  "celestia-tendermint-proto",
- "prost 0.12.6",
+ "prost",
  "prost-build",
  "prost-types",
  "serde",
@@ -3866,7 +3819,7 @@ dependencies = [
  "futures",
  "num-traits",
  "once_cell",
- "prost 0.12.6",
+ "prost",
  "prost-types",
  "serde",
  "serde_bytes",
@@ -3890,7 +3843,7 @@ dependencies = [
  "flex-error",
  "num-derive",
  "num-traits",
- "prost 0.12.6",
+ "prost",
  "prost-types",
  "serde",
  "serde_bytes",
@@ -6355,7 +6308,6 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -6405,19 +6357,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
-dependencies = [
- "hyper 1.4.1",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -7392,13 +7331,13 @@ dependencies = [
  "m1-da-light-node-util",
  "m1-da-light-node-verifier",
  "memseq",
- "prost 0.12.6",
+ "prost",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
  "tokio-stream",
- "tonic 0.11.0",
+ "tonic",
  "tonic-reflection",
  "tonic-web",
  "tracing",
@@ -7422,8 +7361,8 @@ name = "m1-da-light-node-grpc"
 version = "0.3.0"
 dependencies = [
  "buildtime",
- "prost 0.12.6",
- "tonic 0.11.0",
+ "prost",
+ "tonic",
  "tonic-build",
  "tonic-reflection",
  "tonic-web",
@@ -7488,7 +7427,7 @@ dependencies = [
  "jsonrpsee 0.20.3",
  "m1-da-light-node-grpc",
  "memseq-util",
- "prost 0.12.6",
+ "prost",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7496,7 +7435,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml 0.8.14",
- "tonic 0.11.0",
+ "tonic",
  "tonic-reflection",
  "tonic-web",
  "tracing",
@@ -7516,11 +7455,11 @@ dependencies = [
  "m1-da-light-node-grpc",
  "m1-da-light-node-setup",
  "m1-da-light-node-util",
- "prost 0.12.6",
+ "prost",
  "serde_json",
  "tokio",
  "tokio-stream",
- "tonic 0.11.0",
+ "tonic",
  "tonic-reflection",
  "tonic-web",
 ]
@@ -7652,7 +7591,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tonic 0.12.0",
  "tracing",
  "tracing-test",
 ]
@@ -9970,15 +9908,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13db3d3fde688c61e2446b4d843bc27a7e8af269a69440c0308021dc92333cc"
-dependencies = [
- "bytes 1.6.1",
-]
-
-[[package]]
 name = "prost-build"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9992,7 +9921,7 @@ dependencies = [
  "once_cell",
  "petgraph 0.6.5",
  "prettyplease",
- "prost 0.12.6",
+ "prost",
  "prost-types",
  "regex",
  "syn 2.0.71",
@@ -10018,7 +9947,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost 0.12.6",
+ "prost",
 ]
 
 [[package]]
@@ -11806,7 +11735,7 @@ dependencies = [
  "suzuka-config",
  "thiserror",
  "tokio",
- "tonic 0.11.0",
+ "tonic",
  "tracing",
  "tracing-subscriber 0.3.18",
  "url",
@@ -11864,7 +11793,7 @@ dependencies = [
  "suzuka-config",
  "tokio",
  "tokio-stream",
- "tonic 0.11.0",
+ "tonic",
  "tracing",
  "tracing-subscriber 0.3.18",
 ]
@@ -12466,7 +12395,7 @@ checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.6.20",
+ "axum",
  "base64 0.21.7",
  "bytes 1.6.1",
  "flate2",
@@ -12474,10 +12403,10 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
- "hyper-timeout 0.4.1",
+ "hyper-timeout",
  "percent-encoding",
  "pin-project 1.1.5",
- "prost 0.12.6",
+ "prost",
  "rustls-native-certs",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
@@ -12489,36 +12418,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "zstd",
-]
-
-[[package]]
-name = "tonic"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f738b6a169a29bca4e39656db89c44a08e09c5b700b896ee9e7459f0652e81dd"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.7.5",
- "base64 0.22.1",
- "bytes 1.6.1",
- "h2 0.4.5",
- "http 1.1.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.4.1",
- "hyper-timeout 0.5.1",
- "hyper-util",
- "percent-encoding",
- "pin-project 1.1.5",
- "prost 0.13.1",
- "socket2 0.5.7",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -12540,11 +12439,11 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "548c227bd5c0fae5925812c4ec6c66ffcfced23ea370cb823f4d18f0fc1cb6a7"
 dependencies = [
- "prost 0.12.6",
+ "prost",
  "prost-types",
  "tokio",
  "tokio-stream",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]
@@ -12560,7 +12459,7 @@ dependencies = [
  "hyper 0.14.30",
  "pin-project 1.1.5",
  "tokio-stream",
- "tonic 0.11.0",
+ "tonic",
  "tower-http",
  "tower-layer",
  "tower-service",

--- a/protocol-units/execution/opt-executor/Cargo.toml
+++ b/protocol-units/execution/opt-executor/Cargo.toml
@@ -35,7 +35,6 @@ rand_core = { workspace = true }
 bcs = { workspace = true }
 futures = { workspace = true }
 async-channel = { workspace = true }
-tonic = { wrkspace = true }
 
 aptos-vm = { workspace = true }
 aptos-vm-validator = { workspace = true }


### PR DESCRIPTION
# Summary
- **Categories**: `protocol-units`.

Eliminate unnecessary looping and timeouts in `Executor::tick_transaction_pipe`.

# Testing

`cargo test -p maptos-opt-executor`

CI tests shall pass.
