### PR TITLE
Genesis can only be ran once if successful per domain

### DIFF
--- a/protocol-units/settlement/mcr/contracts/src/staking/MovementStaking.sol
+++ b/protocol-units/settlement/mcr/contracts/src/staking/MovementStaking.sol
@@ -60,7 +60,8 @@ contract MovementStaking is
 
     function acceptGenesisCeremony() public {
         address domain = msg.sender;
-
+        if (domainGenesisAccepted[domain]) revert GenesisAlreadyAccepted();
+        domainGenesisAccepted[domain] = true;
         // roll over from 0 (genesis) to current epoch by block time
         currentEpochByDomain[domain] = getEpochByBlockTime(domain);
 

--- a/protocol-units/settlement/mcr/contracts/src/staking/MovementStakingStorage.sol
+++ b/protocol-units/settlement/mcr/contracts/src/staking/MovementStakingStorage.sol
@@ -35,6 +35,8 @@ contract MovementStakingStorage {
         mapping(uint256 epoch =>
             mapping(address attester => uint256 stake))) public epochTotalStakeByDomain;
 
+    mapping(address domain => bool) public domainGenesisAccepted;
+
     // the whitelist role needed to stake/unstake
     bytes32 public constant WHITELIST_ROLE = keccak256("WHITELIST_ROLE");
 }

--- a/protocol-units/settlement/mcr/contracts/src/staking/interfaces/IMovementStaking.sol
+++ b/protocol-units/settlement/mcr/contracts/src/staking/interfaces/IMovementStaking.sol
@@ -97,6 +97,8 @@ interface IMovementStaking {
     );
 
     event EpochRolledOver(address indexed domain, uint256 epoch);
+    
     error StakeExceedsGenesisStake();
     error CustodianTransferAmountMismatch();
+    error GenesisAlreadyAccepted();
 }

--- a/protocol-units/settlement/mcr/contracts/test/staking/MovementStaking.t.sol
+++ b/protocol-units/settlement/mcr/contracts/test/staking/MovementStaking.t.sol
@@ -122,6 +122,10 @@ contract MovementStakingTest is Test {
             staking.getCurrentEpochStake(domain, address(moveToken), staker),
             100
         );
+
+        vm.expectRevert(IMovementStaking.GenesisAlreadyAccepted.selector);
+        vm.prank(domain);
+        staking.acceptGenesisCeremony();
     }
 
     function testSimpleRolloverEpoch() public {


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: `protocol-units`.

https://github.com/movementlabsxyz/movement/issues/529

# Changelog

Added a mapping between domain and bool to check if a genesis ceremony has been done for the specified domain.

# Testing

Checks if running acceptGenesisCeremony() twice on the same domain reverts.

# Outstanding issues
Clarify how a genesis ceremony could fail and ran again.