### PR TITLE
fix: git submodule update added to ci

### DIFF
--- a/.github/workflows/checks-all.yml
+++ b/.github/workflows/checks-all.yml
@@ -213,6 +213,9 @@ jobs:
     - name: Install Nix
       uses: DeterminateSystems/nix-installer-action@main
 
+    - name: Initialize and update submodules
+      run: git submodule update --init --recursive
+
     - name: Run foundry tests
       run: |
         nix develop --command bash -c "


### PR DESCRIPTION
# Summary
- fix the error 

```
Error: 
failed to resolve file: "/home/runner/actions-runner/_work/movement/movement/protocol-units/bridge/contracts/lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol": No such file or directory (os error 2); check configured remappings
	--> /home/runner/actions-runner/_work/movement/movement/protocol-units/bridge/contracts/src/IWETH9.sol
	@openzeppelin/contracts/token/ERC20/IERC20.sol

# Changelog

Add the following to CI checks:

```
    - name: Initialize and update submodules
      run: git submodule update --init --recursive
```

# Testing

CI passing is the main test.

# Outstanding issues
