### PR TITLE
Replace serde_json with bcs in Suzuka partial.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11850,6 +11850,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
+ "bcs 0.1.4",
  "console-subscriber",
  "dot-movement",
  "godfig",
@@ -11860,7 +11861,6 @@ dependencies = [
  "mcr-settlement-manager",
  "movement-rest",
  "movement-types",
- "serde_json",
  "sha2 0.10.8",
  "suzuka-config",
  "tokio",

--- a/networks/suzuka/suzuka-full-node/Cargo.toml
+++ b/networks/suzuka/suzuka-full-node/Cargo.toml
@@ -18,7 +18,7 @@ m1-da-light-node-util = { workspace = true }
 mcr-settlement-client = { workspace = true, features = ["mock"] }
 mcr-settlement-manager = { workspace = true }
 async-channel = { workspace = true }
-serde_json = { workspace = true }
+bcs = { workspace = true }
 anyhow = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }


### PR DESCRIPTION
Closes #182

# Summary
Replaced `serde_json` with `bcs`

# Changelog

- Changed `serde_json::to_vec` to `bcs::to_bytes`

- Changed `serde_json::from_slice` to `bcs::from_bytes`

# Testing

This compiles but hasn't been tested. (See below for details.)

# Outstanding issues
I don't know that it's reasonable to assume transactions will come in in BCS format, even after making the mempool use BCS in [this PR](https://github.com/movementlabsxyz/movement/pull/251). There are some uses of `serde_json` in the DA/M1 protocol unit which seem like they may need to be changed first before this is a good change to implement. 

I wasn't sure how to test this E2E. I tried `just suzuka-full-node native build.setup.test.local` which returned:

```
FTL Failed to read process-compose/suzuka-full-node/process-compose.local.yml error="open process-compose/suzuka-full-node/process-compose.local.yml: no such file or directory"
```

Any advice on how to test this is appreciated.