### PR TITLE
Move tests run in CI

### DIFF
--- a/.github/scripts/update_move_toml.sh
+++ b/.github/scripts/update_move_toml.sh
@@ -2,9 +2,8 @@
 
 MOVE_TOML_PATH="protocol-units/bridge/move-modules/Move.toml"
 
-INIT_OUTPUT=$(aptos init)
+INIT_OUTPUT=$(aptos init 2>&1)
 
-echo "Aptos init output:"
 echo "$INIT_OUTPUT"
 
 ADDRESS=$(echo "$INIT_OUTPUT" | grep -oE '0x[a-f0-9]{64}' | head -1)
@@ -14,7 +13,7 @@ if [[ -z "$ADDRESS" ]]; then
     exit 1
 fi
 
-echo "Extracted Aptos Account Address: $ADDRESS"
+echo "$ADDRESS"
 
 sed -i "s/^atomic_bridge = \".*\"/atomic_bridge = \"$ADDRESS\"/" "$MOVE_TOML_PATH"
 sed -i "s/^moveth = \".*\"/moveth = \"$ADDRESS\"/" "$MOVE_TOML_PATH"

--- a/.github/scripts/update_move_toml.sh
+++ b/.github/scripts/update_move_toml.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+MOVE_TOML_PATH="protocol-units/bridge/move-modules/Move.toml"
+
+ADDRESS=$(aptos init | grep 'Account address:' | awk '{print $3}')
+
+sed -i "s/^atomic_bridge = \".*\"/atomic_bridge = \"$ADDRESS\"/" "$MOVE_TOML_PATH"
+sed -i "s/^moveth = \".*\"/moveth = \"$ADDRESS\"/" "$MOVE_TOML_PATH"
+sed -i "s/^master_minter = \".*\"/master_minter = \"$ADDRESS\"/" "$MOVE_TMOL_PATH"
+sed -i "s/^minter = \".*\"/minter = \"$ADDRESS\"/" "$MOVE_TOML_PATH"
+sed -i "s/^admin = \".*\"/admin = \"$ADDRESS\"/" "$MOVE_TOML_PATH"
+
+echo "Move.toml updated with address: $ADDRESS"

--- a/.github/scripts/update_move_toml.sh
+++ b/.github/scripts/update_move_toml.sh
@@ -7,7 +7,7 @@ INIT_OUTPUT=$(aptos init)
 echo "Aptos init output:"
 echo "$INIT_OUTPUT"
 
-ADDRESS=$(echo "$INIT_OUTPUT" | grep -oP 'Account 0x[a-f0-9]{64}' | head -n 1 | awk '{print $2}')
+ADDRESS=$(echo "$INIT_OUTPUT" | grep -oE '0x[a-f0-9]{64}' | head -1)
 
 if [[ -z "$ADDRESS" ]]; then
     echo "Error: Failed to extract the Aptos account address."

--- a/.github/scripts/update_move_toml.sh
+++ b/.github/scripts/update_move_toml.sh
@@ -2,7 +2,7 @@
 
 MOVE_TOML_PATH="protocol-units/bridge/move-modules/Move.toml"
 
-ADDRESS=$(aptos init | grep 'Aptos CLI is now set up for account' | awk '{print $9}')
+ADDRESS=$(aptos init | grep -oP 'Account \K0x[a-f0-9]{64}')
 
 sed -i "s/^atomic_bridge = \".*\"/atomic_bridge = \"$ADDRESS\"/" "$MOVE_TOML_PATH"
 sed -i "s/^moveth = \".*\"/moveth = \"$ADDRESS\"/" "$MOVE_TOML_PATH"

--- a/.github/scripts/update_move_toml.sh
+++ b/.github/scripts/update_move_toml.sh
@@ -1,23 +1,21 @@
-# Path to your Move.toml file
+#!/bin/bash
+
 MOVE_TOML_PATH="protocol-units/bridge/move-modules/Move.toml"
 
-# Initialize Aptos and capture output
 INIT_OUTPUT=$(aptos init)
 
-# Debugging: Print the output of aptos init
 echo "Aptos init output:"
 echo "$INIT_OUTPUT"
 
-# Extract the address using grep
-ADDRESS=$(echo "$INIT_OUTPUT" | grep -oP 'Account \K0x[a-f0-9]{64}')
+ADDRESS=$(echo "$INIT_OUTPUT" | grep -oP 'Account 0x[a-f0-9]{64}' | head -n 1 | awk '{print $2}')
 
-# Check if the address was successfully extracted
 if [[ -z "$ADDRESS" ]]; then
     echo "Error: Failed to extract the Aptos account address."
     exit 1
 fi
 
-# Update the Move.toml with the new address
+echo "Extracted Aptos Account Address: $ADDRESS"
+
 sed -i "s/^atomic_bridge = \".*\"/atomic_bridge = \"$ADDRESS\"/" "$MOVE_TOML_PATH"
 sed -i "s/^moveth = \".*\"/moveth = \"$ADDRESS\"/" "$MOVE_TOML_PATH"
 sed -i "s/^master_minter = \".*\"/master_minter = \"$ADDRESS\"/" "$MOVE_TOML_PATH"

--- a/.github/scripts/update_move_toml.sh
+++ b/.github/scripts/update_move_toml.sh
@@ -1,12 +1,26 @@
-#!/bin/bash
-
+# Path to your Move.toml file
 MOVE_TOML_PATH="protocol-units/bridge/move-modules/Move.toml"
 
-ADDRESS=$(aptos init | grep -oP 'Account \K0x[a-f0-9]{64}')
+# Initialize Aptos and capture output
+INIT_OUTPUT=$(aptos init)
 
+# Debugging: Print the output of aptos init
+echo "Aptos init output:"
+echo "$INIT_OUTPUT"
+
+# Extract the address using grep
+ADDRESS=$(echo "$INIT_OUTPUT" | grep -oP 'Account \K0x[a-f0-9]{64}')
+
+# Check if the address was successfully extracted
+if [[ -z "$ADDRESS" ]]; then
+    echo "Error: Failed to extract the Aptos account address."
+    exit 1
+fi
+
+# Update the Move.toml with the new address
 sed -i "s/^atomic_bridge = \".*\"/atomic_bridge = \"$ADDRESS\"/" "$MOVE_TOML_PATH"
 sed -i "s/^moveth = \".*\"/moveth = \"$ADDRESS\"/" "$MOVE_TOML_PATH"
-sed -i "s/^master_minter = \".*\"/master_minter = \"$ADDRESS\"/" "$MOVE_TMOL_PATH"
+sed -i "s/^master_minter = \".*\"/master_minter = \"$ADDRESS\"/" "$MOVE_TOML_PATH"
 sed -i "s/^minter = \".*\"/minter = \"$ADDRESS\"/" "$MOVE_TOML_PATH"
 sed -i "s/^admin = \".*\"/admin = \"$ADDRESS\"/" "$MOVE_TOML_PATH"
 

--- a/.github/scripts/update_move_toml.sh
+++ b/.github/scripts/update_move_toml.sh
@@ -2,7 +2,7 @@
 
 MOVE_TOML_PATH="protocol-units/bridge/move-modules/Move.toml"
 
-ADDRESS=$(aptos init | grep 'Account address:' | awk '{print $3}')
+ADDRESS=$(aptos init | grep 'Aptos CLI is now set up for account' | awk '{print $9}')
 
 sed -i "s/^atomic_bridge = \".*\"/atomic_bridge = \"$ADDRESS\"/" "$MOVE_TOML_PATH"
 sed -i "s/^moveth = \".*\"/moveth = \"$ADDRESS\"/" "$MOVE_TOML_PATH"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -152,3 +152,34 @@ jobs:
           forge test --fork-url https://ethereum-sepolia-rpc.publicnode.com -vv
         "
 
+  move-modules-test:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            arch: x86_64
+            runs-on: buildjet-8vcpu-ubuntu-2204
+
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@main
+
+    - name: Install Aptos CLI
+      run: nix develop --command bash -c "aptos-cli install"
+
+    - name: Update Move.toml with new addresses
+      run: |
+        chmod +x .github/scripts/update_move_toml.sh
+        ./.github/scripts/update_move_toml.sh
+
+    - name: Run Aptos Tests
+      run: |
+        nix develop --command bash -c "
+          cd protocol-units/bridge/move-modules && \
+          aptos test
+        "

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,154 +4,6 @@ on:
   push:
 
 jobs:
-  cargo-check:
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-22.04
-            arch: x86_64
-            runs-on: buildjet-8vcpu-ubuntu-2204
-          - os: macos-13-latest
-            arch: arm64
-            runs-on: macos-13-xlarge
-
-    runs-on: ${{ matrix.runs-on }}
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Install Nix
-      uses: DeterminateSystems/nix-installer-action@main
-
-    - name: Run Cargo Check in nix environment
-      run: nix develop --command bash -c "cargo check --all-targets"
-
-  suzuka-full-node-local:
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-22.04
-            arch: x86_64
-            runs-on: buildjet-16vcpu-ubuntu-2204
-
-    runs-on: ${{ matrix.runs-on }}
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        submodules: true
-
-    - name: Install Nix
-      uses: DeterminateSystems/nix-installer-action@main
-
-    - name: Run Suzuka Full Node Tests Against Local ETH and Local Celestia
-      env:
-        CELESTIA_LOG_LEVEL: FATAL # adjust the log level while debugging
-      run: |
-        nix develop --command bash -c "just suzuka-full-node native build.setup.eth-local.celestia-local.test -t=false"
-        nix develop --command bash -c "just suzuka-full-node native build.setup.eth-local.celestia-local.test -t=false"
-
-  suzuka-full-node-remote:
-    if: false 
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-22.04
-            arch: x86_64
-            runs-on: buildjet-8vcpu-ubuntu-2204
-
-    runs-on: ${{ matrix.runs-on }}
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        submodules: true
-
-    - name: Install Nix
-      uses: DeterminateSystems/nix-installer-action@main
-
-    - name: Run Suzuka Full Node Tests Against Holesky and Local Celestia
-      env:
-        CELESTIA_LOG_LEVEL: FATAL # adjust the log level while debugging
-      run: |
-        export MCR_DEPLOYMENT_ACCOUNT_PRIVATE_KEY=${{ secrets.MCR_DEPLOYMENT_ACCOUNT_PRIVATE_KEY }}
-        nix develop --command bash -c "just suzuka-full-node native build.setup.eth-holesky.celestia-local.test -t=false"
-        nix develop --command bash -c "just suzuka-full-node native build.setup.eth-holesky.celestia-local.test -t=false"
-
-  m1-da-light-node:
-    if: false # this is effectively tested by the above
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-22.04
-            arch: x86_64
-            runs-on: buildjet-8vcpu-ubuntu-2204
-
-    runs-on: ${{ matrix.runs-on }}
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Install Nix
-      uses: DeterminateSystems/nix-installer-action@main
-
-    - name: Run M1 DA Light Node tests in nix environment
-      # adjust the log level while debugging
-      run: CELESTIA_LOG_LEVEL=FATAL nix develop --command bash -c "just m1-da-light-node native build.setup.test.local -t=false"
-
-  mcr:
-#    if: false
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-22.04
-            arch: x86_64
-            runs-on: buildjet-8vcpu-ubuntu-2204
-
-    runs-on: ${{ matrix.runs-on }}
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Install Nix
-      uses: DeterminateSystems/nix-installer-action@main
-
-    - name: Run MCR tests in nix environment
-      # adjust the log level while debugging
-      run: CELESTIA_LOG_LEVEL=FATAL nix develop --command bash -c "just mcr native test.local -t=false"
-
-    - name: Run MCR Client Tests
-      run: nix develop --command bash -c "just mcr-client native build.local.test -t=false"
-
-  solidity-contracts:
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-22.04
-            arch: x86_64
-            runs-on: buildjet-8vcpu-ubuntu-2204
-
-    runs-on: ${{ matrix.runs-on }}
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Install Nix
-      uses: DeterminateSystems/nix-installer-action@main
-
-    - name: Run foundry tests
-      run: |
-        nix develop --command bash -c "
-          cd protocol-units/bridge/contracts && \
-          forge test --fork-url https://ethereum-sepolia-rpc.publicnode.com -vv
-        "
-
   move-modules-test:
     strategy:
       matrix:
@@ -170,16 +22,15 @@ jobs:
       run: |
         curl -fsSL "https://aptos.dev/scripts/install_cli.py" | python3
 
-    # - name: Update Move.toml with new addresses
-    #  run: |
-
     - name: Install Nix
       uses: DeterminateSystems/nix-installer-action@main
 
     - name: Run Aptos Tests
       run: |
         nix develop --command bash -c "
-          chmod +x .github/scripts/update_move_toml.sh  
+          set -e
+          set -x
+          chmod +x .github/scripts/update_move_toml.sh && \
           ./.github/scripts/update_move_toml.sh && \
           cd protocol-units/bridge/move-modules && \
           aptos move test

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -179,7 +179,7 @@ jobs:
     - name: Run Aptos Tests
       run: |
         nix develop --command bash -c "
-          chmod +x .github/scripts/update_move_toml.sh && \ 
+          chmod +x .github/scripts/update_move_toml.sh  
           ./.github/scripts/update_move_toml.sh && \
           cd protocol-units/bridge/move-modules && \
           aptos move test

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -169,8 +169,15 @@ jobs:
     - name: Install Nix
       uses: DeterminateSystems/nix-installer-action@main
 
+    - name: Install Homebrew
+      run: |
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> ~/.profile
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+
     - name: Install Aptos CLI
-      run: nix develop --command bash -c "brew install aptos"
+      run: |
+        brew install aptos
 
     - name: Update Move.toml with new addresses
       run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -170,7 +170,7 @@ jobs:
       uses: DeterminateSystems/nix-installer-action@main
 
     - name: Install Aptos CLI
-      run: nix develop --command bash -c "aptos-cli install"
+      run: nix develop --command bash -c "brew install aptos"
 
     - name: Update Move.toml with new addresses
       run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -170,10 +170,8 @@ jobs:
       run: |
         curl -fsSL "https://aptos.dev/scripts/install_cli.py" | python3
 
-    - name: Update Move.toml with new addresses
-      run: |
-        chmod +x .github/scripts/update_move_toml.sh
-        ./.github/scripts/update_move_toml.sh
+    # - name: Update Move.toml with new addresses
+    #  run: |
 
     - name: Install Nix
       uses: DeterminateSystems/nix-installer-action@main
@@ -181,6 +179,8 @@ jobs:
     - name: Run Aptos Tests
       run: |
         nix develop --command bash -c "
+          chmod +x .github/scripts/update_move_toml.sh && \ 
+          ./.github/scripts/update_move_toml.sh && \
           cd protocol-units/bridge/move-modules && \
           aptos move test
         "

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -166,23 +166,17 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Install Nix
-      uses: DeterminateSystems/nix-installer-action@main
-
-    - name: Install Homebrew
-      run: |
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-        echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> ~/.profile
-        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-
     - name: Install Aptos CLI
       run: |
-        brew install aptos
+        curl -fsSL "https://aptos.dev/scripts/install_cli.py" | python3
 
     - name: Update Move.toml with new addresses
       run: |
         chmod +x .github/scripts/update_move_toml.sh
         ./.github/scripts/update_move_toml.sh
+
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@main
 
     - name: Run Aptos Tests
       run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -182,5 +182,5 @@ jobs:
       run: |
         nix develop --command bash -c "
           cd protocol-units/bridge/move-modules && \
-          aptos test
+          aptos move test
         "

--- a/protocol-units/bridge/move-modules/Move.toml
+++ b/protocol-units/bridge/move-modules/Move.toml
@@ -23,8 +23,8 @@ denylister = "0xcade"
 
 
 [dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-core.git"
-rev = "devnet"
+git = "https://github.com/movementlabsxyz/aptos-core.git"
+rev = "movement"
 subdir = "aptos-move/framework/aptos-framework"
 
 [dev-dependencies]


### PR DESCRIPTION
# Summary
Solution for [Issue #211](https://github.com/movementlabsxyz/movement/issues/211) to make Move tests run automatically in CI

# Changelog

* Add Move test workflow to `./github/workflows/checks.yml`
* Add `./github/scripts/update_move_toml.sh` script to run `aptos init` and update `Move.toml` with address generated
* Update `./protocol-units/bridge/move-modules/Move.toml` to use our fork of `aptos-core`

# Testing

* All CI checks pass. 
* When I first ran the workflow successfully, it exposed a Move test failure which appears to have been due to using Aptos Labs' `aptos-core` GitHub repo as a dep, rather than our fork, hence updating `Move.toml` as part of this PR.
 
# Outstanding issues

* Next iteration will replace Aptos CLI with Movement CLI. I'd like to first create more convenient installation options for Movement CLI such as Homebrew and the Python script used in this PR to install Movement CLI, and then switch. Showing that this workflow passes with Aptos CLI provides a baseline level of validation so I think it makes sense as a small PR.