### PR TITLE
Restore Optimizations and Configuration Removed in Background Task Refactor

### DIFF
--- a/networks/suzuka/setup/src/main.rs
+++ b/networks/suzuka/setup/src/main.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
 	// get the config file
 	let dot_movement = dot_movement::DotMovement::try_from_env()?;
-	let mut config_file = dot_movement.try_get_or_create_config_file().await?;
+	let config_file = dot_movement.try_get_or_create_config_file().await?;
 
 	// get a matching godfig object
 	let godfig: Godfig<Config, ConfigFile> = Godfig::new(ConfigFile::new(config_file), vec![]);

--- a/networks/suzuka/suzuka-full-node/src/partial.rs
+++ b/networks/suzuka/suzuka-full-node/src/partial.rs
@@ -43,22 +43,31 @@ where
 			self.da_db,
 			self.light_node_client.clone(),
 			self.commitment_events,
+			self.config.execution_extension.clone(),
 		);
-		let tx_ingress_task = tasks::transaction_ingress::Task::new(
+		let transaction_ingress_task = tasks::transaction_ingress::Task::new(
 			transaction_receiver,
 			self.light_node_client,
 			// FIXME: why are the struct member names so tautological?
 			self.config.m1_da_light_node.m1_da_light_node_config,
 		);
 
-		let (res1, res2, res3, res4) = try_join!(
+		let (
+			execution_and_settlement_result,
+			transaction_ingress_result,
+			background_task_result,
+			services_result,
+		) = try_join!(
 			tokio::spawn(async move { exec_settle_task.run().await }),
-			tokio::spawn(async move { tx_ingress_task.run().await }),
+			tokio::spawn(async move { transaction_ingress_task.run().await }),
 			tokio::spawn(exec_background),
 			tokio::spawn(services.run()),
 			// tokio::spawn(async move { movement_rest.run_service().await }),
 		)?;
-		res1.and(res2).and(res3).and(res4)
+		execution_and_settlement_result
+			.and(transaction_ingress_result)
+			.and(background_task_result)
+			.and(services_result)
 	}
 }
 

--- a/networks/suzuka/suzuka-full-node/src/tasks/execute_settle.rs
+++ b/networks/suzuka/suzuka-full-node/src/tasks/execute_settle.rs
@@ -15,6 +15,7 @@ use movement_types::{Block, BlockCommitment, BlockCommitmentEvent};
 
 use anyhow::Context;
 use futures::{future::Either, stream};
+use suzuka_config::execution_extension;
 use tokio::select;
 use tokio_stream::{Stream, StreamExt};
 use tracing::{debug, error, info, info_span, warn, Instrument};
@@ -27,6 +28,7 @@ pub struct Task<E, S> {
 	// Stream receiving commitment events, conditionally enabled
 	commitment_events:
 		Either<CommitmentEventStream, stream::Pending<<CommitmentEventStream as Stream>::Item>>,
+	execution_extension: execution_extension::Config,
 }
 
 impl<E, S> Task<E, S> {
@@ -36,12 +38,20 @@ impl<E, S> Task<E, S> {
 		da_db: DaDB,
 		da_light_node_client: LightNodeServiceClient<tonic::transport::Channel>,
 		commitment_events: Option<CommitmentEventStream>,
+		execution_extension: execution_extension::Config,
 	) -> Self {
 		let commitment_events = match commitment_events {
 			Some(stream) => Either::Left(stream),
 			None => Either::Right(stream::pending()),
 		};
-		Task { executor, settlement_manager, da_db, da_light_node_client, commitment_events }
+		Task {
+			executor,
+			settlement_manager,
+			da_db,
+			da_light_node_client,
+			commitment_events,
+			execution_extension,
+		}
 	}
 
 	fn settlement_enabled(&self) -> bool {
@@ -167,13 +177,13 @@ where
 		block: Block,
 		mut block_timestamp: u64,
 	) -> anyhow::Result<BlockCommitment> {
-		for _ in 0..5 {
+		for _ in 0..self.execution_extension.block_retry_count {
 			// we have to clone here because the block is supposed to be consumed by the executor
 			match self.execute_block(block.clone(), block_timestamp).await {
 				Ok(commitment) => return Ok(commitment),
 				Err(e) => {
 					warn!("Failed to execute block: {:?}. Retrying", e);
-					block_timestamp += 5000; // increase the timestamp by 5 ms (5000 microseconds)
+					block_timestamp += self.execution_extension.block_retry_increment_microseconds; // increase the timestamp by 5 ms (5000 microseconds)
 				}
 			}
 		}

--- a/protocol-units/execution/dof/src/lib.rs
+++ b/protocol-units/execution/dof/src/lib.rs
@@ -60,6 +60,9 @@ pub trait DynOptFinExecutor {
 
 	/// Decrements transactions in flight on the transaction channel.
 	fn decrement_transactions_in_flight(&self, count: u64);
+
+	/// Gets the config
+	fn config(&self) -> &Config;
 }
 
 pub trait MakeOptFinServices {

--- a/protocol-units/execution/dof/src/v1.rs
+++ b/protocol-units/execution/dof/src/v1.rs
@@ -123,6 +123,10 @@ impl DynOptFinExecutor for Executor {
 	fn decrement_transactions_in_flight(&self, count: u64) {
 		self.executor.decrement_transactions_in_flight(count)
 	}
+
+	fn config(&self) -> &Config {
+		self.executor.config()
+	}
 }
 
 #[cfg(test)]

--- a/protocol-units/execution/opt-executor/src/executor/initialization.rs
+++ b/protocol-units/execution/opt-executor/src/executor/initialization.rs
@@ -35,6 +35,7 @@ impl Executor {
 			block_executor: Arc::new(BlockExecutor::new(db.clone())),
 			signer,
 			transactions_in_flight: Arc::new(AtomicU64::new(0)),
+			config: maptos_config.clone(),
 		})
 	}
 

--- a/protocol-units/execution/opt-executor/src/executor/mod.rs
+++ b/protocol-units/execution/opt-executor/src/executor/mod.rs
@@ -10,6 +10,7 @@ use aptos_vm::AptosVM;
 
 use tracing::info;
 
+use maptos_execution_util::config::Config;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -22,6 +23,8 @@ pub struct Executor {
 	pub signer: ValidatorSigner,
 	// Shared reference on the counter of transactions in flight.
 	transactions_in_flight: Arc<AtomicU64>,
+	// The config for the executor.
+	pub(crate) config: Config,
 }
 
 impl Executor {
@@ -47,5 +50,9 @@ impl Executor {
 				Some(current.saturating_sub(count))
 			})
 			.unwrap_or_else(|_| 0);
+	}
+
+	pub fn config(&self) -> &Config {
+		&self.config
 	}
 }

--- a/protocol-units/execution/opt-executor/src/indexer.rs
+++ b/protocol-units/execution/opt-executor/src/indexer.rs
@@ -1,6 +1,4 @@
 use super::Context;
-
-use aptos_indexer::runtime::bootstrap as bootstrap_indexer_stream;
 use aptos_indexer_grpc_fullnode::runtime::bootstrap as bootstrap_indexer_grpc;
 use aptos_indexer_grpc_table_info::runtime::bootstrap as bootstrap_table_info;
 


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**: `protocol-units`

1. Moves `BlobWriteRequest` submission back into an unawaited task, allowing the next blob batch to be constructed. 
2. Restores configuration for block retries.

# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing
1. e2e testing. 

# Outstanding issues
1. I'm not 100% I caught everything. But, I think this is all of consequence that got dropped. 