### PR TITLE
Load Shedding

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,7 +33,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             arch: x86_64
-            runs-on: buildjet-8vcpu-ubuntu-2204
+            runs-on: buildjet-16vcpu-ubuntu-2204
 
     runs-on: ${{ matrix.runs-on }}
 

--- a/networks/suzuka/suzuka-full-node/src/partial.rs
+++ b/networks/suzuka/suzuka-full-node/src/partial.rs
@@ -118,10 +118,13 @@ where
 			}
 		}
 
-		if transactions.len() > 0 {
+		let length = transactions.len();
+		if length > 0 {
 			let mut light_node_client = self.light_node_client.clone();
 			light_node_client.batch_write(BatchWriteRequest { blobs: transactions }).await?;
 			debug!("Wrote transactions to DA");
+			// We now consider the transactions no longer in mempool flight.
+			self.executor.decrement_transactions_in_flight(length as u64);
 		}
 
 		Ok(())

--- a/protocol-units/da/m1/light-node/src/v1/sequencer.rs
+++ b/protocol-units/da/m1/light-node/src/v1/sequencer.rs
@@ -78,7 +78,6 @@ impl LightNodeV1 {
 		loop {
 			// build the next block from the blobs
 			self.tick_block_proposer().await?;
-			tokio::task::yield_now().await;
 		}
 
 		Ok(())

--- a/protocol-units/execution/dof/src/lib.rs
+++ b/protocol-units/execution/dof/src/lib.rs
@@ -53,4 +53,8 @@ pub trait DynOptFinExecutor {
 
 	/// Rollover the genesis block
 	async fn rollover_genesis_block(&self) -> Result<(), anyhow::Error>;
+
+	/// Decrements transactions in flight on the transaction channel.
+	fn decrement_transactions_in_flight(&self, count : u64);
+
 }

--- a/protocol-units/execution/dof/src/v1.rs
+++ b/protocol-units/execution/dof/src/v1.rs
@@ -115,6 +115,13 @@ impl DynOptFinExecutor for Executor {
 	async fn rollover_genesis_block(&self) -> Result<(), anyhow::Error> {
 		self.executor.rollover_genesis_now().await
 	}
+
+	fn decrement_transactions_in_flight(&self, count : u64) {
+		self.executor.transactions_in_flight.fetch_sub(
+			count,
+			std::sync::atomic::Ordering::Relaxed, // relaxed because this is just for load shedding, now need for strict ordering.
+		);
+	}
 }
 
 #[cfg(test)]

--- a/protocol-units/execution/opt-executor/src/executor/initialization.rs
+++ b/protocol-units/execution/opt-executor/src/executor/initialization.rs
@@ -30,7 +30,7 @@ use tokio::sync::RwLock;
 #[cfg(test)]
 use tempfile::TempDir;
 
-use std::{path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::{atomic::AtomicU64, Arc}};
 
 impl Executor {
 	pub fn genesis_change_set_and_validators(
@@ -152,6 +152,7 @@ impl Executor {
 				maptos_config.chain.maptos_rest_listen_port
 			),
 			maptos_config,
+			transactions_in_flight: Arc::new(AtomicU64::new(0)),
 		})
 	}
 

--- a/protocol-units/execution/opt-executor/src/executor/mod.rs
+++ b/protocol-units/execution/opt-executor/src/executor/mod.rs
@@ -13,7 +13,7 @@ use aptos_storage_interface::DbReaderWriter;
 use aptos_types::validator_signer::ValidatorSigner;
 use aptos_vm::AptosVM;
 use futures::channel::mpsc as futures_mpsc;
-use std::sync::Arc;
+use std::sync::{atomic::AtomicU64, Arc};
 use tokio::sync::RwLock;
 pub mod indexer;
 
@@ -41,6 +41,8 @@ pub struct Executor {
 	pub listen_url: String,
 	/// Maptos config
 	pub maptos_config: maptos_execution_util::config::Config,
+	/// Transactions in flight counter.
+	pub transactions_in_flight: Arc<AtomicU64>,
 }
 
 impl Executor {
@@ -79,6 +81,7 @@ impl Executor {
 				maptos_config.chain.maptos_rest_listen_port
 			),
 			maptos_config,
+			transactions_in_flight: Arc::new(AtomicU64::new(0)),
 		})
 	}
 }

--- a/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
+++ b/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
@@ -1,5 +1,5 @@
 use super::Executor;
-use aptos_logger::info;
+use aptos_logger::{info, warn};
 use aptos_mempool::{core_mempool::TimelineState, MempoolClientRequest};
 use aptos_sdk::types::mempool_status::{MempoolStatus, MempoolStatusCode};
 use aptos_types::transaction::SignedTransaction;
@@ -81,7 +81,9 @@ impl Executor {
 							.map_err(|e| anyhow::anyhow!("Error sending transaction: {:?}", e))?;
 							self.transactions_in_flight.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 						},
-						_ => {}
+						_ => {
+							warn!("Transaction not accepted: {:?}", status);
+						}
 					}
 
 					callback.send(Ok((status.clone(), None))).map_err(

--- a/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
+++ b/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
@@ -1,15 +1,11 @@
 use super::Executor;
+use aptos_logger::info;
 use aptos_mempool::{core_mempool::TimelineState, MempoolClientRequest};
 use aptos_sdk::types::mempool_status::{MempoolStatus, MempoolStatusCode};
 use aptos_types::transaction::SignedTransaction;
-use aptos_vm_validator::vm_validator::TransactionValidation;
-use aptos_vm_validator::vm_validator::VMValidator;
-
 use futures::StreamExt;
 use thiserror::Error;
 use tracing::debug;
-
-use std::sync::Arc;
 
 #[derive(Debug, Clone, Error)]
 pub enum TransactionPipeError {
@@ -43,68 +39,63 @@ impl Executor {
 		if let Some(request) = next {
 			match request {
 				MempoolClientRequest::SubmitTransaction(transaction, callback) => {
-					// Pre-execute Tx to validate its content.
-					// Re-create the validator for each Tx because it uses a frozen version of the ledger.
-					// let vm_validator = VMValidator::new(Arc::clone(&self.db.reader));
-					// let tx_result = vm_validator.validate_transaction(transaction.clone())?;
 
-					// let status = if let Some(vm_status) = tx_result.status() {
-					// 	// If the verification failed, return the error status.
-					// 	let ms = MempoolStatus::new(MempoolStatusCode::VmError);
-					// 	(ms, Some(vm_status))
-					// } else {
+					// Shed load.
+					// Low-ball the load shedding for now with 4096 transactions allowed in flight.
+					// For now, we are going to consider a transaction in flight until it exits the mempool and is sent to the DA as is indicated by WriteBatch.
+					if self.transactions_in_flight.load(std::sync::atomic::Ordering::Relaxed) > 2^12 {
+						info!("Transaction ins flight: {:?}, shedding load", self.transactions_in_flight.load(std::sync::atomic::Ordering::Relaxed));
+						let status = MempoolStatus::new(MempoolStatusCode::MempoolIsFull);
+						callback.send(Ok((status.clone(), None))).map_err(
+							|e| TransactionPipeError::InternalError(format!("Error sending transaction: {:?}", e))
+						)?;
+						return Ok(())
+					}
+
 					let status = {
 						// add to the mempool
-						{
-							let mut core_mempool = self.core_mempool.write().await;
+						let mut core_mempool = self.core_mempool.write().await;
 
-							debug!(
-								"Adding transaction to mempool: {:?} {:?}",
-								transaction,
-								transaction.sequence_number()
-							);
-							let status = core_mempool.add_txn(
-								transaction.clone(),
-								0,
-								transaction.sequence_number(),
-								TimelineState::NonQualified,
-								true,
-							);
+						debug!(
+							"Adding transaction to mempool: {:?} {:?}",
+							transaction,
+							transaction.sequence_number()
+						);
+						core_mempool.add_txn(
+							transaction.clone(),
+							0,
+							transaction.sequence_number(),
+							TimelineState::NonQualified,
+							true,
+						)
+					};
 
-							match status.code {
-								MempoolStatusCode::Accepted => {
-									debug!("Transaction accepted: {:?}", transaction);
-								}
-								_ => {
-									debug!("Transaction not accepted: {:?}", status);
-									Err(TransactionPipeError::TransactionNotAccepted(status))?;
-								}
-							}
-						}
-
-						// send along to the receiver
-						transaction_channel
+					// increment 
+					match &status.code {
+						MempoolStatusCode::Accepted => {
+							// send along to the receiver
+							transaction_channel
 							.send(transaction)
 							.await
 							.map_err(|e| anyhow::anyhow!("Error sending transaction: {:?}", e))?;
-
-						// report status
-						let ms = MempoolStatus::new(MempoolStatusCode::Accepted);
-						(ms, None)
-					};
-
-					if callback.send(Ok(status)).is_err() {
-						debug!("submit_transaction request has been canceled");
+							self.transactions_in_flight.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+						},
+						_ => {}
 					}
+
+					callback.send(Ok((status.clone(), None))).map_err(
+						|e| TransactionPipeError::InternalError(format!("Error sending transaction: {:?}", e))
+					)?;
+
 				}
 				MempoolClientRequest::GetTransactionByHash(hash, sender) => {
 					let mempool_result = {
 						let mempool = self.core_mempool.read().await;
 						mempool.get_by_hash(hash)
 					};
-					if sender.send(mempool_result).is_err() {
-						debug!("get_transaction_by_hash request has been canceled");
-					}
+					sender.send(mempool_result).map_err(
+						|e| TransactionPipeError::InternalError(format!("Error sending transaction: {:?}", e))
+					)?;
 				}
 			}
 		}

--- a/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
+++ b/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
@@ -43,8 +43,9 @@ impl Executor {
 					// Shed load.
 					// Low-ball the load shedding for now with 4096 transactions allowed in flight.
 					// For now, we are going to consider a transaction in flight until it exits the mempool and is sent to the DA as is indicated by WriteBatch.
-					if self.transactions_in_flight.load(std::sync::atomic::Ordering::Relaxed) > 2^12 {
-						info!("Transaction ins flight: {:?}, shedding load", self.transactions_in_flight.load(std::sync::atomic::Ordering::Relaxed));
+					let in_flight = self.transactions_in_flight.load(std::sync::atomic::Ordering::Relaxed);
+					if in_flight > 2^12 {
+						info!("Transaction ins flight: {:?}, shedding load", in_flight);
 						let status = MempoolStatus::new(MempoolStatusCode::MempoolIsFull);
 						callback.send(Ok((status.clone(), None))).map_err(
 							|e| TransactionPipeError::InternalError(format!("Error sending transaction: {:?}", e))


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**: any of `protocol-units`

## Objective
Implement load shedding for transaction flow.

## Transaction Load Milestones
![load-shedding](https://github.com/user-attachments/assets/e910324a-7225-4157-9845-f198cb1dcd3e)


In the current implement only `v1`, pardon the uninspiring naming, is considered. I think ideally, we would transform this such that we have an `enum TransactionLoadMilestone`, that we increment and decrement on relevant structs.

On the full-node, implement `v1` is fairly trivial, as we can report status directly to the client via the `MempoolRequest` API. I believe you may also be able to use the `commit_transaction` and `reject_transaction` API in a similar manner. But I have not yet confirmed. 


# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->