### PR TITLE
fix(maptos-execution-util): default load_shedding

### DIFF
--- a/protocol-units/execution/util/src/config/mod.rs
+++ b/protocol-units/execution/util/src/config/mod.rs
@@ -36,6 +36,7 @@ pub struct Config {
 	pub fin: fin::Config,
 
 	/// The load shedding parameters
+	#[serde(default)]
 	pub load_shedding: load_shedding::Config,
 }
 


### PR DESCRIPTION
# Summary
- **Categories**: `protocol-units`.

In `Deserialize` for top-level execution `Config`, default the `load_shedding` field if not present.

# Testing

None added here, will test in infra.

# Outstanding issues

Should we have example configs for testing regressions?