### PR TITLE
Load shedding in memseq

### DIFF
--- a/protocol-units/da/m1/light-node/src/v1/sequencer.rs
+++ b/protocol-units/da/m1/light-node/src/v1/sequencer.rs
@@ -270,11 +270,10 @@ impl LightNodeV1 {
 				}
 				Err(e) => {
 					info!("block proposer failed: {:?}", e);
+					return Err(e);
 				}
 			}
 		}
-
-		Ok(())
 	}
 
 	pub fn to_sequenced_blob_block(

--- a/protocol-units/da/m1/light-node/src/v1/sequencer.rs
+++ b/protocol-units/da/m1/light-node/src/v1/sequencer.rs
@@ -1,27 +1,28 @@
-use std::{
-	sync::{atomic::AtomicU64, Arc},
-	time::Duration,
+use std::boxed::Box;
+use std::fmt;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::{atomic::AtomicU64, Arc};
+use std::time::Duration;
+
+use tokio::{
+	sync::mpsc::{Receiver, Sender},
+	time::timeout,
 };
 use tokio_stream::Stream;
 use tracing::{debug, info};
 
 use celestia_rpc::HeaderClient;
+use m1_da_light_node_grpc as grpc;
+use m1_da_light_node_grpc::blob_response::BlobType;
 use m1_da_light_node_grpc::light_node_service_server::LightNodeService;
 use m1_da_light_node_util::config::Config;
-use std::{fmt::Debug, path::PathBuf};
-// FIXME: glob imports are bad style
-use m1_da_light_node_grpc::*;
 use memseq::{Sequencer, Transaction};
 use movement_algs::grouping_heuristic::{
 	apply::ToApply, binpacking::FirstFitBinpacking, drop_success::DropSuccess, skip::SkipFor,
 	splitting::Splitting, GroupingHeuristicStack, GroupingOutcome,
 };
 use movement_types::block::Block;
-use std::boxed::Box;
-use tokio::{
-	sync::mpsc::{Receiver, Sender},
-	time::timeout,
-};
 
 use crate::v1::{passthrough::LightNodeV1 as LightNodeV1PassThrough, LightNodeV1Operations};
 
@@ -33,8 +34,8 @@ pub struct LightNodeV1 {
 	pub memseq: Arc<memseq::Memseq<memseq::RocksdbMempool>>,
 }
 
-impl Debug for LightNodeV1 {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for LightNodeV1 {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		f.debug_struct("LightNodeV1").field("pass_through", &self.pass_through).finish()
 	}
 }
@@ -277,31 +278,27 @@ impl LightNodeV1 {
 	}
 
 	pub fn to_sequenced_blob_block(
-		blob_response: BlobResponse,
-	) -> Result<BlobResponse, anyhow::Error> {
+		blob_response: grpc::BlobResponse,
+	) -> Result<grpc::BlobResponse, anyhow::Error> {
 		let blob_type = blob_response.blob_type.ok_or(anyhow::anyhow!("No blob type"))?;
 
 		let sequenced_block = match blob_type {
-			blob_response::BlobType::PassedThroughBlob(blob) => {
-				blob_response::BlobType::SequencedBlobBlock(blob)
-			}
-			blob_response::BlobType::SequencedBlobBlock(blob) => {
-				blob_response::BlobType::SequencedBlobBlock(blob)
-			}
+			BlobType::PassedThroughBlob(blob) => BlobType::SequencedBlobBlock(blob),
+			BlobType::SequencedBlobBlock(blob) => BlobType::SequencedBlobBlock(blob),
 			_ => {
 				anyhow::bail!("Invalid blob type")
 			}
 		};
 
-		Ok(BlobResponse { blob_type: Some(sequenced_block) })
+		Ok(grpc::BlobResponse { blob_type: Some(sequenced_block) })
 	}
 
 	pub fn make_sequenced_blob_intent(
 		data: Vec<u8>,
 		height: u64,
-	) -> Result<BlobResponse, anyhow::Error> {
-		Ok(BlobResponse {
-			blob_type: Some(blob_response::BlobType::SequencedBlobIntent(Blob {
+	) -> Result<grpc::BlobResponse, anyhow::Error> {
+		Ok(grpc::BlobResponse {
+			blob_type: Some(BlobType::SequencedBlobIntent(grpc::Blob {
 				data,
 				blob_id: "".to_string(),
 				height,
@@ -314,63 +311,73 @@ impl LightNodeV1 {
 #[tonic::async_trait]
 impl LightNodeService for LightNodeV1 {
 	/// Server streaming response type for the StreamReadFromHeight method.
-	type StreamReadFromHeightStream = std::pin::Pin<
+	type StreamReadFromHeightStream = Pin<
 		Box<
-			dyn Stream<Item = Result<StreamReadFromHeightResponse, tonic::Status>> + Send + 'static,
+			dyn Stream<Item = Result<grpc::StreamReadFromHeightResponse, tonic::Status>>
+				+ Send
+				+ 'static,
 		>,
 	>;
 
 	/// Stream blobs from a specified height or from the latest height.
 	async fn stream_read_from_height(
 		&self,
-		request: tonic::Request<StreamReadFromHeightRequest>,
+		request: tonic::Request<grpc::StreamReadFromHeightRequest>,
 	) -> std::result::Result<tonic::Response<Self::StreamReadFromHeightStream>, tonic::Status> {
 		self.pass_through.stream_read_from_height(request).await
 	}
 
 	/// Server streaming response type for the StreamReadLatest method.
-	type StreamReadLatestStream = std::pin::Pin<
-		Box<dyn Stream<Item = Result<StreamReadLatestResponse, tonic::Status>> + Send + 'static>,
+	type StreamReadLatestStream = Pin<
+		Box<
+			dyn Stream<Item = Result<grpc::StreamReadLatestResponse, tonic::Status>>
+				+ Send
+				+ 'static,
+		>,
 	>;
 
 	/// Stream the latest blobs.
 	async fn stream_read_latest(
 		&self,
-		request: tonic::Request<StreamReadLatestRequest>,
+		request: tonic::Request<grpc::StreamReadLatestRequest>,
 	) -> std::result::Result<tonic::Response<Self::StreamReadLatestStream>, tonic::Status> {
 		self.pass_through.stream_read_latest(request).await
 	}
 	/// Server streaming response type for the StreamWriteCelestiaBlob method.
-	type StreamWriteBlobStream = std::pin::Pin<
-		Box<dyn Stream<Item = Result<StreamWriteBlobResponse, tonic::Status>> + Send + 'static>,
+	type StreamWriteBlobStream = Pin<
+		Box<
+			dyn Stream<Item = Result<grpc::StreamWriteBlobResponse, tonic::Status>>
+				+ Send
+				+ 'static,
+		>,
 	>;
 	/// Stream blobs out, either individually or in batches.
 	async fn stream_write_blob(
 		&self,
-		_request: tonic::Request<tonic::Streaming<StreamWriteBlobRequest>>,
+		_request: tonic::Request<tonic::Streaming<grpc::StreamWriteBlobRequest>>,
 	) -> std::result::Result<tonic::Response<Self::StreamWriteBlobStream>, tonic::Status> {
 		unimplemented!("stream_write_blob")
 	}
 	/// Read blobs at a specified height.
 	async fn read_at_height(
 		&self,
-		request: tonic::Request<ReadAtHeightRequest>,
-	) -> std::result::Result<tonic::Response<ReadAtHeightResponse>, tonic::Status> {
+		request: tonic::Request<grpc::ReadAtHeightRequest>,
+	) -> std::result::Result<tonic::Response<grpc::ReadAtHeightResponse>, tonic::Status> {
 		self.pass_through.read_at_height(request).await
 	}
 	/// Batch read and write operations for efficiency.
 	async fn batch_read(
 		&self,
-		request: tonic::Request<BatchReadRequest>,
-	) -> std::result::Result<tonic::Response<BatchReadResponse>, tonic::Status> {
+		request: tonic::Request<grpc::BatchReadRequest>,
+	) -> std::result::Result<tonic::Response<grpc::BatchReadResponse>, tonic::Status> {
 		self.pass_through.batch_read(request).await
 	}
 
 	/// Batch write blobs.
 	async fn batch_write(
 		&self,
-		request: tonic::Request<BatchWriteRequest>,
-	) -> std::result::Result<tonic::Response<BatchWriteResponse>, tonic::Status> {
+		request: tonic::Request<grpc::BatchWriteRequest>,
+	) -> std::result::Result<tonic::Response<grpc::BatchWriteResponse>, tonic::Status> {
 		let blobs_for_intent = request.into_inner().blobs;
 		let blobs_for_submission = blobs_for_intent.clone();
 		let height: u64 = self
@@ -382,13 +389,13 @@ impl LightNodeService for LightNodeV1 {
 			.height()
 			.into();
 
-		let intents: Vec<BlobResponse> = blobs_for_intent
+		let intents: Vec<grpc::BlobResponse> = blobs_for_intent
 			.into_iter()
 			.map(|blob| {
 				Self::make_sequenced_blob_intent(blob.data, height)
 					.map_err(|e| tonic::Status::internal(e.to_string()))
 			})
-			.collect::<Result<Vec<BlobResponse>, tonic::Status>>()?;
+			.collect::<Result<Vec<grpc::BlobResponse>, tonic::Status>>()?;
 
 		// make transactions from the blobs
 		let mut transactions = Vec::new();
@@ -405,13 +412,16 @@ impl LightNodeService for LightNodeV1 {
 			.await
 			.map_err(|e| tonic::Status::internal(e.to_string()))?;
 
-		Ok(tonic::Response::new(BatchWriteResponse { blobs: intents }))
+		Ok(tonic::Response::new(grpc::BatchWriteResponse { blobs: intents }))
 	}
 	/// Update and manage verification parameters.
 	async fn update_verification_parameters(
 		&self,
-		request: tonic::Request<UpdateVerificationParametersRequest>,
-	) -> std::result::Result<tonic::Response<UpdateVerificationParametersResponse>, tonic::Status> {
+		request: tonic::Request<grpc::UpdateVerificationParametersRequest>,
+	) -> std::result::Result<
+		tonic::Response<grpc::UpdateVerificationParametersResponse>,
+		tonic::Status,
+	> {
 		self.pass_through.update_verification_parameters(request).await
 	}
 }

--- a/protocol-units/sequencing/memseq/sequencer/src/lib.rs
+++ b/protocol-units/sequencing/memseq/sequencer/src/lib.rs
@@ -1,4 +1,4 @@
-use mempool_util::{MempoolBlockOperations, MempoolTransactionOperations};
+use mempool_util::MempoolTransactionOperations;
 pub use move_rocks::RocksdbMempool;
 pub use movement_types::{
 	block::{self, Block},
@@ -10,7 +10,7 @@ use std::{path::PathBuf, sync::Arc};
 use tokio::sync::RwLock;
 
 #[derive(Clone)]
-pub struct Memseq<T: MempoolBlockOperations + MempoolTransactionOperations> {
+pub struct Memseq<T: MempoolTransactionOperations> {
 	mempool: T,
 	// this value should not be changed after initialization
 	block_size: u32,
@@ -19,7 +19,7 @@ pub struct Memseq<T: MempoolBlockOperations + MempoolTransactionOperations> {
 	building_time_ms: u64,
 }
 
-impl<T: MempoolBlockOperations + MempoolTransactionOperations> Memseq<T> {
+impl<T: MempoolTransactionOperations> Memseq<T> {
 	pub fn new(
 		mempool: T,
 		block_size: u32,
@@ -62,7 +62,7 @@ impl Memseq<RocksdbMempool> {
 	}
 }
 
-impl<T: MempoolBlockOperations + MempoolTransactionOperations> Sequencer for Memseq<T> {
+impl<T: MempoolTransactionOperations> Sequencer for Memseq<T> {
 	async fn publish_many(&self, transactions: Vec<Transaction>) -> Result<(), anyhow::Error> {
 		self.mempool.add_transactions(transactions).await?;
 		Ok(())
@@ -457,24 +457,6 @@ pub mod test {
 
 		async fn pop_transaction(&self) -> Result<Option<Transaction>, anyhow::Error> {
 			Err(anyhow::anyhow!("Mock pop_transaction"))
-		}
-	}
-
-	impl MempoolBlockOperations for MockMempool {
-		async fn has_block(&self, _block_id: block::Id) -> Result<bool, anyhow::Error> {
-			todo!()
-		}
-
-		async fn add_block(&self, _block: Block) -> Result<(), anyhow::Error> {
-			todo!()
-		}
-
-		async fn remove_block(&self, _block_id: block::Id) -> Result<(), anyhow::Error> {
-			todo!()
-		}
-
-		async fn get_block(&self, _block_id: block::Id) -> Result<Option<Block>, anyhow::Error> {
-			todo!()
 		}
 	}
 }

--- a/protocol-units/sequencing/util/src/lib.rs
+++ b/protocol-units/sequencing/util/src/lib.rs
@@ -3,11 +3,11 @@ use movement_types::{
 };
 
 pub trait Sequencer {
-	async fn publish_many(&self, atbs: Vec<Transaction>) -> Result<(), anyhow::Error>;
+	async fn publish_many(&mut self, atbs: Vec<Transaction>) -> Result<(), anyhow::Error>;
 
-	async fn publish(&self, atb: Transaction) -> Result<(), anyhow::Error>;
+	async fn publish(&mut self, atb: Transaction) -> Result<(), anyhow::Error>;
 
-	async fn wait_for_next_block(&self) -> Result<Option<Block>, anyhow::Error>;
+	async fn wait_for_next_block(&mut self) -> Result<Option<Block>, anyhow::Error>;
 }
 
 pub trait SharedSequencer {


### PR DESCRIPTION
Fixes #413

# Summary

- **Categories**: `protocol-units`.

Limit uncontrollable growth of sequencer's mempool by maintaining
a simple in-memory limit.

# Changelog

* Limit the number of transactions in DA sequencer's mempool.

# Testing

Tests to be added in the memseq and m1-da-light-node to test behavior against a configured limit.

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->