### PR TITLE
bringing back indexer-processor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,8 +97,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.2.15",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -117,6 +119,27 @@ name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
+name = "allocative"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082af274fd02beef17b7f0725a49ecafe6c075ef56cac9d6363eb3916a9817ae"
+dependencies = [
+ "allocative_derive",
+ "ctor",
+]
+
+[[package]]
+name = "allocative_derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe233a377643e0fc1a56421d7c90acdec45c291b30345eb9f08e8d0ddce5a4ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
 
 [[package]]
 name = "allocator-api2"
@@ -628,7 +651,7 @@ dependencies = [
  "rustls 0.23.11",
  "serde_json",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.23.1",
  "tracing",
  "ws_stream_wasm",
 ]
@@ -1562,8 +1585,8 @@ dependencies = [
  "aptos-logger",
  "aptos-mempool",
  "aptos-metrics-core",
- "aptos-moving-average",
- "aptos-protos",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77)",
  "aptos-runtimes",
  "aptos-storage-interface",
  "aptos-types",
@@ -1582,7 +1605,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.11.0",
  "tonic-reflection",
 ]
 
@@ -1614,7 +1637,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -1624,7 +1647,7 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
- "aptos-protos",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77)",
  "async-trait",
  "backoff",
  "base64 0.13.1",
@@ -1636,7 +1659,7 @@ dependencies = [
  "lz4",
  "once_cell",
  "prometheus",
- "prost",
+ "prost 0.12.6",
  "redis",
  "redis-test",
  "ripemd",
@@ -1644,7 +1667,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
- "tonic",
+ "tonic 0.11.0",
  "tracing",
  "url",
 ]
@@ -1893,6 +1916,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-moving-average"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=efefd860fdb2f100f3314fc4aa05185e5082d3c7#efefd860fdb2f100f3314fc4aa05185e5082d3c7"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
@@ -1978,7 +2009,7 @@ dependencies = [
  "itertools 0.12.1",
  "maplit",
  "once_cell",
- "ordered-float",
+ "ordered-float 3.9.2",
  "pin-project 1.1.5",
  "rand 0.7.3",
  "rand 0.8.5",
@@ -2080,13 +2111,26 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=69afec8ffc55e5e04711cc3f7477186fb50c2dd1#69afec8ffc55e5e04711cc3f7477186fb50c2dd1"
+dependencies = [
+ "futures-core",
+ "pbjson",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+ "serde",
+ "tonic 0.11.0",
+]
+
+[[package]]
+name = "aptos-protos"
+version = "1.3.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "futures-core",
  "pbjson",
- "prost",
+ "prost 0.12.6",
  "serde",
- "tonic",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -2246,14 +2290,14 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
- "aptos-protos",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77)",
  "bcs 0.1.4",
  "crossbeam-channel",
  "once_cell",
  "serde",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.11.0",
  "tonic-reflection",
 ]
 
@@ -3149,6 +3193,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bb8"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b10cf871f3ff2ce56432fddc2615ac7acc3aa22ca321f8fea800846fbb32f188"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
 name = "bcs"
 version = "0.1.4"
 source = "git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d#d31fab9d81748e2594be5cd5cdf845786a30562d"
@@ -3701,6 +3757,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "canonical_json"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89083fd014d71c47a718d7f4ac050864dac8587668dbe90baf9e261064c5710"
+dependencies = [
+ "hex",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "captcha"
 version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3774,9 +3843,9 @@ source = "git+https://github.com/eigerco/lumina#af040a8665b0a9c1cdae2442cce79c7b
 dependencies = [
  "anyhow",
  "celestia-tendermint-proto",
- "prost",
+ "prost 0.12.6",
  "prost-build",
- "prost-types",
+ "prost-types 0.12.6",
  "serde",
 ]
 
@@ -3809,8 +3878,8 @@ dependencies = [
  "futures",
  "num-traits",
  "once_cell",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -3833,8 +3902,8 @@ dependencies = [
  "flex-error",
  "num-derive",
  "num-traits",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -4208,9 +4277,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a257c22cd7e487dd4a13d413beabc512c5052f0bc048db0da6a84c3d8a6142fd"
 dependencies = [
  "futures-core",
- "prost",
- "prost-types",
- "tonic",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+ "tonic 0.11.0",
  "tracing-core",
 ]
 
@@ -4226,14 +4295,14 @@ dependencies = [
  "futures-task",
  "hdrhistogram",
  "humantime",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "serde",
  "serde_json",
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.11.0",
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.3.18",
@@ -4263,6 +4332,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.15",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "const_fn"
@@ -4621,6 +4710,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4938,6 +5037,20 @@ dependencies = [
  "pq-sys",
  "r2d2",
  "serde_json",
+]
+
+[[package]]
+name = "diesel-async"
+version = "0.4.1"
+source = "git+https://github.com/weiznich/diesel_async.git?rev=d02798c67065d763154d7272dd0c09b39757d0f2#d02798c67065d763154d7272dd0c09b39757d0f2"
+dependencies = [
+ "async-trait",
+ "bb8",
+ "diesel",
+ "futures-util",
+ "scoped-futures",
+ "tokio",
+ "tokio-postgres",
 ]
 
 [[package]]
@@ -5309,6 +5422,12 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible_collections"
@@ -5886,6 +6005,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "google-cloud-gax"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bdaaa4bc036e8318274d1b25f0f2265b3e95418b765fd1ea1c7ef938fd69bd"
+dependencies = [
+ "google-cloud-token",
+ "http 0.2.12",
+ "thiserror",
+ "tokio",
+ "tokio-retry",
+ "tonic 0.9.2",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-googleapis"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3b24a3f57be08afc02344e693afb55e48172c9c2ab86ff3fdb8efff550e4b9"
+dependencies = [
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "tonic 0.9.2",
+]
+
+[[package]]
 name = "google-cloud-metadata"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5894,6 +6040,25 @@ dependencies = [
  "reqwest 0.11.27",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "google-cloud-pubsub"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "095b104502b6e1abbad9b9768af944b9202e032dbc7f0947d3c30d4191761071"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-stream",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-googleapis",
+ "google-cloud-token",
+ "prost-types 0.11.9",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -6000,6 +6165,7 @@ checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
 ]
 
 [[package]]
@@ -6707,6 +6873,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "internment"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7052,6 +7224,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kanal"
+version = "0.1.0-pre8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05d55519627edaf7fd0f29981f6dc03fb52df3f5b257130eb8d0bf2801ea1d7"
+dependencies = [
+ "futures-core",
+ "lock_api",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7384,6 +7566,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "m1-da-light-node"
 version = "0.3.0"
 dependencies = [
@@ -7400,13 +7591,13 @@ dependencies = [
  "m1-da-light-node-util",
  "m1-da-light-node-verifier",
  "memseq",
- "prost",
+ "prost 0.12.6",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.11.0",
  "tonic-reflection",
  "tonic-web",
  "tracing",
@@ -7430,8 +7621,8 @@ name = "m1-da-light-node-grpc"
 version = "0.3.0"
 dependencies = [
  "buildtime",
- "prost",
- "tonic",
+ "prost 0.12.6",
+ "tonic 0.11.0",
  "tonic-build",
  "tonic-reflection",
  "tonic-web",
@@ -7496,7 +7687,7 @@ dependencies = [
  "jsonrpsee 0.20.3",
  "m1-da-light-node-grpc",
  "memseq-util",
- "prost",
+ "prost 0.12.6",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7504,7 +7695,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml 0.8.15",
- "tonic",
+ "tonic 0.11.0",
  "tonic-reflection",
  "tonic-web",
  "tracing",
@@ -7524,11 +7715,11 @@ dependencies = [
  "m1-da-light-node-grpc",
  "m1-da-light-node-setup",
  "m1-da-light-node-util",
- "prost",
+ "prost 0.12.6",
  "serde_json",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.11.0",
  "tonic-reflection",
  "tonic-web",
 ]
@@ -7625,7 +7816,7 @@ dependencies = [
  "aptos-language-e2e-tests",
  "aptos-logger",
  "aptos-mempool",
- "aptos-protos",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77)",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
@@ -7661,7 +7852,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.11.0",
  "tracing",
  "tracing-test",
 ]
@@ -7782,6 +7973,16 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -9090,6 +9291,15 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
@@ -9238,6 +9448,40 @@ dependencies = [
  "redox_syscall 0.5.3",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "parquet"
+version = "52.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f22ba0d95db56dde8685e3fadcb915cdaadda31ab8abbe3ff7f0ad1ef333267"
+dependencies = [
+ "ahash 0.8.11",
+ "bytes 1.6.1",
+ "chrono",
+ "futures",
+ "half 2.4.1",
+ "hashbrown 0.14.5",
+ "lz4_flex",
+ "num",
+ "num-bigint 0.4.6",
+ "paste",
+ "seq-macro",
+ "thrift",
+ "tokio",
+ "twox-hash",
+]
+
+[[package]]
+name = "parquet_derive"
+version = "52.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbfe02f8b63a15a78398db242f9b1d2dcc201319075ea6222c7108ffd48b23c0"
+dependencies = [
+ "parquet",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -9755,6 +9999,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgres-native-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d442770e2b1e244bb5eb03b31c79b65bb2568f413b899eaba850fa945a65954"
+dependencies = [
+ "futures",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acda0ebdebc28befa84bee35e651e4c5f09073d668c7aed4cf7e23c3cda84b23"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes 1.6.1",
+ "fallible-iterator",
+ "hmac 0.12.1",
+ "md-5",
+ "memchr",
+ "rand 0.8.5",
+ "sha2 0.10.8",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02048d9e032fb3cc3413bbf7b83a15d84a5d419778e2628751896d856498eee9"
+dependencies = [
+ "bytes 1.6.1",
+ "fallible-iterator",
+ "postgres-protocol",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9910,6 +10196,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "processor"
+version = "1.0.0"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=efefd860fdb2f100f3314fc4aa05185e5082d3c7#efefd860fdb2f100f3314fc4aa05185e5082d3c7"
+dependencies = [
+ "ahash 0.8.11",
+ "allocative",
+ "allocative_derive",
+ "anyhow",
+ "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=efefd860fdb2f100f3314fc4aa05185e5082d3c7)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=69afec8ffc55e5e04711cc3f7477186fb50c2dd1)",
+ "async-trait",
+ "bcs 0.1.4",
+ "bigdecimal",
+ "bitflags 2.6.0",
+ "canonical_json",
+ "chrono",
+ "clap 4.5.9",
+ "diesel",
+ "diesel-async",
+ "diesel_migrations",
+ "enum_dispatch",
+ "field_count",
+ "futures",
+ "futures-util",
+ "google-cloud-googleapis",
+ "google-cloud-pubsub",
+ "google-cloud-storage",
+ "hex",
+ "hyper 0.14.30",
+ "itertools 0.12.1",
+ "jemallocator",
+ "kanal",
+ "lazy_static",
+ "native-tls",
+ "num",
+ "num_cpus",
+ "once_cell",
+ "parquet",
+ "parquet_derive",
+ "postgres-native-tls",
+ "prometheus",
+ "prost 0.12.6",
+ "regex",
+ "serde",
+ "serde_json",
+ "server-framework",
+ "sha2 0.9.9",
+ "sha3",
+ "strum 0.24.1",
+ "tiny-keccak",
+ "tokio",
+ "tokio-postgres",
+ "tonic 0.11.0",
+ "tracing",
+ "unescape",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "procfs"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9971,12 +10317,22 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes 1.6.1",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes 1.6.1",
- "prost-derive",
+ "prost-derive 0.12.6",
 ]
 
 [[package]]
@@ -9993,11 +10349,24 @@ dependencies = [
  "once_cell",
  "petgraph 0.6.5",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "regex",
  "syn 2.0.72",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -10015,11 +10384,20 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost",
+ "prost 0.12.6",
 ]
 
 [[package]]
@@ -10840,6 +11218,16 @@ checksum = "84e217e7fdc8466b5b35d30f8c0a30febd29173df4a3a0c2115d306b9c4117ad"
 
 [[package]]
 name = "rustls-webpki"
+version = "0.100.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6a5fc258f1c1276dfe3016516945546e2d5383911efc0fc4f1cdc5df3a4ae3"
+dependencies = [
+ "ring 0.16.20",
+ "untrusted 0.7.1",
+]
+
+[[package]]
+name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
@@ -10935,6 +11323,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-futures"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1473e24c637950c9bd38763220bea91ec3e095a89f672bbd7a10d03e77ba467"
+dependencies = [
+ "cfg-if",
+ "pin-utils",
+]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11020,6 +11424,12 @@ name = "send_wrapper"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "sequencing-util"
@@ -11235,6 +11645,26 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "server-framework"
+version = "1.0.0"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=efefd860fdb2f100f3314fc4aa05185e5082d3c7#efefd860fdb2f100f3314fc4aa05185e5082d3c7"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "backtrace",
+ "clap 4.5.9",
+ "prometheus",
+ "serde",
+ "serde_yaml 0.8.26",
+ "tempfile",
+ "tokio",
+ "toml 0.7.8",
+ "tracing",
+ "tracing-subscriber 0.3.18",
+ "warp",
 ]
 
 [[package]]
@@ -11654,6 +12084,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11700,6 +12141,9 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros 0.24.3",
+]
 
 [[package]]
 name = "strum"
@@ -11784,7 +12228,7 @@ name = "suzuka-client"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "aptos-protos",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77)",
  "aptos-sdk",
  "aptos-types",
  "async-trait",
@@ -11807,7 +12251,7 @@ dependencies = [
  "suzuka-config",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.11.0",
  "tracing",
  "tracing-subscriber 0.3.18",
  "url",
@@ -11866,7 +12310,7 @@ dependencies = [
  "suzuka-config",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.11.0",
  "tracing",
  "tracing-subscriber 0.3.18",
 ]
@@ -11894,6 +12338,22 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tracing",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "suzuka-indexer-processor"
+version = "1.0.0"
+dependencies = [
+ "ahash 0.8.11",
+ "anyhow",
+ "dot-movement",
+ "num_cpus",
+ "processor",
+ "server-framework",
+ "suzuka-config",
+ "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",
 ]
@@ -12150,6 +12610,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float 2.10.1",
+]
+
+[[package]]
 name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12287,6 +12758,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-postgres"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03adcf0147e203b6032c0b2d30be1415ba03bc348901f3ff1cc0df6a733e60c3"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes 1.6.1",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.8.5",
+ "socket2 0.5.7",
+ "tokio",
+ "tokio-util",
+ "whoami",
+]
+
+[[package]]
 name = "tokio-retry"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12343,6 +12840,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
@@ -12353,7 +12862,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
- "tungstenite",
+ "tungstenite 0.23.0",
  "webpki-roots 0.26.3",
 ]
 
@@ -12463,6 +12972,39 @@ dependencies = [
 
 [[package]]
 name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.7",
+ "bytes 1.6.1",
+ "flate2",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project 1.1.5",
+ "prost 0.11.9",
+ "rustls-pemfile 1.0.4",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "webpki-roots 0.23.1",
+]
+
+[[package]]
+name = "tonic"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
@@ -12480,7 +13022,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project 1.1.5",
- "prost",
+ "prost 0.12.6",
  "rustls-native-certs",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
@@ -12513,11 +13055,11 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "548c227bd5c0fae5925812c4ec6c66ffcfced23ea370cb823f4d18f0fc1cb6a7"
 dependencies = [
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -12533,7 +13075,7 @@ dependencies = [
  "hyper 0.14.30",
  "pin-project 1.1.5",
  "tokio-stream",
- "tonic",
+ "tonic 0.11.0",
  "tower-http",
  "tower-layer",
  "tower-service",
@@ -12737,6 +13279,25 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes 1.6.1",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
@@ -12753,6 +13314,16 @@ dependencies = [
  "sha1",
  "thiserror",
  "utf-8",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
 ]
 
 [[package]]
@@ -12853,6 +13424,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unescape"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12937,6 +13514,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
 
 [[package]]
 name = "unicode-segmentation"
@@ -13138,6 +13721,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "warp"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
+dependencies = [
+ "bytes 1.6.1",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "http 0.2.12",
+ "hyper 0.14.30",
+ "log",
+ "mime",
+ "mime_guess",
+ "multer",
+ "percent-encoding",
+ "pin-project 1.1.5",
+ "rustls-pemfile 2.1.2",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tokio-tungstenite 0.21.0",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13242,6 +13856,15 @@ checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki 0.100.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6928,6 +6928,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
+name = "indexer-grpc-cache-worker"
+version = "0.3.0"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "antidote"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,7 +1592,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-metrics-core",
  "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf)",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77)",
+ "aptos-protos 1.3.0",
  "aptos-runtimes",
  "aptos-storage-interface",
  "aptos-types",
@@ -1647,7 +1653,7 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77)",
+ "aptos-protos 1.3.0",
  "async-trait",
  "backoff",
  "base64 0.13.1",
@@ -1918,7 +1924,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=efefd860fdb2f100f3314fc4aa05185e5082d3c7#efefd860fdb2f100f3314fc4aa05185e5082d3c7"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=da0ccef0f0e0e1be4b39073edb3277dfd6cb7dc1#da0ccef0f0e0e1be4b39073edb3277dfd6cb7dc1"
 dependencies = [
  "chrono",
 ]
@@ -2099,6 +2105,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-profiler"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-core.git?rev=4541add3fd29826ec57f22658ca286d2d6134b93#4541add3fd29826ec57f22658ca286d2d6134b93"
+dependencies = [
+ "anyhow",
+ "backtrace",
+ "jemalloc-sys",
+ "jemallocator",
+ "pprof",
+ "regex",
+]
+
+[[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
@@ -2111,20 +2130,19 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=69afec8ffc55e5e04711cc3f7477186fb50c2dd1#69afec8ffc55e5e04711cc3f7477186fb50c2dd1"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
 dependencies = [
  "futures-core",
  "pbjson",
  "prost 0.12.6",
- "prost-types 0.12.6",
  "serde",
  "tonic 0.11.0",
 ]
 
 [[package]]
 name = "aptos-protos"
-version = "1.3.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77#b2f58eaeda1d3929a7b381afca78408731b71d77"
+version = "1.3.1"
+source = "git+https://github.com/aptos-labs/aptos-core.git?rev=5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb#5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -2290,7 +2308,7 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77)",
+ "aptos-protos 1.3.0",
  "bcs 0.1.4",
  "crossbeam-channel",
  "once_cell",
@@ -2370,6 +2388,26 @@ dependencies = [
  "serde",
  "thiserror",
  "threadpool",
+]
+
+[[package]]
+name = "aptos-system-utils"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-core.git?rev=4541add3fd29826ec57f22658ca286d2d6134b93#4541add3fd29826ec57f22658ca286d2d6134b93"
+dependencies = [
+ "anyhow",
+ "aptos-profiler",
+ "async-mutex",
+ "http 0.2.12",
+ "hyper 0.14.30",
+ "lazy_static",
+ "mime",
+ "pprof",
+ "regex",
+ "rstack-self",
+ "tokio",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2977,6 +3015,15 @@ name = "async-lock"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
 dependencies = [
  "event-listener 2.5.3",
 ]
@@ -4479,6 +4526,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8227005286ec39567949b33df9896bcadfa6051bccca2488129f108ca23119"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4930,6 +4986,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "delegate"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5180,6 +5245,27 @@ name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
+name = "dw"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0ed82b765c2ab79fb48e4bf2c95bd583202f4078a702bc714cc6e6f3ca80c3"
+dependencies = [
+ "dw-sys",
+ "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "dw-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14eb35c87ff6626cd1021bb32bc7d9a5372ea72547e1eaf0343a841d9d55a973"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "dyn-clone"
@@ -5534,6 +5620,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "fixed"
 version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5642,7 +5740,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5650,6 +5769,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -7816,7 +7941,7 @@ dependencies = [
  "aptos-language-e2e-tests",
  "aptos-logger",
  "aptos-mempool",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77)",
+ "aptos-protos 1.3.0",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
@@ -7990,6 +8115,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mempool-util"
@@ -8944,6 +9078,17 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
@@ -9253,7 +9398,7 @@ checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "once_cell",
  "openssl-macros",
@@ -10047,6 +10192,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "pprof"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196ded5d4be535690899a4631cc9f18cdc41b7ebf24a79400f46f48e49a11059"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "once_cell",
+ "parking_lot",
+ "protobuf",
+ "protobuf-codegen-pure",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10198,14 +10366,14 @@ dependencies = [
 [[package]]
 name = "processor"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=efefd860fdb2f100f3314fc4aa05185e5082d3c7#efefd860fdb2f100f3314fc4aa05185e5082d3c7"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=da0ccef0f0e0e1be4b39073edb3277dfd6cb7dc1#da0ccef0f0e0e1be4b39073edb3277dfd6cb7dc1"
 dependencies = [
  "ahash 0.8.11",
  "allocative",
  "allocative_derive",
  "anyhow",
- "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=efefd860fdb2f100f3314fc4aa05185e5082d3c7)",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=69afec8ffc55e5e04711cc3f7477186fb50c2dd1)",
+ "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=da0ccef0f0e0e1be4b39073edb3277dfd6cb7dc1)",
+ "aptos-protos 1.3.1",
  "async-trait",
  "bcs 0.1.4",
  "bigdecimal",
@@ -10252,7 +10420,6 @@ dependencies = [
  "tracing",
  "unescape",
  "url",
- "uuid",
 ]
 
 [[package]]
@@ -10398,6 +10565,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost 0.12.6",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "protobuf-codegen"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
+dependencies = [
+ "protobuf",
+]
+
+[[package]]
+name = "protobuf-codegen-pure"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a29399fc94bcd3eeaa951c715f7bea69409b2445356b00519740bcd6ddd865"
+dependencies = [
+ "protobuf",
+ "protobuf-codegen",
 ]
 
 [[package]]
@@ -10991,6 +11183,34 @@ dependencies = [
  "spki 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rstack"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7df9d3ebd4f17b52e6134efe2fa20021c80688cbe823d481a729a993b730493"
+dependencies = [
+ "cfg-if",
+ "dw",
+ "lazy_static",
+ "libc",
+ "log",
+]
+
+[[package]]
+name = "rstack-self"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd5030da3aba0ec731502f74ec38e63798eea6bc8b8ba5972129afe3eababd2"
+dependencies = [
+ "antidote",
+ "backtrace",
+ "bincode",
+ "lazy_static",
+ "libc",
+ "rstack",
+ "serde",
 ]
 
 [[package]]
@@ -11650,9 +11870,10 @@ dependencies = [
 [[package]]
 name = "server-framework"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=efefd860fdb2f100f3314fc4aa05185e5082d3c7#efefd860fdb2f100f3314fc4aa05185e5082d3c7"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=da0ccef0f0e0e1be4b39073edb3277dfd6cb7dc1#da0ccef0f0e0e1be4b39073edb3277dfd6cb7dc1"
 dependencies = [
  "anyhow",
+ "aptos-system-utils",
  "async-trait",
  "backtrace",
  "clap 4.5.9",
@@ -12228,7 +12449,7 @@ name = "suzuka-client"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=b2f58eaeda1d3929a7b381afca78408731b71d77)",
+ "aptos-protos 1.3.0",
  "aptos-sdk",
  "aptos-types",
  "async-trait",
@@ -12356,6 +12577,29 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "symbolic-common"
+version = "10.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b55cdc318ede251d0957f07afe5fed912119b8c1bc5a7804151826db999e737"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "10.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79be897be8a483a81fff6a3a4e195b4ac838ef73ca42d348b3f722da9902e489"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,8 +131,8 @@ aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/apto
 aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
 
 # indexer
-processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "efefd860fdb2f100f3314fc4aa05185e5082d3c7", subdir = "rust" }
-server-framework = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "efefd860fdb2f100f3314fc4aa05185e5082d3c7", subdir = "rust" }
+processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "da0ccef0f0e0e1be4b39073edb3277dfd6cb7dc1", subdir = "rust" }
+server-framework = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "da0ccef0f0e0e1be4b39073edb3277dfd6cb7dc1", subdir = "rust" }
 
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
 ethereum-types = "0.14.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,11 @@ aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "
 aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
 aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
 aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "b2f58eaeda1d3929a7b381afca78408731b71d77" }
+
+# indexer
+processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "efefd860fdb2f100f3314fc4aa05185e5082d3c7", subdir = "rust" }
+server-framework = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "efefd860fdb2f100f3314fc4aa05185e5082d3c7", subdir = "rust" }
+
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
 ethereum-types = "0.14.1"
 ethers = "=2.0.10"
@@ -226,6 +231,8 @@ quote = "1.0"
 rand = "0.7.3"
 rand_core = "0.5.1"
 rayon = "1.10.0"
+
+
 reqwest = "0.12.4"
 risc0-build = "0.20"
 risc0-zkvm = { version = "0.21", features = ["std", "getrandom"] }
@@ -264,8 +271,8 @@ rustix = "0.38.34"
 paste = "1.0.15"
 
 # trying to pin diesel
-# diesel = "=2.1.1"
-# migrations_internals = "=2.1.1"
+diesel = "=2.1.1"
+migrations_internals = "=2.1.1"
 num_cpus = "=1.16.0"
 ahash = "=0.8.11"
 

--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,7 @@
           solc
           grpcurl
           grpcui
+          redis
         ];
 
         # Specific version of toolchain

--- a/networks/suzuka/aptos-indexer-grpc-file-store/Cargo.toml
+++ b/networks/suzuka/aptos-indexer-grpc-file-store/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "aptos-indexer-grpc-file-store"
+description = "Indexer gRPC file store saves transactions to persistent storage."
+version = "1.0.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+aptos-indexer-grpc-server-framework = { workspace = true }
+aptos-indexer-grpc-utils = { workspace = true }
+aptos-metrics-core = { workspace = true }
+aptos-moving-average = { workspace = true }
+async-trait = { workspace = true }
+clap = { workspace = true }
+futures = { workspace = true }
+once_cell = { workspace = true }
+redis = { workspace = true }
+serde = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+jemallocator = { workspace = true }

--- a/networks/suzuka/indexer-grpc-cache-worker/Cargo.toml
+++ b/networks/suzuka/indexer-grpc-cache-worker/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "indexer-grpc-cache-worker"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/networks/suzuka/indexer-grpc-cache-worker/src/main.rs
+++ b/networks/suzuka/indexer-grpc-cache-worker/src/main.rs
@@ -1,0 +1,59 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result};
+use aptos_indexer_grpc_utils::{config::IndexerGrpcCacheWorkerConfig, IndexerGrpcFileStoreConfig, types::RedisUrl};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+const RUNTIME_WORKER_MULTIPLIER: usize = 2;
+
+fn main() -> Result<()> {
+
+    use tracing_subscriber::EnvFilter;
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    let dot_movement = dot_movement::DotMovement::try_from_env()?;
+	let config = dot_movement.try_get_config_from_json::<suzuka_config::Config>()?;
+
+
+    let fullnode_grpc_address = format!(
+        "http://{}:{}",
+        config.execution_config.maptos_config.client.maptos_indexer_grpc_connection_hostname,
+        config.execution_config.maptos_config.client.maptos_indexer_grpc_connection_port
+    );
+    println!("Connecting to indexer gRPC server at: {}", fullnode_grpc_address.clone());
+
+    let config = IndexerGrpcCacheWorkerConfig {
+        fullnode_grpc_address: fullnode_grpc_address.clone(),
+        file_store_config: IndexerGrpcFileStoreConfig {
+           // variable provideded by gcs file store and local file store
+           // https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/indexer-grpc/indexer-grpc-utils/src/config.rs#L45
+        },
+        redis_main_instance_address: RedisUrl::new("redis://localhost:6379")?,
+        enable_cache_compression: true,
+    };
+
+    let num_cpus = num_cpus::get();
+    let worker_threads = (num_cpus * RUNTIME_WORKER_MULTIPLIER).max(16);
+    println!(
+        "[Indexer cache worker] Starting cache worker tokio runtime: num_cpus={}, worker_threads={}",
+        num_cpus, worker_threads
+    );
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder
+        .disable_lifo_slot()
+        .enable_all()
+        .worker_threads(worker_threads)
+        .build()
+        .unwrap()
+        .block_on(async {
+            config.run().await
+        })
+}

--- a/networks/suzuka/indexer-grpc-data-service/Cargo.toml
+++ b/networks/suzuka/indexer-grpc-data-service/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "indexer-grpc-data-service"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/networks/suzuka/indexer-processor/Cargo.toml
+++ b/networks/suzuka/indexer-processor/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "suzuka-indexer-processor"
+description = "Indexer GRPC processor in Rust."
+version = "1.0.0"
+
+# Workspace inherited keys
+authors = ["Aptos Labs <opensource@aptoslabs.com>"]
+edition = "2021"
+homepage = "https://aptoslabs.com"
+license = "Apache-2.0"
+publish = false
+repository = "https://github.com/aptos-labs/aptos-core"
+rust-version = { workspace = true }
+
+[dependencies]
+processor = { workspace = true }
+server-framework = { workspace = true }
+tokio = { workspace = true }
+anyhow = { workspace = true }
+num_cpus = { workspace = true }
+dot-movement = { workspace = true }
+suzuka-config = { workspace = true }
+ahash = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/networks/suzuka/indexer-processor/src/main.rs
+++ b/networks/suzuka/indexer-processor/src/main.rs
@@ -1,0 +1,74 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use processor::IndexerGrpcProcessorConfig;
+use processor::processors::ProcessorConfig;
+use server_framework::RunnableConfig;
+use ahash::AHashMap;
+
+const RUNTIME_WORKER_MULTIPLIER: usize = 2;
+
+fn main() -> Result<()> {
+
+    use tracing_subscriber::EnvFilter;
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    let dot_movement = dot_movement::DotMovement::try_from_env()?;
+	let config = dot_movement.try_get_config_from_json::<suzuka_config::Config>()?;
+
+
+    let url = format!(
+        "http://{}:{}",
+        config.execution_config.maptos_config.client.maptos_indexer_grpc_connection_hostname,
+        config.execution_config.maptos_config.client.maptos_indexer_grpc_connection_port
+    );
+    println!("Connecting to indexer gRPC server at: {}", url);
+
+    let config = IndexerGrpcProcessorConfig {
+        processor_config: ProcessorConfig::DefaultProcessor,
+        postgres_connection_string: config.execution_config.maptos_config.indexer_processor.postgres_connection_string.clone(),
+        indexer_grpc_data_service_address: format!(
+            "http://{}:{}", 
+            config.execution_config.maptos_config.client.maptos_indexer_grpc_connection_hostname, 
+            config.execution_config.maptos_config.client.maptos_indexer_grpc_connection_port
+        ).parse()?,
+        grpc_http2_config: Default::default(),
+        auth_token: config.execution_config.maptos_config.indexer_processor.indexer_processor_auth_token.clone(),
+        starting_version: None,
+        ending_version: None,
+        number_concurrent_processing_tasks: None,
+        db_pool_size: None,
+        gap_detection_batch_size: IndexerGrpcProcessorConfig::default_gap_detection_batch_size(),
+        parquet_gap_detection_batch_size: IndexerGrpcProcessorConfig::default_gap_detection_batch_size(),
+        pb_channel_txn_chunk_size: IndexerGrpcProcessorConfig::default_pb_channel_txn_chunk_size(),
+        per_table_chunk_sizes: AHashMap::new(),
+        enable_verbose_logging: None,
+        grpc_response_item_timeout_in_secs: IndexerGrpcProcessorConfig::default_grpc_response_item_timeout_in_secs(),
+        transaction_filter: Default::default(),
+        deprecated_tables: Default::default(),
+    };
+
+    let num_cpus = num_cpus::get();
+    let worker_threads = (num_cpus * RUNTIME_WORKER_MULTIPLIER).max(16);
+    println!(
+        "[Processor] Starting processor tokio runtime: num_cpus={}, worker_threads={}",
+        num_cpus, worker_threads
+    );
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder
+        .disable_lifo_slot()
+        .enable_all()
+        .worker_threads(worker_threads)
+        .build()
+        .unwrap()
+        .block_on(async {
+            config.run().await
+        })
+}

--- a/networks/suzuka/redis-server/main.rs
+++ b/networks/suzuka/redis-server/main.rs
@@ -1,0 +1,5 @@
+// seems like we could only run an instance of redis-server in a separate process, and then connect to it from the other services.
+// we might want to spin up a redis server then. 
+// https://discourse.nixos.org/t/how-can-i-spawn-a-redis-instance-within-a-nix-build/5155
+// For testing purposes we could use:
+// https://medium.com/@suyashkant.srivastava/this-post-aims-to-help-setting-up-a-minimal-redis-cluster-on-nix-environment-d607e3628e08

--- a/networks/suzuka/suzuka-client/src/tests/indexer_stream.rs
+++ b/networks/suzuka/suzuka-client/src/tests/indexer_stream.rs
@@ -8,6 +8,8 @@ use aptos_protos::indexer::v1::{
     raw_data_client::RawDataClient,
 };
 use futures::StreamExt;
+use std::io::{self, Write};
+
 
 static SUZUKA_CONFIG: Lazy<suzuka_config::Config> = Lazy::new(|| {
 	let dot_movement = dot_movement::DotMovement::try_from_env().unwrap();
@@ -39,11 +41,11 @@ static INDEXER_URL: Lazy<String> = Lazy::new(|| {
 #[tokio::test]
 async fn test_example_indexer_stream() -> Result<(), anyhow::Error> {
 
-    /*let channel = tonic::transport::Channel::from_shared(
+    let channel = tonic::transport::Channel::from_shared(
         INDEXER_URL.to_string(),
     ).expect(
         "[Parser] Failed to build GRPC channel, perhaps because the data service URL is invalid",
-    );*/
+    );
     
     let mut client = RawDataClient::connect(
         INDEXER_URL.as_str(),
@@ -54,7 +56,7 @@ async fn test_example_indexer_stream() -> Result<(), anyhow::Error> {
         transactions_count : Some(10),
         batch_size : Some(100),
     }; 
-
+	println!("{:?}", request);
     let mut stream = client.get_transactions(request).await?.into_inner();
 
 	for _ in 1..10 {
@@ -62,7 +64,8 @@ async fn test_example_indexer_stream() -> Result<(), anyhow::Error> {
 			.next()
 			.await;
 		println!("{:?}", response);
-	}
+		io::stdout().flush().unwrap();
+	}	
 
 	Ok(())
 }

--- a/process-compose/suzuka-full-node/process-compose.yml
+++ b/process-compose/suzuka-full-node/process-compose.yml
@@ -84,6 +84,7 @@ processes:
       # for now, we will just prove the service is running with a grpcurl call
       # we will check the output
       RESPONSE=$(grpcurl -plaintext 0.0.0.0:30734 list aptos.indexer.v1.RawData)
+      echho $RESPONSE
       EXPECTED="aptos.indexer.v1.RawData.GetTransactions"
       if [[ "$RESPONSE" == "$EXPECTED" ]]; then
         exit 0
@@ -97,3 +98,5 @@ processes:
       initial_delay_seconds: 30
       exec:
         command: echo "true"
+
+  

--- a/process-compose/suzuka-full-node/process-compose.yml
+++ b/process-compose/suzuka-full-node/process-compose.yml
@@ -75,3 +75,25 @@ processes:
       exec:
         command: curl http://0.0.0.0:30732
 
+  suzuka-indexer-processor:
+  
+    command : |
+      #/bin/bash
+      # todo: this fails with gRPC Unimplemented error on the RawData.GetTransactions call
+      RUST_LOG=debug suzuka-indexer-processor
+      # for now, we will just prove the service is running with a grpcurl call
+      # we will check the output
+      RESPONSE=$(grpcurl -plaintext 0.0.0.0:30734 list aptos.indexer.v1.RawData)
+      EXPECTED="aptos.indexer.v1.RawData.GetTransactions"
+      if [[ "$RESPONSE" == "$EXPECTED" ]]; then
+        exit 0
+      else
+        exit 1
+      fi
+    depends_on:
+      suzuka-full-node:
+        condition: process_healthy
+    readiness_probe:
+      initial_delay_seconds: 30
+      exec:
+        command: echo "true"

--- a/scripts/cargo/choose
+++ b/scripts/cargo/choose
@@ -3,5 +3,3 @@ set -e
 
 # change symbolic link to be Cargo.$1.toml
 ln -sf Cargo.$1.toml Cargo.toml
-
-

--- a/scripts/services/suzuka-full-node/build
+++ b/scripts/services/suzuka-full-node/build
@@ -32,3 +32,7 @@ echo "Built suzuka-full-node-setup!"
 echo "Building wait-for-celestia-light-node..."
 cargo build $CARGO_PROFILE_FLAGS --bin wait-for-celestia-light-node
 echo "Built wait-for-celestia-light-node!"
+
+echo "Building suzuka-indexer-processor..."
+cargo build $CARGO_PROFILE_FLAGS --bin suzuka-indexer-processor
+echo "Built suzuka-indexer-processor!"


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

Readding modifications made by @l-monninger 
https://github.com/movementlabsxyz/movement/pull/124

> nix develop

> just suzuka-full-node native build.setup.eth-local.celestia-local.test --keep-tui

# Changelog


# Testing


# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->