### PR TITLE
Add state and storage proof rest APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9058,8 +9058,12 @@ version = "0.0.2"
 dependencies = [
  "anyhow",
  "aptos-api",
+ "aptos-types",
  "futures",
+ "hex",
  "poem",
+ "serde",
+ "serde_json",
  "tokio",
  "tracing",
 ]

--- a/flake.nix
+++ b/flake.nix
@@ -95,6 +95,9 @@
               # rust toolchain
               (toolchain pkgs)
 
+              # for `hostname -I`
+              hostname-debian
+
               # build dependencies
               llvmPackages.bintools openssl openssl.dev libiconv pkg-config
               libclang.lib libz clang pkg-config protobuf rustPlatform.bindgenHook

--- a/networks/suzuka/suzuka-full-node/src/partial.rs
+++ b/networks/suzuka/suzuka-full-node/src/partial.rs
@@ -57,17 +57,19 @@ where
 			transaction_ingress_result,
 			background_task_result,
 			services_result,
+			movement_rest_result,
 		) = try_join!(
 			tokio::spawn(async move { exec_settle_task.run().await }),
 			tokio::spawn(async move { transaction_ingress_task.run().await }),
 			tokio::spawn(exec_background),
 			tokio::spawn(services.run()),
-			// tokio::spawn(async move { movement_rest.run_service().await }),
+			tokio::spawn(async move { movement_rest.run_service().await }),
 		)?;
 		execution_and_settlement_result
 			.and(transaction_ingress_result)
 			.and(background_task_result)
 			.and(services_result)
+			.and(movement_rest_result)
 	}
 }
 

--- a/protocol-units/movement-rest/Cargo.toml
+++ b/protocol-units/movement-rest/Cargo.toml
@@ -19,7 +19,11 @@ poem = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
+aptos-types = { workspace = true }
 aptos-api = { workspace = true }
+serde_json = { workspace = true }
+hex = { workspace = true }
+serde = { workspace = true }
 
 [dev-dependencies]
 poem = { workspace = true, features = ["test"] }

--- a/protocol-units/movement-rest/src/lib.rs
+++ b/protocol-units/movement-rest/src/lib.rs
@@ -1,6 +1,16 @@
 use aptos_api::Context;
 
 use anyhow::Error;
+use aptos_types::{
+	account_address::AccountAddress,
+	aggregate_signature::AggregateSignature,
+	block_info::BlockInfo,
+	epoch_change::EpochChangeProof,
+	ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+	proof::TransactionInfoWithProof,
+	state_proof::StateProof,
+	state_store::{state_key::StateKey, table::TableHandle},
+};
 use futures::prelude::*;
 use poem::listener::TcpListener;
 use poem::{
@@ -28,7 +38,7 @@ impl MovementRest {
 
 	pub fn try_from_env() -> Result<Self, Error> {
 		let url = env::var(Self::MOVEMENT_REST_ENV_VAR)
-			.unwrap_or_else(|_| "http://0.0.0.0:30832".to_string());
+			.unwrap_or_else(|_| "0.0.0.0:30832".to_string());
 		Ok(Self { url, context: None })
 	}
 
@@ -36,7 +46,7 @@ impl MovementRest {
 		self.context = Some(context);
 	}
 
-	pub fn run_service(&self) -> impl Future<Output = Result<(), Error>> + Send {
+	pub fn run_service(&self) -> impl Future<Output = anyhow::Result<()>> + Send {
 		info!("Starting movement rest service at {}", self.url);
 		let movement_rest = self.create_routes();
 		Server::new(TcpListener::bind(self.url.clone()))
@@ -49,7 +59,12 @@ impl MovementRest {
 			.at("/health", get(health))
 			.at("/movement/v1/state-root-hash/:blockheight", get(state_root_hash))
 			.at("movement/v1/richard", get(richard))
-			.data(self.context.clone())
+			.at(
+				"/movement/v1/table-item-with-proof/:table_handle/:key/:blockheight",
+				get(table_item_with_proof),
+			)
+			.at("/movement/v1/state-proof/:blockheight", get(state_proof))
+			.data(self.context.as_ref().unwrap().clone())
 			.with(Tracing)
 	}
 }
@@ -84,6 +99,76 @@ pub async fn state_root_hash(
 		.state_checkpoint_hash()
 		.ok_or_else(|| anyhow::anyhow!("No state root hash found"))?;
 	Ok(state_root_hash.to_string().into_response())
+}
+
+/// Get a table item with the (non)inclusion proof.
+///
+/// Returns a tuple of value and (non)inclusion proof.
+///
+/// Also see [`https://aptos.dev/en/build/apis/fullnode-rest-api-reference?network=mainnet#tag/tables/POST/tables/{table_handle}/item`].
+#[handler]
+pub async fn table_item_with_proof(
+	Path((table_handle, key, blockheight)): Path<(AccountAddress, String, u64)>,
+	context: Data<&Arc<Context>>,
+) -> Result<Response, anyhow::Error> {
+	let (_, end_version, _) = context.db.get_block_info_by_height(blockheight)?;
+
+	let key = hex::decode(&key)?;
+	let key = StateKey::table_item(&TableHandle(table_handle), &key);
+
+	let resp = context.db.get_state_value_with_proof_by_version(&key, end_version)?;
+
+	Ok(serde_json::to_string(&resp)?.into_response())
+}
+
+/// Get the `StateProof` at a specific height. Note that this doesn't give you the latest `StateProof` against the latest ledger info.
+/// This gives you the `StateProof` that is committed to L1 at a specific height.
+#[handler]
+pub async fn state_proof(
+	Path(blockheight): Path<u64>,
+	context: Data<&Arc<Context>>,
+) -> Result<Response, anyhow::Error> {
+	#[derive(serde::Serialize, serde::Deserialize)]
+	struct StateProofResponse {
+		tx_index: u64,
+		state_proof: StateProof,
+		tx_proof: TransactionInfoWithProof,
+	}
+
+	let (_, end_version, block_event) = context.db.get_block_info_by_height(blockheight)?;
+
+	let mut epoch_state = context.db.get_latest_epoch_state()?;
+	epoch_state.epoch = block_event.epoch();
+
+	// We are reconstructing `StateProof` from scratch since Aptos lacks the api to fetch the `StateProof` at a specific height.
+	let block_info = BlockInfo::new(
+		block_event.epoch(),
+		block_event.round(),
+		block_event.hash()?,
+		context.db.get_accumulator_root_hash(end_version)?,
+		end_version,
+		block_event.timestamp,
+		Some(epoch_state),
+	);
+
+	// `consensus_data_hash` and `signatures` are always meant to be empty.
+	let ledger_info = LedgerInfoWithSignatures::new(
+		LedgerInfo::new(block_info, Default::default()),
+		AggregateSignature::empty(),
+	);
+
+	// Epoch change is empty as well since `StateProof` is always calculated at the latest state which
+	// means no epoch change exists.
+	let state_proof = StateProof::new(ledger_info, EpochChangeProof::new(vec![], false));
+
+	let tx = context.db.get_transaction_by_version(end_version, end_version, false)?;
+
+	Ok(serde_json::to_string(&StateProofResponse {
+		tx_index: tx.version,
+		state_proof,
+		tx_proof: tx.proof.clone(),
+	})?
+	.into_response())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**: `protocol-units`

In order for Movement to support IBC and light clients, it should expose some API's for getting transaction, storage and state proofs. This PR adds the necessary API's for supporting IBC. Please see `Changelog` for more details.

# Changelog

The following API's have been added:
1. `/movement/v1/table-item-with-proof/:table_handle/:key/:blockheight`: Returns a table item and it's storage proof at a specific height. This is being used to verify whether some data `N` is really committed. The proof is verified against the [state_checkpoint_hash](https://github.com/aptos-labs/aptos-core/blob/d10449df4f68f9af0f5ee3620963fe5e3bfaf5ac/api/types/src/transaction.rs#L367) of the transaction which is the final transaction at the block at `blockheight`.
2.   `/movement/v1/state-proof/:blockheight`: Returns the state proof that is committed by Movement to L1 and also the transaction proof and info which contains the `state_checkpoint_hash`. The transaction proof is verified against the [executed_state_id](https://github.com/aptos-labs/aptos-core/blob/d10449df4f68f9af0f5ee3620963fe5e3bfaf5ac/types/src/block_info.rs#L35) which is a part of the `StateProof`. Note that in order to verify the validity of the given `StateProof`, the light clients would have to check it against the hash that is committed to Ethereum L1.

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->