### PR TITLE
fix(maptos-opt-executor): lower load shedding limit

### DIFF
--- a/protocol-units/execution/opt-executor/src/executor/initialization.rs
+++ b/protocol-units/execution/opt-executor/src/executor/initialization.rs
@@ -108,6 +108,7 @@ impl Executor {
 			self.db().reader.clone(),
 			&node_config,
 			Arc::clone(&self.transactions_in_flight),
+			maptos_config.load_shedding.max_transactions_in_flight,
 		);
 		let cx = Context::new(
 			self.db().clone(),

--- a/protocol-units/execution/opt-executor/src/transaction_pipe.rs
+++ b/protocol-units/execution/opt-executor/src/transaction_pipe.rs
@@ -19,7 +19,7 @@ use tracing::{debug, info, info_span, warn, Instrument};
 use std::sync::{atomic::AtomicU64, Arc};
 use std::time::{Duration, Instant};
 
-const IN_FLIGHT_LIMIT: u64 = 2u64.pow(16);
+const IN_FLIGHT_LIMIT: u64 = 12_000;
 
 const GC_INTERVAL: Duration = Duration::from_secs(30);
 

--- a/protocol-units/execution/util/src/config/common.rs
+++ b/protocol-units/execution/util/src/config/common.rs
@@ -133,3 +133,5 @@ env_default!(
 	String,
 	"auth_token".to_string()
 );
+
+env_default!(default_max_transactions_in_flight, "MAPTOS_MAX_TRANSACTIONS_IN_FLIGHT", u64, 12000);

--- a/protocol-units/execution/util/src/config/load_shedding.rs
+++ b/protocol-units/execution/util/src/config/load_shedding.rs
@@ -1,0 +1,19 @@
+//! Configuration for load-sheding limits.
+
+use super::common::default_max_transactions_in_flight;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Config {
+	/// The maximum number of transactions permitted to be in flight
+	/// before new transactions are rejected.
+	#[serde(default = "default_max_transactions_in_flight")]
+	pub max_transactions_in_flight: u64,
+}
+
+impl Default for Config {
+	fn default() -> Self {
+		Self { max_transactions_in_flight: default_max_transactions_in_flight() }
+	}
+}

--- a/protocol-units/execution/util/src/config/mod.rs
+++ b/protocol-units/execution/util/src/config/mod.rs
@@ -5,6 +5,8 @@ pub mod faucet;
 pub mod fin;
 pub mod indexer;
 pub mod indexer_processor;
+pub mod load_shedding;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -32,6 +34,9 @@ pub struct Config {
 	/// The fin configuration
 	#[serde(default)]
 	pub fin: fin::Config,
+
+	/// The load shedding parameters
+	pub load_shedding: load_shedding::Config,
 }
 
 impl Default for Config {
@@ -43,6 +48,7 @@ impl Default for Config {
 			client: client::Config::default(),
 			faucet: faucet::Config::default(),
 			fin: fin::Config::default(),
+			load_shedding: load_shedding::Config::default(),
 		}
 	}
 }


### PR DESCRIPTION
# Summary
- **Categories**: `protocol-units`

Lower the load shedding limit in the transaction ingress pipe task
to 12k.

# Changelog

* Maximum number of transactions in flight set to 12000.
