### PR TITLE
Add spans and timing into tracing logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4202,44 +4202,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console-api"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a257c22cd7e487dd4a13d413beabc512c5052f0bc048db0da6a84c3d8a6142fd"
-dependencies = [
- "futures-core",
- "prost",
- "prost-types",
- "tonic",
- "tracing-core",
-]
-
-[[package]]
-name = "console-subscriber"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c4cc54bae66f7d9188996404abdf7fdfa23034ef8e43478c8810828abad758"
-dependencies = [
- "console-api",
- "crossbeam-channel",
- "crossbeam-utils",
- "futures-task",
- "hdrhistogram",
- "humantime",
- "prost",
- "prost-types",
- "serde",
- "serde_json",
- "thread_local",
- "tokio",
- "tokio-stream",
- "tonic",
- "tracing",
- "tracing-core",
- "tracing-subscriber 0.3.18",
-]
-
-[[package]]
 name = "const-hex"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6045,19 +6007,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hdrhistogram"
-version = "7.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
-dependencies = [
- "base64 0.21.7",
- "byteorder",
- "flate2",
- "nom",
- "num-traits",
-]
-
-[[package]]
 name = "headers"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6332,12 +6281,6 @@ checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
 dependencies = [
  "libm",
 ]
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -7392,7 +7335,6 @@ dependencies = [
  "celestia-rpc",
  "celestia-types",
  "chrono",
- "console-subscriber",
  "dot-movement",
  "godfig",
  "hex",
@@ -7400,6 +7342,7 @@ dependencies = [
  "m1-da-light-node-util",
  "m1-da-light-node-verifier",
  "memseq",
+ "movement-tracing",
  "movement-types",
  "prost",
  "serde",
@@ -7411,7 +7354,6 @@ dependencies = [
  "tonic-reflection",
  "tonic-web",
  "tracing",
- "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -8610,6 +8552,14 @@ dependencies = [
  "poem",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "movement-tracing"
+version = "0.3.0"
+dependencies = [
+ "tracing-appender",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -11849,7 +11799,6 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
- "console-subscriber",
  "dot-movement",
  "godfig",
  "m1-da-light-node-client",
@@ -11858,6 +11807,7 @@ dependencies = [
  "mcr-settlement-client",
  "mcr-settlement-manager",
  "movement-rest",
+ "movement-tracing",
  "movement-types",
  "serde_json",
  "sha2 0.10.8",
@@ -11866,8 +11816,6 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing",
- "tracing-appender",
- "tracing-subscriber 0.3.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11866,6 +11866,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber 0.3.18",
 ]
 
@@ -12598,6 +12599,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7713,7 +7713,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -8609,7 +8608,6 @@ dependencies = [
  "poem",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7400,6 +7400,7 @@ dependencies = [
  "m1-da-light-node-util",
  "m1-da-light-node-verifier",
  "memseq",
+ "movement-types",
  "prost",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7657,6 +7657,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,15 @@ members = [
     "protocol-units/settlement/mcr/manager",
     "protocol-units/settlement/mcr/setup",
     "protocol-units/movement-rest",
-    "util/*",
+    "util/buildtime",
     "util/buildtime/buildtime-helpers",
     "util/buildtime/buildtime-macros",
     "util/commander",
+    "util/dot-movement",
+    "util/flocks",
+    "util/godfig",
+    "util/movement-types",
+    "util/tracing",
     "networks/suzuka/*",
     "protocol-units/settlement/mcr/setup",
     "protocol-units/settlement/mcr/runner",
@@ -81,6 +86,7 @@ monza-config = { path = "networks/monza/monza-config" }
 # util
 flocks = { path = "util/flocks" }
 godfig = { path = "util/godfig" }
+movement-tracing = { path = "util/tracing" }
 
 # Serialization and Deserialization
 borsh = { version = "0.10" } # todo: internalize jmt and bump

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,6 +253,7 @@ tonic-reflection = "0.11"
 tonic-web = "0.11"
 ### To try (experimental) std support, add `features = [ "std" ]` to risc0-zkvm
 tracing = "0.1.40"
+tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-test = "0.2.5"
 trie-db = "0.28.0"

--- a/networks/suzuka/suzuka-full-node/Cargo.toml
+++ b/networks/suzuka/suzuka-full-node/Cargo.toml
@@ -26,13 +26,11 @@ sha2 = { workspace = true }
 tonic = { workspace = true }
 movement-types = { workspace = true }
 movement-rest = { workspace = true }
+movement-tracing = { workspace = true }
 suzuka-config = { workspace = true }
 dot-movement = { workspace = true }
 godfig = { workspace = true }
 tracing = { workspace = true }
-tracing-appender = { workspace = true }
-tracing-subscriber = { workspace = true }
-console-subscriber = { workspace = true }
 
 [features]
 default = []

--- a/networks/suzuka/suzuka-full-node/Cargo.toml
+++ b/networks/suzuka/suzuka-full-node/Cargo.toml
@@ -24,12 +24,13 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true }
 sha2 = { workspace = true }
 tonic = { workspace = true }
-tracing = { workspace = true }
 movement-types = { workspace = true }
 movement-rest = { workspace = true }
 suzuka-config = { workspace = true }
 dot-movement = { workspace = true }
 godfig = { workspace = true }
+tracing = { workspace = true }
+tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
 console-subscriber = { workspace = true }
 

--- a/networks/suzuka/suzuka-full-node/src/main.rs
+++ b/networks/suzuka/suzuka-full-node/src/main.rs
@@ -1,20 +1,20 @@
-use suzuka_full_node::{
-	manager::Manager,
-	partial::SuzukaPartialNode,
-};
 use maptos_dof_execution::v1::Executor;
+use suzuka_full_node::{manager::Manager, partial::SuzukaPartialNode};
+
+use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
+
 use std::process::ExitCode;
 
 fn main() -> Result<ExitCode, anyhow::Error> {
 	let runtime = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
 
 	// console_subscriber::init();
-	use tracing_subscriber::EnvFilter;
 
 	tracing_subscriber::fmt()
 		.with_env_filter(
 			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
 		)
+		.with_span_events(FmtSpan::CLOSE)
 		.init();
 
 	if let Err(err) = runtime.block_on(run_suzuka()) {
@@ -27,10 +27,9 @@ fn main() -> Result<ExitCode, anyhow::Error> {
 }
 
 async fn run_suzuka() -> Result<ExitCode, anyhow::Error> {
-
 	// get the config file
 	let dot_movement = dot_movement::DotMovement::try_from_env()?;
-	let mut config_file = dot_movement.try_get_or_create_config_file().await?;
+	let config_file = dot_movement.try_get_or_create_config_file().await?;
 
 	let manager = Manager::<SuzukaPartialNode<Executor>>::new(config_file).await?;
 	manager.try_run().await?;

--- a/networks/suzuka/suzuka-full-node/src/main.rs
+++ b/networks/suzuka/suzuka-full-node/src/main.rs
@@ -1,21 +1,17 @@
 use maptos_dof_execution::v1::Executor;
 use suzuka_full_node::{manager::Manager, partial::SuzukaPartialNode};
 
-use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
+use tracing_subscriber::{filter::LevelFilter, fmt::format::FmtSpan, EnvFilter};
 
+use std::env;
 use std::process::ExitCode;
 
+const TIMING_ENV_VAR: &str = "SUZUKA_TIMING";
+
 fn main() -> Result<ExitCode, anyhow::Error> {
+	init_tracing_subscriber();
+
 	let runtime = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
-
-	// console_subscriber::init();
-
-	tracing_subscriber::fmt()
-		.with_env_filter(
-			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-		)
-		.with_span_events(FmtSpan::CLOSE)
-		.init();
 
 	if let Err(err) = runtime.block_on(run_suzuka()) {
 		tracing::error!("Suzuka node main task exit with an error : {err}",);
@@ -35,4 +31,16 @@ async fn run_suzuka() -> Result<ExitCode, anyhow::Error> {
 	manager.try_run().await?;
 
 	Ok(ExitCode::SUCCESS)
+}
+
+fn init_tracing_subscriber() {
+	// TODO: compose console_subscriber as a layer
+	let env_filter = EnvFilter::builder()
+		.with_default_directive(LevelFilter::INFO.into())
+		.from_env_lossy();
+	let mut subscriber = tracing_subscriber::fmt().with_env_filter(env_filter);
+	if env::var(TIMING_ENV_VAR).map_or(false, |v| v != "0") {
+		subscriber = subscriber.with_span_events(FmtSpan::CLOSE);
+	}
+	subscriber.init()
 }

--- a/networks/suzuka/suzuka-full-node/src/main.rs
+++ b/networks/suzuka/suzuka-full-node/src/main.rs
@@ -1,15 +1,15 @@
 use maptos_dof_execution::v1::Executor;
 use suzuka_full_node::{manager::Manager, partial::SuzukaPartialNode};
 
-use tracing_subscriber::{filter::LevelFilter, fmt::format::FmtSpan, EnvFilter};
-
 use std::env;
 use std::process::ExitCode;
 
 const TIMING_ENV_VAR: &str = "SUZUKA_TIMING";
+const TIMING_LOG_ENV_VAR: &str = "SUZUKA_TIMING_LOG";
+const DEFAULT_TIMING_LOG_FILE: &str = "suzuka-full-node.timing.json";
 
 fn main() -> Result<ExitCode, anyhow::Error> {
-	init_tracing_subscriber();
+	let _guard = init_tracing_subscriber();
 
 	let runtime = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
 
@@ -33,14 +33,49 @@ async fn run_suzuka() -> Result<ExitCode, anyhow::Error> {
 	Ok(ExitCode::SUCCESS)
 }
 
-fn init_tracing_subscriber() {
+fn init_tracing_subscriber() -> Option<tracing_appender::non_blocking::WorkerGuard> {
+	use std::{fs::File, path::PathBuf};
+	use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+	use tracing_subscriber::fmt::format::FmtSpan;
+	use tracing_subscriber::prelude::*;
+
 	// TODO: compose console_subscriber as a layer
 	let env_filter = EnvFilter::builder()
 		.with_default_directive(LevelFilter::INFO.into())
 		.from_env_lossy();
-	let mut subscriber = tracing_subscriber::fmt().with_env_filter(env_filter);
-	if env::var(TIMING_ENV_VAR).map_or(false, |v| v != "0") {
-		subscriber = subscriber.with_span_events(FmtSpan::CLOSE);
-	}
-	subscriber.init()
+	let log_layer = tracing_subscriber::fmt::layer().with_filter(env_filter);
+
+	let (timing_layer, timing_writer_guard) =
+		if let Ok(timing_directives) = env::var(TIMING_ENV_VAR) {
+			let env_filter = EnvFilter::try_new(timing_directives);
+			let timing_log_path: PathBuf = env::var_os(TIMING_LOG_ENV_VAR)
+				.unwrap_or_else(|| DEFAULT_TIMING_LOG_FILE.into())
+				.into();
+			let timing_log_file = File::create(&timing_log_path);
+			match (env_filter, timing_log_file) {
+				(Ok(env_filter), Ok(file)) => {
+					let (writer, guard) = tracing_appender::non_blocking(file);
+					let layer = tracing_subscriber::fmt::layer()
+						.with_writer(writer)
+						.json()
+						.with_span_events(FmtSpan::CLOSE)
+						.with_filter(env_filter);
+					(Some(layer), Some(guard))
+				}
+				(Err(e), _) => {
+					eprintln!("invalid value of {TIMING_ENV_VAR}: {e}");
+					(None, None)
+				}
+				(_, Err(e)) => {
+					eprintln!("can't create `{}`: {}", timing_log_path.display(), e);
+					(None, None)
+				}
+			}
+		} else {
+			(None, None)
+		};
+
+	tracing_subscriber::registry().with(log_layer).with(timing_layer).init();
+
+	timing_writer_guard
 }

--- a/networks/suzuka/suzuka-full-node/src/partial.rs
+++ b/networks/suzuka/suzuka-full-node/src/partial.rs
@@ -167,7 +167,7 @@ where
 				}
 			};
 
-			let span = info_span!("execute_block", id = block_id);
+			let span = info_span!(target: "movement_timing", "execute_block", id = block_id);
 
 			let commitment = self
 				.execute_block(block_bytes, block_id, block_timestamp)

--- a/networks/suzuka/suzuka-full-node/src/partial.rs
+++ b/networks/suzuka/suzuka-full-node/src/partial.rs
@@ -95,10 +95,15 @@ where
 		{
 			match transaction_result {
 				Ok(transaction) => {
-					debug!("Got transaction: {:?}", transaction);
+					debug!(
+						tx_hash = %transaction.committed_hash(),
+						sender = %transaction.sender(),
+						sequence_number = transaction.sequence_number(),
+						"received transaction",
+					);
 
 					let serialized_aptos_transaction = serde_json::to_vec(&transaction)?;
-					debug!("Serialized transaction: {:?}", serialized_aptos_transaction);
+					trace!("Serialized transaction: {:?}", serialized_aptos_transaction);
 					let movement_transaction = movement_types::Transaction {
 						data: serialized_aptos_transaction,
 						sequence_number: transaction.sequence_number(),

--- a/process-compose/suzuka-full-node/process-compose.yml
+++ b/process-compose/suzuka-full-node/process-compose.yml
@@ -52,7 +52,9 @@ processes:
     
   suzuka-full-node:
     command: |
-      RUST_LOG=aptos-indexer=debug suzuka-full-node
+      suzuka-full-node
+    env:
+      RUST_LOG: info,aptos-indexer=debug
     depends_on:
       m1-da-light-node:
         condition: process_healthy

--- a/protocol-units/da/m1/light-node/Cargo.toml
+++ b/protocol-units/da/m1/light-node/Cargo.toml
@@ -34,13 +34,11 @@ tracing = { workspace = true }
 chrono = { workspace = true }
 dot-movement = { workspace = true }
 godfig = { workspace = true }
-
+movement-tracing = { workspace = true }
 
 # sequencer
 memseq = { workspace = true, optional = true }
 
-tracing-subscriber = { workspace = true }
-console-subscriber = { workspace = true }
 
 [features]
 default = ["sequencer"]

--- a/protocol-units/da/m1/light-node/Cargo.toml
+++ b/protocol-units/da/m1/light-node/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "m1-da-light-node"
 version = { workspace = true }
-edition  = { workspace = true }
-license  = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
@@ -21,6 +21,7 @@ prost = { workspace = true }
 m1-da-light-node-grpc = { workspace = true, features = ["server"] }
 m1-da-light-node-util = { workspace = true }
 m1-da-light-node-verifier = { workspace = true }
+movement-types = { workspace = true }
 celestia-rpc = { workspace = true }
 celestia-types = { workspace = true }
 anyhow = { workspace = true }
@@ -42,12 +43,8 @@ tracing-subscriber = { workspace = true }
 console-subscriber = { workspace = true }
 
 [features]
-default = [
-    "sequencer"
-]
-sequencer = [
-    "memseq",
-]
+default = ["sequencer"]
+sequencer = ["memseq"]
 
 [lints]
 workspace = true

--- a/protocol-units/da/m1/light-node/src/v1/passthrough.rs
+++ b/protocol-units/da/m1/light-node/src/v1/passthrough.rs
@@ -132,7 +132,7 @@ impl LightNodeV1 {
 		Ok(verified_blobs)
 	}
 
-	#[tracing::instrument(level = "debug")]
+	#[tracing::instrument(target = "movement_timing", level = "debug")]
 	async fn get_blobs_at_height(&self, height: u64) -> Result<Vec<Blob>, anyhow::Error> {
 		let celestia_blobs = self.get_celestia_blobs_at_height(height).await?;
 		let mut blobs = Vec::new();

--- a/protocol-units/da/m1/light-node/src/v1/passthrough.rs
+++ b/protocol-units/da/m1/light-node/src/v1/passthrough.rs
@@ -132,11 +132,14 @@ impl LightNodeV1 {
 		Ok(verified_blobs)
 	}
 
-	pub async fn get_blobs_at_height(&self, height: u64) -> Result<Vec<Blob>, anyhow::Error> {
+	#[tracing::instrument(level = "debug")]
+	async fn get_blobs_at_height(&self, height: u64) -> Result<Vec<Blob>, anyhow::Error> {
 		let celestia_blobs = self.get_celestia_blobs_at_height(height).await?;
 		let mut blobs = Vec::new();
-		for blob in celestia_blobs {
-			blobs.push(Self::celestia_blob_to_blob(blob, height)?);
+		for celestia_blob in celestia_blobs {
+			let blob = Self::celestia_blob_to_blob(celestia_blob, height)?;
+			debug!(blob_id = %blob.blob_id, "got blob");
+			blobs.push(blob);
 		}
 		Ok(blobs)
 	}

--- a/protocol-units/da/m1/light-node/src/v1/sequencer.rs
+++ b/protocol-units/da/m1/light-node/src/v1/sequencer.rs
@@ -58,7 +58,8 @@ impl LightNodeV1 {
 		let block = self.memseq.wait_for_next_block().await?;
 		match block {
 			Some(block) => {
-				let span = info_span!("submit_block", block_id = %block.id());
+				let span =
+					info_span!(target: "movement_timing", "submit_block", block_id = %block.id());
 				self.submit_proposed_block(block).instrument(span).await?;
 			}
 			None => {

--- a/protocol-units/execution/dof/src/v1.rs
+++ b/protocol-units/execution/dof/src/v1.rs
@@ -424,7 +424,7 @@ mod tests {
 				let user_account_creation_tx = root_account.sign_with_transaction_builder(
 					tx_factory.create_user_account(new_account.public_key()),
 				);
-				let tx_hash = user_account_creation_tx.clone().committed_hash();
+				let tx_hash = user_account_creation_tx.committed_hash();
 				transaction_hashes.push(tx_hash);
 				transactions.push(Transaction::UserTransaction(user_account_creation_tx));
 			}
@@ -490,7 +490,7 @@ mod tests {
 			let user_account_creation_tx = root_account.sign_with_transaction_builder(
 				tx_factory.create_user_account(new_account.public_key()),
 			);
-			let tx_hash = user_account_creation_tx.clone().committed_hash();
+			let tx_hash = user_account_creation_tx.committed_hash();
 			transaction_hashes.push(tx_hash);
 			transactions.push(Transaction::UserTransaction(user_account_creation_tx));
 

--- a/protocol-units/execution/opt-executor/src/executor/execution.rs
+++ b/protocol-units/execution/opt-executor/src/executor/execution.rs
@@ -101,6 +101,7 @@ impl Executor {
 			let mut core_mempool = self.core_mempool.write().await;
 			for (sender, sequence_number) in chunk {
 				let _span = debug_span!(
+					target: "movement_timing",
 					"commit_transaction",
 					%sender,
 					sequence_number = *sequence_number,

--- a/protocol-units/execution/opt-executor/src/executor/execution.rs
+++ b/protocol-units/execution/opt-executor/src/executor/execution.rs
@@ -364,7 +364,7 @@ mod tests {
 			let mint_tx = root_account
 				.sign_with_transaction_builder(tx_factory.mint(new_account.address(), 2000));
 			// Store the hash of the committed transaction for later verification.
-			let mint_tx_hash = mint_tx.clone().committed_hash();
+			let mint_tx_hash = mint_tx.committed_hash();
 
 			// Block Metadata
 			let transactions =
@@ -457,7 +457,7 @@ mod tests {
 				let user_account_creation_tx = root_account.sign_with_transaction_builder(
 					tx_factory.create_user_account(new_account.public_key()),
 				);
-				let tx_hash = user_account_creation_tx.clone().committed_hash();
+				let tx_hash = user_account_creation_tx.committed_hash();
 				transaction_hashes.push(tx_hash);
 				transactions.push(Transaction::UserTransaction(user_account_creation_tx));
 			}

--- a/protocol-units/execution/opt-executor/src/executor/execution.rs
+++ b/protocol-units/execution/opt-executor/src/executor/execution.rs
@@ -96,6 +96,7 @@ impl Executor {
 						.entered();
 						core_mempool
 							.commit_transaction(&AccountAddress::from(sender), sequence_number);
+						debug!("committed transaction");
 					}
 					_ => {}
 				}

--- a/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
+++ b/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
@@ -44,8 +44,9 @@ impl Executor {
 				MempoolClientRequest::SubmitTransaction(transaction, callback) => {
 					let span = info_span!(
 						"submit_transaction",
-						seq = transaction.sequence_number(),
-						// TODO: more identifying data for this span
+						tx_hash = %transaction.committed_hash(),
+						sender = %transaction.sender(),
+						sequence_number = transaction.sequence_number(),
 					);
 					let status = self
 						.submit_transaction(transaction, transaction_channel)

--- a/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
+++ b/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
@@ -43,6 +43,7 @@ impl Executor {
 			match request {
 				MempoolClientRequest::SubmitTransaction(transaction, callback) => {
 					let span = info_span!(
+						target: "movement_timing",
 						"submit_transaction",
 						tx_hash = %transaction.committed_hash(),
 						sender = %transaction.sender(),

--- a/protocol-units/movement-rest/Cargo.toml
+++ b/protocol-units/movement-rest/Cargo.toml
@@ -19,7 +19,6 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 aptos-api = { workspace = true }
-tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 poem = { workspace = true, features = ["test"] }

--- a/protocol-units/settlement/mcr/client/Cargo.toml
+++ b/protocol-units/settlement/mcr/client/Cargo.toml
@@ -50,6 +50,7 @@ dot-movement = { workspace = true }
 [dev-dependencies]
 alloy-rpc-types = { workspace = true }
 futures = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [features]
 default = ["eth"]

--- a/protocol-units/settlement/mcr/client/Cargo.toml
+++ b/protocol-units/settlement/mcr/client/Cargo.toml
@@ -21,14 +21,12 @@ alloy = { workspace = true, features = [
     "signers",
     "signer-yubihsm",
     "pubsub",
-    "providers"
-]}
+    "providers",
+] }
 alloy-contract = { workspace = true }
 alloy-network = { workspace = true }
 alloy-primitives = { workspace = true }
-alloy-provider = { workspace = true, features = [
-
-] }
+alloy-provider = { workspace = true, features = [] }
 alloy-signer = { workspace = true }
 alloy-sol-types = { workspace = true }
 alloy-transport = { workspace = true }
@@ -43,7 +41,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 serde = { workspace = true }
 
 godfig = { workspace = true }

--- a/util/tracing/Cargo.toml
+++ b/util/tracing/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "movement-tracing"
+description = "Tracing utilities with timing support for Movement services"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+tracing-appender = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["json"] }
+#console-subscriber = { workspace = true }
+
+[lints]
+workspace = true

--- a/util/tracing/src/lib.rs
+++ b/util/tracing/src/lib.rs
@@ -1,5 +1,5 @@
 use tracing_appender::non_blocking::WorkerGuard as AppenderGuard;
-use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+use tracing_subscriber::filter::{self, EnvFilter, LevelFilter};
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::prelude::*;
 
@@ -56,7 +56,8 @@ pub fn init_tracing_subscriber(config: Config) -> WorkerGuard {
 						.with_writer(writer)
 						.json()
 						.with_span_events(FmtSpan::CLOSE)
-						.with_filter(env_filter);
+						.with_filter(env_filter)
+						.with_filter(filter::filter_fn(|meta| meta.target() == "movement_timing"));
 					(Some(layer), Some(guard))
 				}
 				Err(e) => {

--- a/util/tracing/src/lib.rs
+++ b/util/tracing/src/lib.rs
@@ -1,0 +1,77 @@
+use tracing_appender::non_blocking::WorkerGuard as AppenderGuard;
+use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::prelude::*;
+
+use std::{env, fs::File, path::PathBuf};
+
+const TIMING_ENV: &str = "MOVEMENT_TIMING";
+
+/// The default path name for the timing log file.
+/// If the path not specified in [`Config`] and the `MOVEMENT_TIMING`
+/// environment variable is set, the log file with this name will be created.
+pub const DEFAULT_TIMING_LOG_FILE: &str = "movement-timing.log";
+
+/// A guard for background log appender(s) returned by `init_tracing_subscriber`.
+pub struct WorkerGuard {
+	_drop_me: Option<AppenderGuard>,
+}
+
+/// Options for the tracing subscriber.
+#[derive(Default)]
+pub struct Config {
+	/// Custom name for the timing log file.
+	pub timing_log_path: Option<PathBuf>,
+}
+
+/// Sets up the tracing subscribers for a Movement process. This should be
+/// called at the beginning of a process' `main` function.
+/// Returns a guard object that should be dropped at the end of the process'
+/// `main`` function scope.
+///
+/// This function may output encounted errors to the standard error stream,
+/// as this is the only facility
+pub fn init_tracing_subscriber(config: Config) -> WorkerGuard {
+	// TODO: compose console_subscriber as a layer
+	let env_filter = EnvFilter::builder()
+		.with_default_directive(LevelFilter::INFO.into())
+		.from_env_lossy();
+	let log_layer = tracing_subscriber::fmt::layer().with_filter(env_filter);
+
+	let (timing_layer, timing_writer_guard) = match env::var(TIMING_ENV) {
+		Err(env::VarError::NotPresent) => {
+			// Disable timing
+			(None, None)
+		}
+		Ok(timing_directives) => {
+			let env_filter = EnvFilter::new(timing_directives);
+			let timing_log_path = config
+				.timing_log_path
+				.as_deref()
+				.unwrap_or_else(|| DEFAULT_TIMING_LOG_FILE.as_ref());
+			match File::create(timing_log_path) {
+				Ok(file) => {
+					let (writer, guard) = tracing_appender::non_blocking(file);
+					let layer = tracing_subscriber::fmt::layer()
+						.with_writer(writer)
+						.json()
+						.with_span_events(FmtSpan::CLOSE)
+						.with_filter(env_filter);
+					(Some(layer), Some(guard))
+				}
+				Err(e) => {
+					eprintln!("can't create `{}`: {}", timing_log_path.display(), e);
+					(None, None)
+				}
+			}
+		}
+		Err(e) => {
+			eprintln!("invalid {TIMING_ENV}: {e}");
+			(None, None)
+		}
+	};
+
+	tracing_subscriber::registry().with(log_layer).with(timing_layer).init();
+
+	WorkerGuard { _drop_me: timing_writer_guard }
+}


### PR DESCRIPTION
# Summary
- **Categories**: any of `protocol-units`, `networks`.

Instrument async processing flows with tracing spans to get information about latency of processing.
Use KV pairs in spans to identify entities such as transactions.

Currently based on #243 to have simpler, better behaving code to instrument.

# Changelog

* suzuka-full-node, m1-da-light-node: log tracing events with timing information suzuka-full-node if the `SUZUKA_TIMING` environment variable is set. The information logged is filtered accordingly to the directives given in the value of `SUZUKA_TIMING`, with the same syntax as `RUST_LOG`.

# Testing

Run suzuka-full-node in a local setup with e.g. the `test` overlay:

```
SUZUKA_TIMING=info just suzuka-full-node native build.setup.eth-local.celestia-local.test
```

Observe the events created in the `suzuka-full-node.timing.json` file.
