### PR TITLE
Create counterparty.sol contract

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -144,7 +144,7 @@ jobs:
     - name: Install Foundry
       run: |
         curl -L https://foundry.paradigm.xyz | bash
-        echo "::add-path::${HOME}/.foundry/bin"
+        echo "${HOME}/.foundry/bin" >> $GITHUB_PATH
         source ${HOME}/.foundry/bin/foundryup
 
     - name: Run foundry tests

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -142,11 +142,13 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Foundry
-      run: curl -L https://foundry.paradigm.xyz | bash
+      run: |
+        curl -L https://foundry.paradigm.xyz | bash
+        echo "::add-path::${HOME}/.foundry/bin"
+        source ${HOME}/.foundry/bin/foundryup
 
     - name: Run foundry tests
       run: |
-        source $HOME/.foundry/bin
         cd protocol-units/bridge/contracts
         forge test --fork-url https://ethereum-sepolia-rpc.publicnode.com -vv
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -145,7 +145,8 @@ jobs:
       run: |
         curl -L https://foundry.paradigm.xyz | bash
         echo "${HOME}/.foundry/bin" >> $GITHUB_PATH
-        source ${HOME}/.foundry/bin/foundryup
+        export PATH=$HOME/.foundry/bin:$PATH
+        source $HOME/.foundry/bin/foundryup
 
     - name: Run foundry tests
       run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -141,15 +141,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Install Foundry
-      run: |
-        curl -L https://foundry.paradigm.xyz | bash
-        echo "${HOME}/.foundry/bin" >> $GITHUB_PATH
-        export PATH=$HOME/.foundry/bin:$PATH
-        source $HOME/.foundry/bin/foundryup
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@main
 
     - name: Run foundry tests
       run: |
-        cd protocol-units/bridge/contracts
-        forge test --fork-url https://ethereum-sepolia-rpc.publicnode.com -vv
+        nix develop --command bash -c "
+          cd protocol-units/bridge/contracts && \
+          forge test --fork-url https://ethereum-sepolia-rpc.publicnode.com -vv
+        "
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,7 +25,7 @@ jobs:
       uses: DeterminateSystems/nix-installer-action@main
 
     - name: Run Cargo Check in nix environment
-      run: nix develop --command bash  -c "cargo check --all-targets"  
+      run: nix develop --command bash -c "cargo check --all-targets"
 
   suzuka-full-node-local:
     strategy:
@@ -50,9 +50,9 @@ jobs:
       env:
         CELESTIA_LOG_LEVEL: FATAL # adjust the log level while debugging
       run: |
-        nix develop --command bash  -c "just suzuka-full-node native build.setup.eth-local.celestia-local.test -t=false"
-        nix develop --command bash  -c "just suzuka-full-node native build.setup.eth-local.celestia-local.test -t=false"  
-  
+        nix develop --command bash -c "just suzuka-full-node native build.setup.eth-local.celestia-local.test -t=false"
+        nix develop --command bash -c "just suzuka-full-node native build.setup.eth-local.celestia-local.test -t=false"
+
   suzuka-full-node-remote:
     strategy:
       matrix:
@@ -73,12 +73,12 @@ jobs:
       uses: DeterminateSystems/nix-installer-action@main
 
     - name: Run Suzuka Full Node Tests Against Holesky and Local Celestia
-      env: 
+      env:
         CELESTIA_LOG_LEVEL: FATAL # adjust the log level while debugging
       run: |
         export MCR_DEPLOYMENT_ACCOUNT_PRIVATE_KEY=${{ secrets.MCR_DEPLOYMENT_ACCOUNT_PRIVATE_KEY }}
-        nix develop --command bash  -c "just suzuka-full-node native build.setup.eth-holesky.celestia-local.test -t=false"
-        nix develop --command bash  -c "just suzuka-full-node native build.setup.eth-holesky.celestia-local.test -t=false"
+        nix develop --command bash -c "just suzuka-full-node native build.setup.eth-holesky.celestia-local.test -t=false"
+        nix develop --command bash -c "just suzuka-full-node native build.setup.eth-holesky.celestia-local.test -t=false"
 
   m1-da-light-node:
     if: false # this is effectively tested by the above
@@ -100,11 +100,7 @@ jobs:
 
     - name: Run M1 DA Light Node tests in nix environment
       # adjust the log level while debugging
-      run: CELESTIA_LOG_LEVEL=FATAL nix develop --command bash  -c "just m1-da-light-node native build.setup.test.local -t=false"  
-
-    - name: Run foundry tests
-      # Run the foundry solidity contracts using the WETH9 contract on sepolia
-      run: cd protocol-units/bridge/contracts && forge test --fork-url https://ethereum-sepolia-rpc.publicnode.com -vv  
+      run: CELESTIA_LOG_LEVEL=FATAL nix develop --command bash -c "just m1-da-light-node native build.setup.test.local -t=false"
 
   mcr:
 #    if: false
@@ -126,8 +122,31 @@ jobs:
 
     - name: Run MCR tests in nix environment
       # adjust the log level while debugging
-      run: CELESTIA_LOG_LEVEL=FATAL nix develop --command bash  -c "just mcr native test.local -t=false"  
+      run: CELESTIA_LOG_LEVEL=FATAL nix develop --command bash -c "just mcr native test.local -t=false"
 
     - name: Run MCR Client Tests
-      run: nix develop --command bash  -c "just mcr-client native build.local.test -t=false"
+      run: nix develop --command bash -c "just mcr-client native build.local.test -t=false"
+
+  solidity-contracts:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            arch: x86_64
+            runs-on: buildjet-8vcpu-ubuntu-2204
+
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install Foundry
+      run: curl -L https://foundry.paradigm.xyz | bash
+
+    - name: Run foundry tests
+      run: |
+        source $HOME/.foundry/bin
+        cd protocol-units/bridge/contracts
+        forge test --fork-url https://ethereum-sepolia-rpc.publicnode.com -vv
 

--- a/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
@@ -25,9 +25,7 @@ contract AtomicBridgeCounterparty is IAtomicBridgeCounterparty, Initializable {
     mapping(bytes32 => BridgeTransferDetails) public bridgeTransfers; 
 
     function initialize(address _atomicBridgeInitiator) public initializer {
-        if (_atomicBridgeInitiator == address(0)) {
-            revert ZeroAddress();
-        }
+        if (_atomicBridgeInitiator == address(0)) revert ZeroAddress();
         atomicBridgeInitiator = AtomicBridgeInitiator(_atomicBridgeInitiator);
     }
 
@@ -81,4 +79,3 @@ contract AtomicBridgeCounterparty is IAtomicBridgeCounterparty, Initializable {
         emit BridgeTransferCancelled(bridgeTransferId);
     }
 }
-

--- a/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
@@ -92,9 +92,6 @@ contract AtomicBridgeCounterparty is IAtomicBridgeCounterparty, Initializable {
         delete pendingTransfers[bridgeTransferId];
         abortedTransfers[bridgeTransferId] = details;
 
-        // Call withdrawWETH on AtomicBridgeInitiator to refund the initiator
-        atomicBridgeInitiator.withdrawWETH(details.recipient, details.amount);
-
         emit BridgeTransferCancelled(bridgeTransferId);
     }
 }

--- a/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/cryptography/keccak256.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
+
+contract AtomicBridgeCounterparty is Ownable {
+    using EnumerableMap for EnumerableMap.Bytes32ToAddressMap;
+
+    struct BridgeTransferDetails {
+        address initiator; // Ethereum address
+        address recipient;
+        uint256 amount;
+        bytes32 hashLock;
+        uint256 timeLock;
+    }
+
+    IERC20 public weth;
+    mapping(bytes32 => BridgeTransferDetails) public pendingTransfers;
+    mapping(bytes32 => BridgeTransferDetails) public completedTransfers;
+    mapping(bytes32 => BridgeTransferDetails) public abortedTransfers;
+
+    event BridgeTransferAssetsLocked(
+        bytes32 bridgeTransferId,
+        address recipient,
+        uint256 amount,
+        bytes32 hashLock,
+        uint256 timeLock
+    );
+
+    event BridgeTransferCompleted(
+        bytes32 bridgeTransferId,
+        bytes preImage
+    );
+
+    event BridgeTransferCancelled(
+        bytes32 bridgeTransferId
+    );
+
+    constructor(IERC20 _weth) {
+        weth = _weth;
+    }
+
+    function lockBridgeTransferAssets(
+        bytes32 bridgeTransferId,
+        bytes32 hashLock,
+        uint256 timeLock,
+        address recipient,
+        uint256 amount
+    ) external returns (bool) {
+        require(pendingTransfers[bridgeTransferId].initiator == address(0), "Transfer ID already exists");
+
+        weth.transferFrom(msg.sender, address(this), amount);
+
+        pendingTransfers[bridgeTransferId] = BridgeTransferDetails({
+            initiator: msg.sender,
+            recipient: recipient,
+            amount: amount,
+            hashLock: hashLock,
+            timeLock: block.timestamp + timeLock
+        });
+
+        emit BridgeTransferAssetsLocked(bridgeTransferId, recipient, amount, hashLock, timeLock);
+
+        return true;
+    }
+
+    function completeBridgeTransfer(
+        bytes32 bridgeTransferId,
+        bytes memory preImage
+    ) external {
+        BridgeTransferDetails memory details = pendingTransfers[bridgeTransferId];
+        require(details.initiator != address(0), "Transfer ID does not exist");
+
+        bytes32 computedHash = keccak256(preImage);
+        require(computedHash == details.hashLock, "Invalid preImage");
+
+        delete pendingTransfers[bridgeTransferId];
+        completedTransfers[bridgeTransferId] = details;
+
+        weth.transfer(details.recipient, details.amount);
+
+        emit BridgeTransferCompleted(bridgeTransferId, preImage);
+    }
+
+    function abortBridgeTransfer(
+        bytes32 bridgeTransferId
+    ) external onlyOwner {
+        BridgeTransferDetails memory details = pendingTransfers[bridgeTransferId];
+        require(details.initiator != address(0), "Transfer ID does not exist");
+        require(block.timestamp > details.timeLock, "Timelock has not expired");
+
+        delete pendingTransfers[bridgeTransferId];
+        abortedTransfers[bridgeTransferId] = details;
+
+        weth.transfer(details.initiator, details.amount);
+
+        emit BridgeTransferCancelled(bridgeTransferId);
+    }
+}
+

--- a/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
@@ -81,7 +81,7 @@ contract AtomicBridgeCounterparty is IAtomicBridgeCounterparty, OwnableUpgradeab
 
         details.state = MessageState.REFUNDED;
 
-        emit BridgeTransferCancelled(bridgeTransferId);
+        emit BridgeTransferAborted(bridgeTransferId);
     }
 }
 

--- a/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
@@ -43,8 +43,6 @@ contract AtomicBridgeCounterparty is IAtomicBridgeCounterparty, OwnableUpgradeab
         address recipient,
         uint256 amount
     ) external onlyOwner returns (bool) {
-        BridgeTransferDetails storage transfer = bridgeTransfers[bridgeTransferId];
-        if (transfer.recipient != address(0)) revert BridgeTransferInvalid();
         if (amount == 0) revert ZeroAmount();
 
         bridgeTransfers[bridgeTransferId] = BridgeTransferDetails({

--- a/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
@@ -13,17 +13,16 @@ contract AtomicBridgeCounterparty is IAtomicBridgeCounterparty, Initializable {
     }
 
     struct BridgeTransferDetails {
-        bytes32 initiator; // address of the initiator
+        bytes32 initiator; // movement address 
         address recipient;
         uint256 amount;
         bytes32 hashLock;
         uint256 timeLock;
+        MessageState state; 
     }
 
     AtomicBridgeInitiator public atomicBridgeInitiator;
-    mapping(bytes32 => BridgeTransferDetails) public pendingTransfers;
-    mapping(bytes32 => BridgeTransferDetails) public completedTransfers;
-    mapping(bytes32 => BridgeTransferDetails) public abortedTransfers;
+    mapping(bytes32 => BridgeTransferDetails) public bridgeTransfers; 
 
     function initialize(address _atomicBridgeInitiator) public initializer {
         if (_atomicBridgeInitiator == address(0)) {
@@ -40,19 +39,16 @@ contract AtomicBridgeCounterparty is IAtomicBridgeCounterparty, Initializable {
         address recipient,
         uint256 amount
     ) external returns (bool) {
-        if (pendingTransfers[bridgeTransferId].recipient != address(0)) {
-            revert BridgeTransferInvalid();
-        }
-        if (amount == 0) {
-            revert ZeroAmount();
-        }
-
-        pendingTransfers[bridgeTransferId] = BridgeTransferDetails({
+        BridgeTransferDetails storage transfer = bridgeTransfers[bridgeTransferId];
+        if (transfer.recipient != address(0)) revert BridgeTransferInvalid();
+        if (amount == 0) revert ZeroAmount();
+        bridgeTransfers[bridgeTransferId] = BridgeTransferDetails({
             recipient: recipient,
             initiator: initiator,
             amount: amount,
             hashLock: hashLock,
-            timeLock: block.timestamp + timeLock
+            timeLock: block.timestamp + timeLock,
+            state: MessageState.PENDING 
         });
 
         emit BridgeTransferAssetsLocked(bridgeTransferId, recipient, amount, hashLock, timeLock);
@@ -61,18 +57,14 @@ contract AtomicBridgeCounterparty is IAtomicBridgeCounterparty, Initializable {
     }
 
     function completeBridgeTransfer(bytes32 bridgeTransferId, bytes32 preImage) external {
-        BridgeTransferDetails memory details = pendingTransfers[bridgeTransferId];
-        if (details.recipient == address(0)) {
-            revert BridgeTransferInvalid();
-        }
+        BridgeTransferDetails storage details = bridgeTransfers[bridgeTransferId];
+        if (details.state != MessageState.PENDING) revert BridgeTransferInvalid();
+        
 
         bytes32 computedHash = keccak256(abi.encodePacked(preImage));
-        if (computedHash != details.hashLock) {
-            revert InvalidSecret();
-        }
-
-        delete pendingTransfers[bridgeTransferId];
-        completedTransfers[bridgeTransferId] = details;
+        if (computedHash != details.hashLock) revert InvalidSecret();
+        if (block.timestamp > details.timeLock) revert TimeLockNotExpired();
+        details.state = MessageState.COMPLETED;
 
         // Call withdrawWETH on AtomicBridgeInitiator to transfer funds to the recipient
         atomicBridgeInitiator.withdrawWETH(details.recipient, details.amount);
@@ -81,17 +73,12 @@ contract AtomicBridgeCounterparty is IAtomicBridgeCounterparty, Initializable {
     }
 
     function abortBridgeTransfer(bytes32 bridgeTransferId) external {
-        BridgeTransferDetails memory details = pendingTransfers[bridgeTransferId];
-        if (details.recipient == address(0)) {
-            revert BridgeTransferInvalid();
-        }
-        if (block.timestamp <= details.timeLock) {
-            revert TimeLockNotExpired();
-        }
-
-        delete pendingTransfers[bridgeTransferId];
-        abortedTransfers[bridgeTransferId] = details;
+        BridgeTransferDetails storage details = bridgeTransfers[bridgeTransferId];
+        if (details.state != MessageState.PENDING) revert BridgeTransferInvalid();
+        if (block.timestamp <= details.timeLock) revert TimeLockNotExpired();
+        details.state = MessageState.REFUNDED;
 
         emit BridgeTransferCancelled(bridgeTransferId);
     }
 }
+

--- a/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
@@ -14,16 +14,16 @@ contract AtomicBridgeCounterparty is IAtomicBridgeCounterparty, Initializable, O
     }
 
     struct BridgeTransferDetails {
-        bytes32 initiator; // address of the initiator
+        bytes32 initiator; // move address 
         address recipient;
         uint256 amount;
         bytes32 hashLock;
         uint256 timeLock;
-        MessageState state; // Added state to manage the status of each transfer
+        MessageState state; 
     }
 
     AtomicBridgeInitiator public atomicBridgeInitiator;
-    mapping(bytes32 => BridgeTransferDetails) public bridgeTransfers; // Single mapping for all transfers
+    mapping(bytes32 => BridgeTransferDetails) public bridgeTransfers; 
 
     function initialize(address _atomicBridgeInitiator, address owner) public initializer {
         if (_atomicBridgeInitiator == address(0)) revert ZeroAddress();

--- a/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.22;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {IWETH9} from "./IWETH9.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {IAtomicBridgeCounterparty} from "./IAtomicBridgeCounterparty.sol";
+import {AtomicBridgeInitiator} from "./AtomicBridgeInitator.sol";
 
 contract AtomicBridgeCounterparty is IAtomicBridgeCounterparty, Initializable {
     enum MessageState {
@@ -14,23 +13,23 @@ contract AtomicBridgeCounterparty is IAtomicBridgeCounterparty, Initializable {
     }
 
     struct BridgeTransferDetails {
-        bytes32 initiator; // move address
+        bytes32 initiator; // address of the initiator
         address recipient;
         uint256 amount;
         bytes32 hashLock;
         uint256 timeLock;
     }
 
-    IERC20 public weth;
+    AtomicBridgeInitiator public atomicBridgeInitiator;
     mapping(bytes32 => BridgeTransferDetails) public pendingTransfers;
     mapping(bytes32 => BridgeTransferDetails) public completedTransfers;
     mapping(bytes32 => BridgeTransferDetails) public abortedTransfers;
 
-    function initialize(address _weth) public initializer {
-        if (_weth == address(0)) {
+    function initialize(address _atomicBridgeInitiator) public initializer {
+        if (_atomicBridgeInitiator == address(0)) {
             revert ZeroAddress();
         }
-        weth = IWETH9(_weth);
+        atomicBridgeInitiator = AtomicBridgeInitiator(_atomicBridgeInitiator);
     }
 
     function lockBridgeTransferAssets(
@@ -43,8 +42,6 @@ contract AtomicBridgeCounterparty is IAtomicBridgeCounterparty, Initializable {
     ) external returns (bool) {
         require(pendingTransfers[bridgeTransferId].recipient == address(0), "Transfer ID already exists");
         require(amount > 0, "Zero amount not allowed");
-
-        weth.transferFrom(msg.sender, address(this), amount);
 
         pendingTransfers[bridgeTransferId] = BridgeTransferDetails({
             recipient: recipient,
@@ -69,7 +66,8 @@ contract AtomicBridgeCounterparty is IAtomicBridgeCounterparty, Initializable {
         delete pendingTransfers[bridgeTransferId];
         completedTransfers[bridgeTransferId] = details;
 
-        weth.transfer(details.recipient, details.amount);
+        // Call withdrawWETH on AtomicBridgeInitiator to transfer funds to the recipient
+        atomicBridgeInitiator.withdrawWETH(details.recipient, details.amount);
 
         emit BridgeTransferCompleted(bridgeTransferId, preImage);
     }
@@ -82,9 +80,9 @@ contract AtomicBridgeCounterparty is IAtomicBridgeCounterparty, Initializable {
         delete pendingTransfers[bridgeTransferId];
         abortedTransfers[bridgeTransferId] = details;
 
-        weth.transfer(details.recipient, details.amount);
+        // Call withdrawWETH on AtomicBridgeInitiator to refund the initiator
+        atomicBridgeInitiator.withdrawWETH(details.recipient, details.amount);
 
         emit BridgeTransferCancelled(bridgeTransferId);
     }
 }
-

--- a/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
@@ -44,7 +44,6 @@ contract AtomicBridgeCounterparty is IAtomicBridgeCounterparty, OwnableUpgradeab
         uint256 amount
     ) external onlyOwner returns (bool) {
         if (amount == 0) revert ZeroAmount();
-
         bridgeTransfers[bridgeTransferId] = BridgeTransferDetails({
             recipient: recipient,
             initiator: initiator,

--- a/protocol-units/bridge/contracts/src/AtomicBridgeInitator.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeInitator.sol
@@ -5,7 +5,7 @@ import {IAtomicBridgeInitiator} from "./IAtomicBridgeInitiator.sol";
 import {IWETH9} from "./IWETH9.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
-contract AtomicBridgeInitiator is IAtomicBridgeInitiator,  OwnableUpgradeable {
+contract AtomicBridgeInitiator is IAtomicBridgeInitiator, OwnableUpgradeable {
     enum MessageState {
         INITIALIZED,
         COMPLETED,

--- a/protocol-units/bridge/contracts/src/AtomicBridgeInitator.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeInitator.sol
@@ -105,11 +105,11 @@ contract AtomicBridgeInitiator is IAtomicBridgeInitiator, OwnableUpgradeable {
     }
 
     // Counterparty contract to withdraw WETH for originator
-    function withdrawWETH(address originator, uint256 amount) external {
+    function withdrawWETH(address recipient, uint256 amount) external {
         if (msg.sender != counterpartyContract) revert Unauthorized();
-        if (balances[originator] < amount) revert ZeroAmount();
-        balances[originator] -= amount;
-        if (!weth.transfer(originator, amount)) revert WETHTransferFailed();
+        if (balances[recipient] < amount) revert ZeroAmount();
+        balances[recipient] -= amount;
+        if (!weth.transfer(recipient, amount)) revert WETHTransferFailed();
     }
 }
 

--- a/protocol-units/bridge/contracts/src/AtomicBridgeInitator.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeInitator.sol
@@ -106,10 +106,10 @@ contract AtomicBridgeInitiator is IAtomicBridgeInitiator, OwnableUpgradeable {
 
     // Counterparty contract to withdraw WETH for originator
     function withdrawWETH(address originator, uint256 amount) external {
-        require(msg.sender == counterpartyContract, "Caller is not the counterparty contract");
-        require(balances[originator] >= amount, "Insufficient balance");
+        if (msg.sender != counterpartyContract) revert Unauthorized();
+        if (balances[originator] < amount) revert ZeroAmount();
         balances[originator] -= amount;
-        require(weth.transfer(originator, amount), "WETH transfer failed");
+        if (!weth.transfer(originator, amount)) revert WETHTransferFailed();
     }
 }
 

--- a/protocol-units/bridge/contracts/src/AtomicBridgeInitator.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeInitator.sol
@@ -108,7 +108,7 @@ contract AtomicBridgeInitiator is IAtomicBridgeInitiator, OwnableUpgradeable {
     // Counterparty contract to withdraw WETH for originator
     function withdrawWETH(address recipient, uint256 amount) external {
         if (msg.sender != counterpartyContract) revert Unauthorized();
-        if (poolBalance < amount) revert ZeroAmount();
+        if (poolBalance < amount) revert InsufficientWethBalance();
         poolBalance -= amount;
         if (!weth.transfer(recipient, amount)) revert WETHTransferFailed();
     }

--- a/protocol-units/bridge/contracts/src/IAtomicBridgeCounterparty.sol
+++ b/protocol-units/bridge/contracts/src/IAtomicBridgeCounterparty.sol
@@ -23,6 +23,7 @@ interface IAtomicBridgeCounterparty {
     error BridgeTransferHasBeenCompleted();
     error BridgeTransferStateNotInitialized();
     error BridgeTransferStateNotPending();
+    error InsufficientWethBalance();
     error TimeLockNotExpired();
     error ZeroAddress();
     error Unauthorized();

--- a/protocol-units/bridge/contracts/src/IAtomicBridgeCounterparty.sol
+++ b/protocol-units/bridge/contracts/src/IAtomicBridgeCounterparty.sol
@@ -13,8 +13,8 @@ interface IAtomicBridgeCounterparty {
     // Event emitted when a BridgeTransfer is completed
     event BridgeTransferCompleted(bytes32 indexed bridgeTransferId, bytes32 pre_image);
 
-    // Event emitted when a BridgeTransfer is cancelled
-    event BridgeTransferCancelled(bytes32 indexed bridgeTransferId);
+    // Event emitted when a BridgeTransfer is aborted 
+    event BridgeTransferAborted(bytes32 indexed bridgeTransferId);
 
     error ZeroAmount();
     error WETHTransferFailed();

--- a/protocol-units/bridge/contracts/src/IAtomicBridgeCounterparty.sol
+++ b/protocol-units/bridge/contracts/src/IAtomicBridgeCounterparty.sol
@@ -22,6 +22,7 @@ interface IAtomicBridgeCounterparty {
     error InvalidSecret();
     error BridgeTransferHasBeenCompleted();
     error BridgeTransferStateNotInitialized();
+    error BridgeTransferStateNotPending();
     error TimeLockNotExpired();
     error ZeroAddress();
     error Unauthorized();

--- a/protocol-units/bridge/contracts/src/IAtomicBridgeCounterparty.sol
+++ b/protocol-units/bridge/contracts/src/IAtomicBridgeCounterparty.sol
@@ -3,18 +3,18 @@ pragma solidity ^0.8.22;
 interface IAtomicBridgeCounterparty {
     // Event emitted when a new atomic bridge transfer is locked
     event BridgeTransferAssetsLocked(
-        bytes32 indexed _bridgeTransferId,
-        address indexed _recipient,
+        bytes32 indexed bridgeTransferId,
+        address indexed recipient,
         uint256 amount,
-        bytes32 _hashLock,
-        uint256 _timeLock
+        bytes32 hashLock,
+        uint256 timeLock
     );
 
     // Event emitted when a BridgeTransfer is completed
-    event BridgeTransferCompleted(bytes32 indexed _bridgeTransferId, bytes32 pre_image);
+    event BridgeTransferCompleted(bytes32 indexed bridgeTransferId, bytes32 pre_image);
 
     // Event emitted when a BridgeTransfer is cancelled
-    event BridgeTransferCancelled(bytes32 indexed _bridgeTransferId);
+    event BridgeTransferCancelled(bytes32 indexed bridgeTransferId);
 
     error ZeroAmount();
     error WETHTransferFailed();
@@ -28,35 +28,37 @@ interface IAtomicBridgeCounterparty {
 
     /**
      * @dev Locks the assets for a new atomic bridge transfer
-     * @param _bridgeTransferId A unique id representing this BridgeTransfer
-     * @param _hashLock The hash of the secret (HASH) that will unlock the funds
-     * @param _timeLock The timestamp until which this BridgeTransfer is valid and can be executed
-     * @param _recipient The address to which to transfer the funds
-     * @param _amount The amount of WETH to lock
+     * @param initiator The address of the initiator of the BridgeTransfer 
+     * @param bridgeTransferId A unique id representing this BridgeTransfer
+     * @param hashLock The hash of the secret (HASH) that will unlock the funds
+     * @param timeLock The timestamp until which this BridgeTransfer is valid and can be executed
+     * @param recipient The address to which to transfer the funds
+     * @param amount The amount of WETH to lock
      * @return bool indicating successful lock
      *
      */
     function lockBridgeTransferAssets(
-        bytes32 _bridgeTransferId,
-        bytes32 _hashLock,
-        uint256 _timeLock,
-        address _recipient,
-        uint256 _amount
+        bytes32 initiator,
+        bytes32 bridgeTransferId,
+        bytes32 hashLock,
+        uint256 timeLock,
+        address recipient,
+        uint256 amount
     ) external returns (bool);
 
     /**
      * @dev Completes the bridge transfer and withdraws WETH to the recipient
-     * @param _bridgeTransferId Unique identifier for the BridgeTransfer
+     * @param bridgeTransferId Unique identifier for the BridgeTransfer
      * @param preImage The secret that unlocks the funds
      *
      */
-    function completeBridgeTransfer(bytes32 _bridgeTransferId, bytes32 preImage) external;
+    function completeBridgeTransfer(bytes32 bridgeTransferId, bytes32 preImage) external;
 
     /**
      * @dev Cancels the bridge transfer and refunds the initiator if the timelock has expired
-     * @param _bridgeTransferId Unique identifier for the BridgeTransfer
+     * @param bridgeTransferId Unique identifier for the BridgeTransfer
      *
      */
-    function abortBridgeTransfer(bytes32 _bridgeTransferId) external;
+    function abortBridgeTransfer(bytes32 bridgeTransferId) external;
 }
 

--- a/protocol-units/bridge/contracts/src/IAtomicBridgeCounterparty.sol
+++ b/protocol-units/bridge/contracts/src/IAtomicBridgeCounterparty.sol
@@ -1,0 +1,62 @@
+pragma solidity ^0.8.22;
+
+interface IAtomicBridgeCounterparty {
+    // Event emitted when a new atomic bridge transfer is locked
+    event BridgeTransferAssetsLocked(
+        bytes32 indexed _bridgeTransferId,
+        address indexed _recipient,
+        uint256 amount,
+        bytes32 _hashLock,
+        uint256 _timeLock
+    );
+
+    // Event emitted when a BridgeTransfer is completed
+    event BridgeTransferCompleted(bytes32 indexed _bridgeTransferId, bytes32 pre_image);
+
+    // Event emitted when a BridgeTransfer is cancelled
+    event BridgeTransferCancelled(bytes32 indexed _bridgeTransferId);
+
+    error ZeroAmount();
+    error WETHTransferFailed();
+    error BridgeTransferInvalid();
+    error InvalidSecret();
+    error BridgeTransferHasBeenCompleted();
+    error BridgeTransferStateNotInitialized();
+    error TimeLockNotExpired();
+    error ZeroAddress();
+    error Unauthorized();
+
+    /**
+     * @dev Locks the assets for a new atomic bridge transfer
+     * @param _bridgeTransferId A unique id representing this BridgeTransfer
+     * @param _hashLock The hash of the secret (HASH) that will unlock the funds
+     * @param _timeLock The timestamp until which this BridgeTransfer is valid and can be executed
+     * @param _recipient The address to which to transfer the funds
+     * @param _amount The amount of WETH to lock
+     * @return bool indicating successful lock
+     *
+     */
+    function lockBridgeTransferAssets(
+        bytes32 _bridgeTransferId,
+        bytes32 _hashLock,
+        uint256 _timeLock,
+        address _recipient,
+        uint256 _amount
+    ) external returns (bool);
+
+    /**
+     * @dev Completes the bridge transfer and withdraws WETH to the recipient
+     * @param _bridgeTransferId Unique identifier for the BridgeTransfer
+     * @param preImage The secret that unlocks the funds
+     *
+     */
+    function completeBridgeTransfer(bytes32 _bridgeTransferId, bytes32 preImage) external;
+
+    /**
+     * @dev Cancels the bridge transfer and refunds the initiator if the timelock has expired
+     * @param _bridgeTransferId Unique identifier for the BridgeTransfer
+     *
+     */
+    function abortBridgeTransfer(bytes32 _bridgeTransferId) external;
+}
+

--- a/protocol-units/bridge/contracts/src/IAtomicBridgeInitiator.sol
+++ b/protocol-units/bridge/contracts/src/IAtomicBridgeInitiator.sol
@@ -22,6 +22,7 @@ interface IAtomicBridgeInitiator {
     error InvalidSecret();
     error BridgeTransferHasBeenCompleted();
     error BridgeTransferStateNotInitialized();
+    error InsufficientWethBalance();
     error TimeLockNotExpired();
     error TimelockExpired();
     error ZeroAddress();

--- a/protocol-units/bridge/contracts/test/AtomicBridgeCounterparty.t.sol
+++ b/protocol-units/bridge/contracts/test/AtomicBridgeCounterparty.t.sol
@@ -50,8 +50,9 @@ contract AtomicBridgeCounterpartyTest is Test {
             address pendingRecipient,
             uint256 pendingAmount,
             bytes32 pendingHashLock,
-            uint256 pendingTimelock
-        ) = atomicBridgeCounterparty.pendingTransfers(bridgeTransferId);
+            uint256 pendingTimelock,
+            AtomicBridgeCounterparty.MessageState pendingState
+        ) = atomicBridgeCounterparty.bridgeTransfers(bridgeTransferId);
 
         assert(result);
         assertEq(pendingInitiator, initiator);
@@ -59,6 +60,7 @@ contract AtomicBridgeCounterpartyTest is Test {
         assertEq(pendingAmount, amount);
         assertEq(pendingHashLock, hashLock);
         assertGt(pendingTimelock, block.timestamp);
+        assertEq(uint8(pendingState), uint8(AtomicBridgeCounterparty.MessageState.PENDING));
 
         vm.stopPrank();
     }
@@ -92,14 +94,16 @@ contract AtomicBridgeCounterpartyTest is Test {
             address completedRecipient,
             uint256 completedAmount,
             bytes32 completedHashLock,
-            uint256 completedTimeLock 
-        ) = atomicBridgeCounterparty.completedTransfers(bridgeTransferId);
+            uint256 completedTimeLock,
+            AtomicBridgeCounterparty.MessageState completedState
+        ) = atomicBridgeCounterparty.bridgeTransfers(bridgeTransferId);
 
         assertEq(completedInitiator, initiator);
         assertEq(completedRecipient, recipient);
         assertEq(completedAmount, amount);
         assertEq(completedHashLock, testHashLock);
         assertGt(completedTimeLock, block.timestamp);
+        assertEq(uint8(completedState), uint8(AtomicBridgeCounterparty.MessageState.COMPLETED));
 
         vm.stopPrank();
     }
@@ -133,15 +137,16 @@ contract AtomicBridgeCounterpartyTest is Test {
         address abortedRecipient,
         uint256 abortedAmount,
         bytes32 abortedHashLock,
-        uint256 abortedTimeLock
-    ) = atomicBridgeCounterparty.abortedTransfers(bridgeTransferId);
+        uint256 abortedTimeLock,
+        AtomicBridgeCounterparty.MessageState abortedState
+    ) = atomicBridgeCounterparty.bridgeTransfers(bridgeTransferId);
 
-    // Correct assertions
     assertEq(abortedInitiator, initiator);
     assertEq(abortedRecipient, recipient);
     assertEq(abortedAmount, amount);
     assertEq(abortedHashLock, hashLock);
     assertLe(abortedTimeLock, block.timestamp, "Timelock is not less than or equal to current block timestamp");
+    assertEq(uint8(abortedState), uint8(AtomicBridgeCounterparty.MessageState.REFUNDED));
 
     vm.stopPrank();
 }

--- a/protocol-units/bridge/contracts/test/AtomicBridgeCounterparty.t.sol
+++ b/protocol-units/bridge/contracts/test/AtomicBridgeCounterparty.t.sol
@@ -61,8 +61,8 @@ contract AtomicBridgeCounterpartyTest is Test {
     }
 
     function testCompleteBridgeTransfer() public {
-        bytes memory preImage = "secret";
-        bytes32 testHashLock = keccak256(preImage);
+        bytes32 preImage = "secret";
+        bytes32 testHashLock = keccak256(abi.encodePacked(preImage));
 
         vm.deal(deployer, 1 ether);
         vm.startPrank(deployer);

--- a/protocol-units/bridge/contracts/test/AtomicBridgeCounterparty.t.sol
+++ b/protocol-units/bridge/contracts/test/AtomicBridgeCounterparty.t.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.22;
+pragma abicoder v2;
+
+import {Test, console} from "forge-std/Test.sol";
+import {AtomicBridgeCounterparty} from "../src/AtomicBridgeCounterparty.sol";
+import {IWETH9} from "../src/IWETH9.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract AtomicBridgeCounterpartyTest is Test {
+    AtomicBridgeCounterparty public atomicBridgeCounterparty;
+    IWETH9 public weth;
+
+    address public deployer = address(1);
+    address public recipient = address(2);
+    address public otherUser = address(3);
+    bytes32 public hashLock = keccak256(abi.encodePacked("secret"));
+    uint256 public amount = 1 ether;
+    uint256 public timeLock = 100;
+    bytes32 public bridgeTransferId = keccak256(abi.encodePacked(block.number, deployer, recipient, amount, hashLock, timeLock));
+
+    function setUp() public {
+        // Sepolia WETH9 address
+        address wethAddress = 0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14;
+        weth = IWETH9(wethAddress);
+
+        atomicBridgeCounterparty = new AtomicBridgeCounterparty(IERC20(wethAddress));
+    }
+
+    function testLockBridgeTransferAssets() public {
+        vm.deal(deployer, 1 ether);
+        vm.startPrank(deployer);
+
+        weth.deposit{value: amount}();
+        weth.approve(address(atomicBridgeCounterparty), amount);
+
+        bool result = atomicBridgeCounterparty.lockBridgeTransferAssets(
+            bridgeTransferId,
+            hashLock,
+            timeLock,
+            recipient,
+            amount
+        );
+
+        (
+            address initiator,
+            address storedRecipient,
+            uint256 storedAmount,
+            bytes32 storedHashLock,
+            uint256 storedTimeLock
+        ) = atomicBridgeCounterparty.pendingTransfers(bridgeTransferId);
+
+        assert(result);
+        assertEq(initiator, deployer);
+        assertEq(storedRecipient, recipient);
+        assertEq(storedAmount, amount);
+        assertEq(storedHashLock, hashLock);
+        assertGt(storedTimeLock, block.timestamp);
+
+        vm.stopPrank();
+    }
+
+    function testCompleteBridgeTransfer() public {
+        bytes memory preImage = "secret";
+        bytes32 testHashLock = keccak256(preImage);
+
+        vm.deal(deployer, 1 ether);
+        vm.startPrank(deployer);
+
+        weth.deposit{value: amount}();
+        weth.approve(address(atomicBridgeCounterparty), amount);
+
+        atomicBridgeCounterparty.lockBridgeTransferAssets(
+            bridgeTransferId,
+            testHashLock,
+            timeLock,
+            recipient,
+            amount
+        );
+
+        vm.stopPrank();
+        vm.startPrank(otherUser);
+
+        atomicBridgeCounterparty.completeBridgeTransfer(bridgeTransferId, preImage);
+
+        (
+            address initiator,
+            address storedRecipient,
+            uint256 storedAmount,
+            bytes32 storedHashLock,
+            uint256 storedTimeLock
+        ) = atomicBridgeCounterparty.completedTransfers(bridgeTransferId);
+
+        assertEq(initiator, deployer);
+        assertEq(storedRecipient, recipient);
+        assertEq(storedAmount, amount);
+        assertEq(storedHashLock, testHashLock);
+        assertGt(storedTimeLock, block.timestamp);
+
+        vm.stopPrank();
+    }
+
+    function testAbortBridgeTransfer() public {
+        vm.deal(deployer, 1 ether);
+        vm.startPrank(deployer);
+
+        weth.deposit{value: amount}();
+        weth.approve(address(atomicBridgeCounterparty), amount);
+
+        atomicBridgeCounterparty.lockBridgeTransferAssets(
+            bridgeTransferId,
+            hashLock,
+            timeLock,
+            recipient,
+            amount
+        );
+
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + timeLock + 1);
+        vm.startPrank(deployer);
+
+        atomicBridgeCounterparty.abortBridgeTransfer(bridgeTransferId);
+
+        (
+            address initiator,
+            address storedRecipient,
+            uint256 storedAmount,
+            bytes32 storedHashLock,
+            uint256 storedTimeLock
+        ) = atomicBridgeCounterparty.abortedTransfers(bridgeTransferId);
+
+        assertEq(initiator, deployer);
+        assertEq(storedRecipient, recipient);
+        assertEq(storedAmount, amount);
+        assertEq(storedHashLock, hashLock);
+        assertGt(storedTimeLock, block.timestamp);
+
+        vm.stopPrank();
+    }
+}
+

--- a/protocol-units/bridge/contracts/test/AtomicBridgeInitiator.t.sol
+++ b/protocol-units/bridge/contracts/test/AtomicBridgeInitiator.t.sol
@@ -25,11 +25,11 @@ contract AtomicBridgeInitiatorWethTest is Test {
     uint256 public timeLock = 100;
 
     function setUp() public {
-        //Sepolia WETH9 address
+        // Sepolia WETH9 address
         address wethAddress = 0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14;
         weth = IWETH9(wethAddress);
 
-        //generate random address for each test
+        // generate random address for each test
         originator = vm.addr(uint256(keccak256(abi.encodePacked(block.number, block.prevrandao))));
 
         // Deploy the AtomicBridgeInitiator contract with the WETH address
@@ -60,14 +60,16 @@ contract AtomicBridgeInitiatorWethTest is Test {
             address transferOriginator,
             bytes32 transferRecipient,
             bytes32 transferHashLock,
-            uint256 transferTimeLock
-            ,
+            uint256 transferTimeLock,
+            AtomicBridgeInitiator.MessageState transferState
         ) = atomicBridgeInitiator.bridgeTransfers(bridgeTransferId);
+
         assertEq(transferAmount, amount);
         assertEq(transferOriginator, originator);
         assertEq(transferRecipient, recipient);
         assertEq(transferHashLock, hashLock);
         assertGt(transferTimeLock, block.number);
+        assertEq(uint8(transferState), uint8(AtomicBridgeInitiator.MessageState.INITIALIZED));
 
         vm.stopPrank();
     }
@@ -94,14 +96,16 @@ contract AtomicBridgeInitiatorWethTest is Test {
             address completedOriginator,
             bytes32 completedRecipient,
             bytes32 completedHashLock,
-            uint256 completedTimeLock
-            ,
+            uint256 completedTimeLock,
+            AtomicBridgeInitiator.MessageState completedState
         ) = atomicBridgeInitiator.bridgeTransfers(bridgeTransferId);
+
         assertEq(completedAmount, amount);
         assertEq(completedOriginator, originator);
         assertEq(completedRecipient, recipient);
         assertEq(completedHashLock, testHashLock);
         assertGt(completedTimeLock, block.number);
+        assertEq(uint8(completedState), uint8(AtomicBridgeInitiator.MessageState.COMPLETED));
     }
 
     function testInitiateBridgeTransferWithWeth() public {
@@ -120,14 +124,16 @@ contract AtomicBridgeInitiatorWethTest is Test {
             address transferOriginator,
             bytes32 transferRecipient,
             bytes32 transferHashLock,
-            uint256 transferTimeLock
-            ,
+            uint256 transferTimeLock,
+            AtomicBridgeInitiator.MessageState transferState
         ) = atomicBridgeInitiator.bridgeTransfers(bridgeTransferId);
+
         assertEq(transferAmount, wethAmount);
         assertEq(transferOriginator, originator);
         assertEq(transferRecipient, recipient);
         assertEq(transferHashLock, hashLock);
         assertGt(transferTimeLock, block.number);
+        assertEq(uint8(transferState), uint8(AtomicBridgeInitiator.MessageState.INITIALIZED));
 
         vm.stopPrank();
     }
@@ -159,8 +165,8 @@ contract AtomicBridgeInitiatorWethTest is Test {
             address transferOriginator,
             bytes32 transferRecipient,
             bytes32 transferHashLock,
-            uint256 transferTimeLock
-            ,
+            uint256 transferTimeLock,
+            AtomicBridgeInitiator.MessageState transferState
         ) = atomicBridgeInitiator.bridgeTransfers(bridgeTransferId);
 
         // Assertions
@@ -169,6 +175,7 @@ contract AtomicBridgeInitiatorWethTest is Test {
         assertEq(transferRecipient, recipient, "Recipient address mismatch");
         assertEq(transferHashLock, hashLock, "HashLock mismatch");
         assertGt(transferTimeLock, block.number, "TimeLock is not greater than current block number");
+        assertEq(uint8(transferState), uint8(AtomicBridgeInitiator.MessageState.INITIALIZED));
 
         vm.stopPrank();
     }
@@ -198,3 +205,4 @@ contract AtomicBridgeInitiatorWethTest is Test {
         vm.stopPrank();
     }
 }
+

--- a/protocol-units/bridge/contracts/test/AtomicBridgeInitiator.t.sol
+++ b/protocol-units/bridge/contracts/test/AtomicBridgeInitiator.t.sol
@@ -7,6 +7,7 @@ import {AtomicBridgeInitiator} from "../src/AtomicBridgeInitator.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {IWETH9} from "../src/IWETH9.sol";
+import {console} from "forge-std/console.sol";
 
 
 contract AtomicBridgeInitiatorWethTest is Test {
@@ -37,8 +38,9 @@ contract AtomicBridgeInitiatorWethTest is Test {
         proxy = new TransparentUpgradeableProxy(
             address(atomicBridgeInitiatorImplementation),
             address(proxyAdmin),
-            abi.encodeWithSignature("initialize(address)", wethAddress)
+            abi.encodeWithSignature("initialize(address,address)", wethAddress, address(this))
         );
+
         atomicBridgeInitiator = AtomicBridgeInitiator(address(proxy));
     }
 


### PR DESCRIPTION
# Summary
Creates the `AtomicBridgeCounterparty.sol` contract, tests and updates necessary logic in `AtomicBridgeInitiator.sol`. I added a storage mapping of balances in the Initiator contract. This is so that when users move MOVETH -> WETH they are able to withdraw their associated balance. We could have used a seperate Vault type contract, but I decided to keep it as simple as possible with minimal change necessary. 

Because of this, counterpary needs to call a withdraw function on Initiator, where the balances mapping is held. This function should of course only be callable by that contract and not by anyone, For this I added the ownable patter. To keep the contract upgradable, I used `UpgradableOwnable`.

# Changelog
- Creates new contract
- Creates new test
- Uses `UpgradableOwnable.sol` openzeppelin lib for initiator
- Updates `AtomicBridgeInitiator.t.sol` to assert on the enum values. 
- Adds the solidity tests to Checks CI

# Testing
Please run the tests.
`cd protocol-units/bridge/contracts && forge test --fork-url https://ethereum-sepolia-rpc.publicnode.com`

