### PR TITLE
Create the config file if not present when the indexer start.

### DIFF
--- a/.github/workflows/checks-all.yml
+++ b/.github/workflows/checks-all.yml
@@ -140,25 +140,25 @@ jobs:
     - name: Run MCR Client Tests
       run: nix develop --command bash  -c "just mcr-client native build.local.test -t=false"
 
-  Indexer:
-    if: github.event.label.name == 'cicd:suzuka-full-node' ||  github.ref == 'refs/heads/main'
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-22.04
-            arch: x86_64
-            runs-on: buildjet-8vcpu-ubuntu-2204
+#  Indexer:
+#    strategy:
+#      matrix:
+#        include:
+#          - os: ubuntu-22.04
+#            arch: x86_64
+#            runs-on: buildjet-8vcpu-ubuntu-2204
+#
+#    runs-on: ${{ matrix.runs-on }}
+#
+#    steps:
+#    - name: Checkout repository
+#      uses: actions/checkout@v4
+#
+#    - name: Install Nix
+#      uses: DeterminateSystems/nix-installer-action@main
+#
+#    - name: Run Indexer tests in nix environment
+#      # adjust the log level while debugging
+#      run: CELESTIA_LOG_LEVEL=FATAL nix develop --command bash  -c "just suzuka-full-node native build.celestia-local.indexer.hasura.indexer-test -t=false"
 
-    runs-on: ${{ matrix.runs-on }}
 
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Install Nix
-      uses: DeterminateSystems/nix-installer-action@main
-
-    - name: Run Indexer tests in nix environment
-      # adjust the log level while debugging
-      run: CELESTIA_LOG_LEVEL=FATAL nix develop --command bash  -c "just suzuka-full-node native build.celestia-local.indexer.hasura.indexer-test -t=false"
-      

--- a/.github/workflows/checks-all.yml
+++ b/.github/workflows/checks-all.yml
@@ -140,25 +140,25 @@ jobs:
     - name: Run MCR Client Tests
       run: nix develop --command bash  -c "just mcr-client native build.local.test -t=false"
 
-#  Indexer:
-#    strategy:
-#      matrix:
-#        include:
-#          - os: ubuntu-22.04
-#            arch: x86_64
-#            runs-on: buildjet-8vcpu-ubuntu-2204
-#
-#    runs-on: ${{ matrix.runs-on }}
-#
-#    steps:
-#    - name: Checkout repository
-#      uses: actions/checkout@v4
-#
-#    - name: Install Nix
-#      uses: DeterminateSystems/nix-installer-action@main
-#
-#    - name: Run Indexer tests in nix environment
-#      # adjust the log level while debugging
-#      run: CELESTIA_LOG_LEVEL=FATAL nix develop --command bash  -c "just suzuka-full-node native build.celestia-local.indexer.hasura.indexer-test -t=false"
+  Indexer:
+    if: github.event.label.name == 'cicd:suzuka-full-node' ||  github.ref == 'refs/heads/main'
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            arch: x86_64
+            runs-on: buildjet-8vcpu-ubuntu-2204
 
+    runs-on: ${{ matrix.runs-on }}
 
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@main
+
+    - name: Run Indexer tests in nix environment
+      # adjust the log level while debugging
+      run: CELESTIA_LOG_LEVEL=FATAL nix develop --command bash  -c "just suzuka-full-node native build.celestia-local.indexer.hasura.indexer-test -t=false"
+      

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12614,6 +12614,7 @@ dependencies = [
  "processor",
  "reqwest 0.12.7",
  "server-framework",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",

--- a/networks/suzuka/indexer/Cargo.toml
+++ b/networks/suzuka/indexer/Cargo.toml
@@ -21,6 +21,7 @@ tracing-subscriber = { workspace = true }
 maptos-execution-util = { workspace = true }
 clap = { workspace = true }
 reqwest = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/networks/suzuka/indexer/src/main.rs
+++ b/networks/suzuka/indexer/src/main.rs
@@ -16,23 +16,18 @@ fn main() -> Result<(), anyhow::Error> {
 		.init();
 
 	let dot_movement = dot_movement::DotMovement::try_from_env()?;
-	let maptos_config =
-		dot_movement.try_get_config_from_json::<maptos_execution_util::config::Config>()?;
+	let maptos_config = dot_movement
+		.try_get_or_create_config_from_json::<maptos_execution_util::config::Config>()?;
 
-	let default_indexer_config =
-		build_processor_conf("default_processor", &maptos_config, &dot_movement)?;
-	let usertx_indexer_config =
-		build_processor_conf("user_transaction_processor", &maptos_config, &dot_movement)?;
+	let default_indexer_config = build_processor_conf("default_processor", &maptos_config)?;
+	let usertx_indexer_config = build_processor_conf("user_transaction_processor", &maptos_config)?;
 	let accounttx_indexer_config =
-		build_processor_conf("account_transactions_processor", &maptos_config, &dot_movement)?;
-	let coin_indexer_config =
-		build_processor_conf("coin_processor", &maptos_config, &dot_movement)?;
-	let event_indexer_config =
-		build_processor_conf("events_processor", &maptos_config, &dot_movement)?;
-	let fungible_indexer_config =
-		build_processor_conf("fungible_asset_processor", &maptos_config, &dot_movement)?;
+		build_processor_conf("account_transactions_processor", &maptos_config)?;
+	let coin_indexer_config = build_processor_conf("coin_processor", &maptos_config)?;
+	let event_indexer_config = build_processor_conf("events_processor", &maptos_config)?;
+	let fungible_indexer_config = build_processor_conf("fungible_asset_processor", &maptos_config)?;
 	let txmeta_indexer_config =
-		build_processor_conf("transaction_metadata_processor", &maptos_config, &dot_movement)?;
+		build_processor_conf("transaction_metadata_processor", &maptos_config)?;
 
 	let num_cpus = num_cpus::get();
 	let worker_threads = (num_cpus * RUNTIME_WORKER_MULTIPLIER).max(16);
@@ -88,7 +83,6 @@ fn main() -> Result<(), anyhow::Error> {
 fn build_processor_conf(
 	processor_name: &str,
 	maptos_config: &maptos_execution_util::config::Config,
-	dot_movement: &dot_movement::DotMovement,
 ) -> Result<IndexerGrpcProcessorConfig, anyhow::Error> {
 	let indexer_grpc_data_service_address = build_grpc_url(maptos_config);
 	//create config file
@@ -108,14 +102,15 @@ auth_token: \"{}\"",
 		maptos_config.indexer_processor.indexer_processor_auth_token,
 	);
 
-	let indexer_config_path = dot_movement.get_path().join("indexer_config.yaml");
-	let mut output_file = std::fs::File::create(&indexer_config_path).map_err(|err| {
-		anyhow::anyhow!("Indexer temps config file :{indexer_config_path:?} can't be created because of err:{err}")
-	})?;
+	//let indexer_config_path = dot_movement.get_path().join("indexer_config.yaml");
+	let mut output_file = tempfile::NamedTempFile::new()?;
+	// let mut output_file = std::fs::File::create(&indexer_config_path).map_err(|err| {
+	// 	anyhow::anyhow!("Indexer temps config file :{indexer_config_path:?} can't be created because of err:{err}")
+	// })?;
 	write!(output_file, "{}", indexer_config_content)?;
 
 	let indexer_config =
-		server_framework::load::<IndexerGrpcProcessorConfig>(&indexer_config_path)?;
+		server_framework::load::<IndexerGrpcProcessorConfig>(&output_file.path().to_path_buf())?;
 	Ok(indexer_config)
 }
 

--- a/util/dot-movement/src/lib.rs
+++ b/util/dot-movement/src/lib.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 pub mod path;
 
 #[derive(Debug, Clone)]
@@ -47,6 +48,43 @@ impl DotMovement {
 				Ok(file)
 			}
 		}
+	}
+
+	/// Tries to get a configuration from a JSON file.
+	pub fn try_get_or_create_config_from_json<
+		T: serde::de::DeserializeOwned + serde::ser::Serialize + Default,
+	>(
+		&self,
+	) -> Result<T, anyhow::Error> {
+		let config_path = self.get_config_json_path();
+		// get res for opening in read-write mode
+		let res = std::fs::OpenOptions::new().read(true).write(true).open(config_path.clone());
+
+		let file = match res {
+			Ok(file) => file,
+			Err(_e) => {
+				// create parent directories
+				std::fs::DirBuilder::new().recursive(true).create(
+					config_path
+						.parent()
+						.ok_or(anyhow::anyhow!("Failed to get parent directory of config path"))?,
+				)?;
+
+				// create the file
+				{
+					let mut file = std::fs::File::create_new(&config_path)?;
+					let default_config = T::default();
+					let json_contents = serde_json::to_string_pretty(&default_config)?;
+					file.write_all(json_contents.as_bytes())?;
+					file.sync_all()?;
+				}
+				std::fs::OpenOptions::new().read(true).write(true).open(config_path.clone())?
+			}
+		};
+		let reader = std::io::BufReader::new(file);
+		let config = serde_json::from_reader(reader)
+			.map_err(|e| anyhow::anyhow!("Failed to parse config: {}", e))?;
+		Ok(config)
 	}
 
 	/// Tries to get a configuration from a JSON file.


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

<!--
Add your summary text here. 
 -->
To ease the test of the indexer as a standalone program, add the Config.json file creation if not present.

# Changelog
- Change dot-movement lib to add the function: try_get_or_create_config_from_json
- Activate the CI index test.
- Call the new function in the indexer main.rs.
-  Change indexer processor config file generation to tempfile, to avoid confusion with real config file.
<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing
<!--
Describe your Test Plan and explain added or modified test components.
-->
To test: CELESTIA_LOG_LEVEL=FATAL nix develop --extra-experimental-features nix-command --extra-experimental-features flakes --command bash  -c "just suzuka-full-node native build.celestia-local.indexer.hasura.indexer-test --keep-tui"
# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->