### PR TITLE
correct mcr e2e test build

### DIFF
--- a/protocol-units/settlement/mcr/client/src/tests/e2e/test_client_settlement.rs
+++ b/protocol-units/settlement/mcr/client/src/tests/e2e/test_client_settlement.rs
@@ -251,7 +251,7 @@ pub async fn test_client_settlement() -> Result<(), anyhow::Error> {
 		},
 		..config.clone()
 	};
-	let client1 = Client::build_with_config(config1).await.unwrap();
+	let client1 = Client::build_with_config(&config1).await.unwrap();
 
 	let mut client1_stream = client1.stream_block_commitments().await.unwrap();
 	// Client post a new commitment
@@ -278,7 +278,7 @@ pub async fn test_client_settlement() -> Result<(), anyhow::Error> {
 		},
 		..config.clone()
 	};
-	let client2 = Client::build_with_config(config2).await.unwrap();
+	let client2 = Client::build_with_config(&config2).await.unwrap();
 
 	let mut client2_stream = client2.stream_block_commitments().await.unwrap();
 


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

<!--
Add your summary text here. 
 -->
Coorect the e2e MRC build error.
# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->