### PR TITLE
Persistent M1 DA Heights

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,7 +33,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             arch: x86_64
-            runs-on: buildjet-8vcpu-ubuntu-2204
+            runs-on: buildjet-16vcpu-ubuntu-2204
 
     runs-on: ${{ matrix.runs-on }}
 
@@ -54,6 +54,7 @@ jobs:
         nix develop --command bash  -c "just suzuka-full-node native build.setup.eth-local.celestia-local.test -t=false"  
   
   suzuka-full-node-remote:
+    if: false
     strategy:
       matrix:
         include:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11817,6 +11817,7 @@ name = "suzuka-config"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "godfig",
  "m1-da-light-node-util",
  "maptos-execution-util",
  "mcr-settlement-client",
@@ -11860,6 +11861,7 @@ dependencies = [
  "mcr-settlement-manager",
  "movement-rest",
  "movement-types",
+ "rocksdb",
  "serde_json",
  "sha2 0.10.8",
  "suzuka-config",

--- a/networks/suzuka/setup/src/local.rs
+++ b/networks/suzuka/setup/src/local.rs
@@ -52,6 +52,21 @@ impl Local {
 
 		Ok(config)
 	}
+
+	async fn setup_da_db_config(
+		&self,
+		dot_movement: DotMovement,
+		mut config: suzuka_config::Config,
+	) -> Result<suzuka_config::Config, anyhow::Error> {
+		// update the db path
+		let db_path = dot_movement.get_path().join(config.da_db.da_db_path.clone());
+		config.da_db.da_db_path = db_path.to_str().ok_or(
+			anyhow::anyhow!("Failed to convert db path to string: {:?}", db_path),
+		)?.to_string();
+
+		Ok(config)
+	}
+
 }
 
 impl SuzukaFullNodeSetupOperations for Local {
@@ -65,6 +80,9 @@ impl SuzukaFullNodeSetupOperations for Local {
 
 		// run the maptos execution config setup
 		let config = self.setup_maptos_execution_config(dot_movement.clone(), config).await?;
+
+		// run the da_db config setup
+		let config = self.setup_da_db_config(dot_movement.clone(), config).await?;
 
 		// Placeholder for returning the actual configuration.
 		Ok((config, join_handle))

--- a/networks/suzuka/suzuka-config/Cargo.toml
+++ b/networks/suzuka/suzuka-config/Cargo.toml
@@ -23,3 +23,4 @@ serde_derive = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 m1-da-light-node-util = { workspace = true }
+godfig = { workspace = true }

--- a/networks/suzuka/suzuka-config/src/da_db.rs
+++ b/networks/suzuka/suzuka-config/src/da_db.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+use godfig::env_default;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Config {
+
+    #[serde(default = "default_da_db_path")]
+    pub da_db_path: String,
+
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            da_db_path: default_da_db_path(),
+        }
+    }
+}
+
+env_default!(
+    default_da_db_path,
+    "SUZUKA_DA_DB_PATH",
+    String,
+    "suzuka-da-db".to_string()
+);

--- a/networks/suzuka/suzuka-config/src/lib.rs
+++ b/networks/suzuka/suzuka-config/src/lib.rs
@@ -1,8 +1,11 @@
+pub mod da_db;
+
 use serde::{Deserialize, Serialize};
 
 use m1_da_light_node_util::config::M1DaLightNodeConfig;
 use maptos_execution_util::config::MaptosConfig;
 use mcr_settlement_config::Config as McrConfig;
+
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -16,6 +19,9 @@ pub struct Config {
 
 	#[serde(default)]
 	pub mcr: McrConfig,
+
+	#[serde(default)]
+	pub da_db: da_db::Config,
 }
 
 impl Default for Config {
@@ -24,6 +30,7 @@ impl Default for Config {
 			execution_config: MaptosConfig::default(),
 			m1_da_light_node: M1DaLightNodeConfig::default(),
 			mcr: McrConfig::default(),
+			da_db: da_db::Config::default(),
 		}
 	}
 }

--- a/networks/suzuka/suzuka-full-node/Cargo.toml
+++ b/networks/suzuka/suzuka-full-node/Cargo.toml
@@ -32,6 +32,7 @@ dot-movement = { workspace = true }
 godfig = { workspace = true }
 tracing-subscriber = { workspace = true }
 console-subscriber = { workspace = true }
+rocksdb = { workspace = true }
 
 [features]
 default = []

--- a/networks/suzuka/suzuka-full-node/src/partial.rs
+++ b/networks/suzuka/suzuka-full-node/src/partial.rs
@@ -359,7 +359,7 @@ impl <T> SuzukaPartialNode<T> {
 
 	pub async fn add_executed_block(&self, id : String) -> Result<(), anyhow::Error> {
 		let cf = self.da_db.cf_handle("executed_blocks").ok_or(anyhow::anyhow!("No executed_blocks column family"))?;
-		self.da_db.put_cf(&cf, "executed_blocks", id).map_err(|e| anyhow::anyhow!("Failed to add executed block: {:?}", e))?;
+		self.da_db.put_cf(&cf, id.clone(), id).map_err(|e| anyhow::anyhow!("Failed to add executed block: {:?}", e))?;
 		Ok(())
 	}
 

--- a/protocol-units/da/m1/light-node/src/v1/passthrough.rs
+++ b/protocol-units/da/m1/light-node/src/v1/passthrough.rs
@@ -82,6 +82,17 @@ impl LightNodeV1 {
 		Ok(height)
 	}
 
+	/// Submits Celestia blobs to the Celestia node.
+	pub async fn submit_celestia_blobs(&self, blobs: &[CelestiaBlob]) -> Result<u64, anyhow::Error> {
+		let height = self
+			.default_client
+			.blob_submit(blobs, GasPrice::default())
+			.await
+			.map_err(|e| anyhow::anyhow!("Failed submitting the blob: {}", e))?;
+
+		Ok(height)
+	}
+
 	/// Submits a blob to the Celestia node.
 	pub async fn submit_blob(&self, data: Vec<u8>) -> Result<Blob, anyhow::Error> {
 		let celestia_blob = self.create_new_celestia_blob(data)?;

--- a/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
+++ b/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
@@ -2,14 +2,9 @@ use super::Executor;
 use aptos_mempool::{core_mempool::TimelineState, MempoolClientRequest};
 use aptos_sdk::types::mempool_status::{MempoolStatus, MempoolStatusCode};
 use aptos_types::transaction::SignedTransaction;
-use aptos_vm_validator::vm_validator::TransactionValidation;
-use aptos_vm_validator::vm_validator::VMValidator;
-
 use futures::StreamExt;
 use thiserror::Error;
 use tracing::debug;
-
-use std::sync::Arc;
 
 #[derive(Debug, Clone, Error)]
 pub enum TransactionPipeError {


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$
- **Categories**: `protocol-units`

Persists M1 DA reported heights to prevent syncing from too far back. 

# Changelog

1. Stores M1 DA reported heights (not the same as Suzuka heights) in RocksDB to inform syncing. 
2. Stores `Block.id()s` that have been executed.   

# Testing

1. e2e testing.

# Outstanding issues
1. It would be nice to add unit tests to the store here. It's difficult to do currently because it is attached to the executor which needs several pieces to run. Perhaps I can move it out into a separate crate. 