### PR TITLE
Adds Restart Policies to Docker Compose Application

### DIFF
--- a/docker/compose/suzuka-full-node/docker-compose.celestia-local.yml
+++ b/docker/compose/suzuka-full-node/docker-compose.celestia-local.yml
@@ -19,6 +19,12 @@ services:
       retries: 10
       interval: 10s
       timeout: 5s
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s
 
   m1-da-light-node-celestia-bridge:
     image: ghcr.io/movementlabsxyz/m1-da-light-node-celestia-bridge:${CONTAINER_REV}
@@ -39,6 +45,12 @@ services:
       retries: 10
       interval: 10s
       timeout: 5s
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s
 
   celestia-light-node:
     image: busybox

--- a/docker/compose/suzuka-full-node/docker-compose.yml
+++ b/docker/compose/suzuka-full-node/docker-compose.yml
@@ -18,6 +18,12 @@ services:
       - POSTGRES_DB=postgres
     ports:
       - "5432:5432"
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s
 
   celestia-light-node:
     image: busybox
@@ -35,6 +41,12 @@ services:
       test: [ "CMD-SHELL", "echo 'health check'" ]
       retries: 3
       start_period: 3s
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 5
+        window: 150s
 
   celestia-light-node-synced:
     image: ghcr.io/movementlabsxyz/wait-for-celestia-light-node:${CONTAINER_REV}
@@ -64,6 +76,12 @@ services:
       retries: 10
       interval: 10s
       timeout: 5s
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 5
+        window: 150s
 
   suzuka-full-node:
     image: ghcr.io/movementlabsxyz/suzuka-full-node:${CONTAINER_REV}
@@ -82,6 +100,12 @@ services:
       retries: 10
       interval: 10s
       timeout: 5s
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 5
+        window: 150s
 
   suzuka-faucet-service:
     image: ghcr.io/movementlabsxyz/suzuka-faucet-service:${CONTAINER_REV}
@@ -101,6 +125,12 @@ services:
       retries: 10
       interval: 10s
       timeout: 5s
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 10 # high number of attempts in case the mempool is backed up
+        window: 150s
 
 volumes:
   dot-movement:


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$
- **Categories**:  `networks`

Adds Restart Policies to Docker Compose application. Where this is used in infrastructure, adding these restart policies well prevent the entire application from being restarted by higher-order process managers. 

# Changelog

1. Adds appropriate restart policies by service. 

# Testing

1. e2e testing. 

# Outstanding issues
1. `docker-compose` files need some rewrites to better match `process-compose` files. 