### PR TITLE
Add shared bridge lib tests to CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -163,6 +163,30 @@ jobs:
           cd protocol-units/bridge/move-modules && \
           aptos move test
         "
+  
+  bridge-shared-lib-tests:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            arch: x86_64
+            runs-on: buildjet-8vcpu-ubuntu-2204
+
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@main
+
+    - name: Run rust tests
+      run: |
+        nix develop --command bash -c "
+          cargo test -p bridge-shared  
+        "
+  
 
   solidity-bridge-tests:
     strategy:


### PR DESCRIPTION
# Summary
Noticed these tests were not in our CI. At some point they failed and we did not catch it. It's important that this shared lib tests are always ran as the entire bridge service implementation is based off it. 

# Changelog
- Adds the tests for `bridge/shared/*` to our CI

# Testing
- Runs in CI

# Outstanding Issues
None