### PR TITLE
Retry Config

### DIFF
--- a/networks/suzuka/suzuka-config/src/execution_extension.rs
+++ b/networks/suzuka/suzuka-config/src/execution_extension.rs
@@ -1,11 +1,15 @@
 use godfig::env_default;
 use serde::{Deserialize, Serialize};
 
+/// The execution extension configuration.
+/// This covers Suzuka configurations that do not configure the Maptos executor, but do configure the way it is used.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
+	/// The number of times to retry a block if it fails to execute.
 	#[serde(default = "default_block_retry_count")]
 	pub block_retry_count: u64,
 
+	/// The amount by which to increment the block timestamp if it fails to execute. (This is the most common reason for a block to fail to execute.)
 	#[serde(default = "default_block_retry_increment_microseconds")]
 	pub block_retry_increment_microseconds: u64,
 }
@@ -19,11 +23,11 @@ impl Default for Config {
 	}
 }
 
-env_default!(default_block_retry_count, "BLOCK_RETRY_COUNT", u64, 10);
+env_default!(default_block_retry_count, "SUZUKA_BLOCK_RETRY_COUNT", u64, 10);
 
 env_default!(
 	default_block_retry_increment_microseconds,
-	"BLOCK_RETRY_INCREMENT_MICROSECONDS",
+	"SUZUKA_BLOCK_RETRY_INCREMENT_MICROSECONDS",
 	u64,
 	5000
 );

--- a/networks/suzuka/suzuka-config/src/execution_extension.rs
+++ b/networks/suzuka/suzuka-config/src/execution_extension.rs
@@ -1,0 +1,29 @@
+use godfig::env_default;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Config {
+	#[serde(default = "default_block_retry_count")]
+	pub block_retry_count: u64,
+
+	#[serde(default = "default_block_retry_increment_microseconds")]
+	pub block_retry_increment_microseconds: u64,
+}
+
+impl Default for Config {
+	fn default() -> Self {
+		Self {
+			block_retry_count: default_block_retry_count(),
+			block_retry_increment_microseconds: default_block_retry_increment_microseconds(),
+		}
+	}
+}
+
+env_default!(default_block_retry_count, "BLOCK_RETRY_COUNT", u64, 10);
+
+env_default!(
+	default_block_retry_increment_microseconds,
+	"BLOCK_RETRY_INCREMENT_MICROSECONDS",
+	u64,
+	5000
+);

--- a/networks/suzuka/suzuka-config/src/lib.rs
+++ b/networks/suzuka/suzuka-config/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod da_db;
+pub mod execution_extension;
 
 use serde::{Deserialize, Serialize};
 
@@ -21,6 +22,9 @@ pub struct Config {
 
 	#[serde(default)]
 	pub da_db: da_db::Config,
+
+	#[serde(default)]
+	pub execution_extension: execution_extension::Config,
 }
 
 impl Default for Config {
@@ -30,6 +34,7 @@ impl Default for Config {
 			m1_da_light_node: M1DaLightNodeConfig::default(),
 			mcr: McrConfig::default(),
 			da_db: da_db::Config::default(),
+			execution_extension: execution_extension::Config::default(),
 		}
 	}
 }


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$
- **Categories**: any of `protocol-units`

Allows retries to be configured by config variables. 

# Changelog

1. Adds `execution_extension` config field to Suzuka config.
2. Adds retry fields to this extension. 
3. Applies them to the "partial" implementation. 

# Testing

1. e2e testing. 

# Outstanding issues
1. I think at this point we can change the "partial" naming.
2. The protocol this affects has a bit of a cascading effect, whereby increasing the timestamp of a block will mean that the next block has a greater likelihood of also needing to have its timestamp increased and with a greater number of retries. This will generally reset so long as the retry increment and count do not increases the timestamp beyond the block building time.