### PR TITLE
Adds Garbage Collection on Interval for Mempool

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,7 +33,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             arch: x86_64
-            runs-on: buildjet-8vcpu-ubuntu-2204
+            runs-on: buildjet-16vcpu-ubuntu-2204
 
     runs-on: ${{ matrix.runs-on }}
 
@@ -52,33 +52,6 @@ jobs:
       run: |
         nix develop --command bash  -c "just suzuka-full-node native build.setup.eth-local.celestia-local.test -t=false"
         nix develop --command bash  -c "just suzuka-full-node native build.setup.eth-local.celestia-local.test -t=false"  
-  
-  suzuka-full-node-remote:
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-22.04
-            arch: x86_64
-            runs-on: buildjet-8vcpu-ubuntu-2204
-
-    runs-on: ${{ matrix.runs-on }}
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        submodules: true
-
-    - name: Install Nix
-      uses: DeterminateSystems/nix-installer-action@main
-
-    - name: Run Suzuka Full Node Tests Against Holesky and Local Celestia
-      env: 
-        CELESTIA_LOG_LEVEL: FATAL # adjust the log level while debugging
-      run: |
-        export MCR_DEPLOYMENT_ACCOUNT_PRIVATE_KEY=${{ secrets.MCR_DEPLOYMENT_ACCOUNT_PRIVATE_KEY }}
-        nix develop --command bash  -c "just suzuka-full-node native build.setup.eth-holesky.celestia-local.test -t=false"
-        nix develop --command bash  -c "just suzuka-full-node native build.setup.eth-holesky.celestia-local.test -t=false"
 
   m1-da-light-node:
     if: false # this is effectively tested by the above

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7559,6 +7559,7 @@ dependencies = [
  "movement-types",
  "rand 0.7.3",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 

--- a/protocol-units/execution/dof/Cargo.toml
+++ b/protocol-units/execution/dof/Cargo.toml
@@ -28,6 +28,7 @@ maptos-opt-executor = { workspace = true }
 maptos-fin-view = { workspace = true }
 maptos-execution-util = { workspace = true }
 movement-types = { workspace = true }
+tokio-stream = { workspace = true }
 
 [dev-dependencies]
 chrono = { workspace = true }

--- a/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
+++ b/protocol-units/execution/opt-executor/src/executor/transaction_pipe.rs
@@ -28,6 +28,13 @@ impl From<anyhow::Error> for TransactionPipeError {
 }
 
 impl Executor {
+
+	pub async fn gc_mempool(&self) -> Result<(), TransactionPipeError> {
+		let mut core_mempool = self.core_mempool.write().await;
+		core_mempool.gc();
+		Ok(())
+	}
+
 	/// Pipes a batch of transactions from the mempool to the transaction channel.
 	/// todo: it may be wise to move the batching logic up a level to the consuming structs.
 	pub async fn tick_transaction_pipe(


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$
- **Categories**: `protocol-units`

Adds mempool garbage collection on hard-coded 60 second interval. This should help with mempool load. 

# Changelog

1. Add `gc()` methods to `maptos-opt-executor`.
2. Call on interval in `dof-executor` background task. 

# Testing

1. e2e tested. 

# Outstanding issues
1. Should be added to the config perhaps. 
2. Mempool task spawning still deserves optimization. 