### PR TITLE
Catch All Heuristic

### DIFF
--- a/util/movement-algs/src/grouping_heuristic/binpacking/mod.rs
+++ b/util/movement-algs/src/grouping_heuristic/binpacking/mod.rs
@@ -104,3 +104,18 @@ mod block {
 		}
 	}
 }
+
+mod shared {
+
+	use super::*;
+	use std::sync::Arc;
+
+	impl<T> BinpackingWeighted for Arc<T>
+	where
+		T: BinpackingWeighted,
+	{
+		fn weight(&self) -> usize {
+			self.as_ref().weight()
+		}
+	}
+}

--- a/util/movement-algs/src/grouping_heuristic/catch.rs
+++ b/util/movement-algs/src/grouping_heuristic/catch.rs
@@ -1,0 +1,43 @@
+use crate::grouping_heuristic::{GroupingHeuristic, GroupingOutcome};
+
+/// Heuristic combinator that converts all outcomes to failures if the inner heuristic fails.
+/// This relies on cloning the inner heuristic, so it is advised that this be used with types that can be cloned cheaply.
+pub struct CatchAllToFailure<T>(pub Box<dyn GroupingHeuristic<T>>)
+where
+	T: Clone;
+
+impl<T> CatchAllToFailure<T>
+where
+	T: Clone,
+{
+	pub fn new(heuristic: Box<dyn GroupingHeuristic<T>>) -> Self {
+		Self(heuristic)
+	}
+
+	pub fn boxed(heuristic: Box<dyn GroupingHeuristic<T>>) -> Box<Self> {
+		Box::new(Self(heuristic))
+	}
+}
+
+impl<T> GroupingHeuristic<T> for CatchAllToFailure<T>
+where
+	T: Clone,
+{
+	fn distribute(
+		&mut self,
+		distribution: Vec<GroupingOutcome<T>>,
+	) -> Result<Vec<GroupingOutcome<T>>, anyhow::Error> {
+		let recoverable = distribution.clone();
+
+		match self.0.distribute(distribution) {
+			Ok(outcome) => Ok(outcome),
+			Err(_) => {
+				let failures = recoverable
+					.into_iter()
+					.map(|outcomes| outcomes.to_failures_prefer_instrumental())
+					.collect();
+				Ok(failures)
+			}
+		}
+	}
+}

--- a/util/movement-algs/src/grouping_heuristic/mod.rs
+++ b/util/movement-algs/src/grouping_heuristic/mod.rs
@@ -1,5 +1,6 @@
 pub mod apply;
 pub mod binpacking;
+pub mod catch;
 pub mod chunking;
 pub mod drop_success;
 pub mod skip;

--- a/util/movement-algs/src/grouping_heuristic/splitting.rs
+++ b/util/movement-algs/src/grouping_heuristic/splitting.rs
@@ -119,3 +119,18 @@ mod block {
 		}
 	}
 }
+
+mod shared {
+
+	use super::*;
+	use std::sync::Arc;
+
+	impl<T> Splitable for Arc<T>
+	where
+		T: Splitable,
+	{
+		fn split(self, factor: usize) -> Vec<Self> {
+			self.to_owned().into_inner().split(factor).into_iter().map(Arc::new).collect()
+		}
+	}
+}


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

Early attempt at implementing catch-all heuristic.

The hard part here is it requires cloning with the current trait bounds. Even though this behavior is common, I think it may be better to either:

1. Implement a single recover point in a `GroupingHeuristic` stack. So that the cloning only occurs once.
```rust
CatchAll::boxed(vec![
    ToApply::boxed(),
    FirstFit::boxed()
]);
```
2. Even though this is a common/generic operation, just leave the catching to individual variations of distributions. 

# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->