### PR TITLE
Set `RUST_BACKTRACE` for docker-compose services

### DIFF
--- a/docker/compose/suzuka-full-node/docker-compose.yml
+++ b/docker/compose/suzuka-full-node/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       - DOT_MOVEMENT_PATH=/.movement
       - MOVEMENT_TIMING=info
       - M1_DA_LIGHT_NODE_TIMING_LOG=/.movement/m1-da-light-node-timing.log
+      - RUST_BACKTRACE=1
     volumes:
       - ${DOT_MOVEMENT_PATH}:/.movement
     depends_on:
@@ -67,6 +68,7 @@ services:
       - DOT_MOVEMENT_PATH=/.movement
       - MOVEMENT_TIMING=info
       - SUZUKA_TIMING_LOG=/.movement/suzuka-timing.log
+      - RUST_BACKTRACE=1
     volumes:
       - ${DOT_MOVEMENT_PATH}:/.movement
     depends_on:
@@ -87,6 +89,7 @@ services:
     command: run-simple
     environment:
       - DOT_MOVEMENT_PATH=/.movement
+      - RUST_BACKTRACE=1
     volumes:
       - ${DOT_MOVEMENT_PATH}:/.movement
     ports:


### PR DESCRIPTION
https://github.com/movementlabsxyz/infra/issues/163

# Summary
- **Categories**: `misc`.

Enable backtrace printouts on crashes of Movement services in docker-compose.
