### PR TITLE
deps: bump aptos-core to enable pruner tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -800,7 +800,7 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -823,7 +823,7 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-logger",
  "aptos-types",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -879,7 +879,7 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "hex",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -927,7 +927,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -962,7 +962,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -983,7 +983,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "futures",
  "rustversion",
@@ -993,7 +993,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "shadow-rs",
 ]
@@ -1001,7 +1001,7 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -1026,7 +1026,7 @@ dependencies = [
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -1038,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1069,7 +1069,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1096,7 +1096,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1159,7 +1159,7 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
@@ -1201,12 +1201,13 @@ dependencies = [
  "serde",
  "static_assertions",
  "status-line",
+ "tracing",
 ]
 
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1226,7 +1227,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer-schemas"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-schemadb",
@@ -1240,7 +1241,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1271,7 +1272,7 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-infallible",
  "aptos-metrics-core",
@@ -1282,7 +1283,7 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -1298,7 +1299,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-consensus-types",
@@ -1330,7 +1331,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-block-partitioner",
  "aptos-config",
@@ -1360,7 +1361,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -1382,7 +1383,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1402,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-runtimes",
  "core_affinity",
@@ -1415,7 +1416,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1449,7 +1450,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -1463,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -1531,7 +1532,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "either",
  "move-core-types",
@@ -1540,7 +1541,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -1555,7 +1556,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -1575,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
@@ -1588,17 +1589,17 @@ dependencies = [
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 
 [[package]]
 name = "aptos-indexer"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1630,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1642,7 +1643,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-metrics-core",
  "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors)",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd)",
  "aptos-runtimes",
  "aptos-storage-interface",
  "aptos-types",
@@ -1668,7 +1669,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-table-info"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1699,11 +1700,11 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-utils"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd)",
  "async-trait",
  "backoff",
  "base64 0.13.1",
@@ -1731,12 +1732,12 @@ dependencies = [
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1764,7 +1765,7 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1774,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
@@ -1818,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1831,7 +1832,7 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1841,7 +1842,7 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-infallible",
  "aptos-log-derive",
@@ -1865,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
@@ -1878,7 +1879,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -1918,7 +1919,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-types",
  "async-trait",
@@ -1931,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-infallible",
  "bytes 1.7.2",
@@ -1942,7 +1943,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -1951,7 +1952,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -1982,7 +1983,7 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2003,7 +2004,7 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2020,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
@@ -2037,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2082,7 +2083,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2093,7 +2094,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-build-info",
  "aptos-infallible",
@@ -2109,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2119,7 +2120,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -2132,7 +2133,7 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -2145,7 +2146,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-config",
  "aptos-types",
@@ -2170,23 +2171,11 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "crossbeam",
  "proptest",
  "proptest-derive",
-]
-
-[[package]]
-name = "aptos-protos"
-version = "1.3.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
-dependencies = [
- "futures-core",
- "pbjson",
- "prost 0.12.6",
- "serde",
- "tonic 0.11.0",
 ]
 
 [[package]]
@@ -2202,9 +2191,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-protos"
+version = "1.3.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+dependencies = [
+ "futures-core",
+ "pbjson",
+ "prost 0.12.6",
+ "serde",
+ "tonic 0.11.0",
+]
+
+[[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "ipnet",
 ]
@@ -2212,7 +2213,7 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -2223,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "aptos-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2237,7 +2238,7 @@ dependencies = [
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -2260,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-config",
  "rocksdb",
@@ -2269,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "rayon",
  "tokio",
@@ -2278,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2295,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-crypto",
  "aptos-drop-helper",
@@ -2314,7 +2315,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -2336,7 +2337,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2354,11 +2355,11 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd)",
  "bcs 0.1.4",
  "crossbeam-channel",
  "once_cell",
@@ -2372,7 +2373,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-crypto",
  "aptos-infallible",
@@ -2393,7 +2394,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -2404,7 +2405,7 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2415,7 +2416,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2463,7 +2464,7 @@ dependencies = [
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -2481,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -2490,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -2503,7 +2504,7 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2560,12 +2561,12 @@ dependencies = [
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
@@ -2581,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2631,7 +2632,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-cached-packages",
  "aptos-crypto",
@@ -2652,7 +2653,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -2667,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2689,7 +2690,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -8024,7 +8025,7 @@ dependencies = [
  "aptos-language-e2e-tests",
  "aptos-logger",
  "aptos-mempool",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd)",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
@@ -8377,7 +8378,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -8394,7 +8395,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -8409,12 +8410,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -8429,7 +8430,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-spec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "once_cell",
  "quote",
@@ -8439,7 +8440,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -8451,7 +8452,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "fail",
  "move-binary-format",
@@ -8465,7 +8466,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "clap 4.5.18",
@@ -8480,7 +8481,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "clap 4.5.18",
@@ -8510,7 +8511,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "difference",
@@ -8527,7 +8528,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -8553,7 +8554,7 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -8584,7 +8585,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -8609,7 +8610,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -8628,7 +8629,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "clap 4.5.18",
@@ -8645,7 +8646,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "clap 4.5.18",
@@ -8664,7 +8665,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -8676,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -8692,7 +8693,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -8710,7 +8711,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "hex",
@@ -8723,7 +8724,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -8736,7 +8737,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "codespan",
@@ -8762,7 +8763,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "clap 4.5.18",
@@ -8796,7 +8797,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "atty",
@@ -8823,7 +8824,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8852,7 +8853,7 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -8869,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "hex",
@@ -8896,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "abstract-domain-derive",
  "codespan-reporting",
@@ -8915,7 +8916,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "hex",
@@ -8938,7 +8939,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "once_cell",
  "serde",
@@ -8947,7 +8948,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "better_any",
  "bytes 1.7.2",
@@ -8962,7 +8963,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "better_any",
@@ -8990,7 +8991,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "better_any",
  "bytes 1.7.2",
@@ -9014,7 +9015,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "anyhow",
  "bytes 1.7.2",
@@ -9029,7 +9030,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899#1d5900920753e93cae0e3e526e16d366851e1899"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
 dependencies = [
  "bcs 0.1.4",
  "derivative",
@@ -12580,7 +12581,7 @@ name = "suzuka-client"
 version = "0.0.2"
 dependencies = [
  "anyhow",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d5900920753e93cae0e3e526e16d366851e1899)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd)",
  "aptos-sdk",
  "aptos-types",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,40 +104,40 @@ serde_yaml = "0.9.34"
 ## Aptos dependencies
 ### We use a forked version so that we can override dependency versions. This is required
 ### to be avoid dependency conflicts with other Sovereign Labs crates.
-aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899", features = [
+aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd", features = [
     "cloneable-private-keys",
 ] }
-aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
-aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d5900920753e93cae0e3e526e16d366851e1899" }
+aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
 
 # Indexer
 processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "1d1d7c72a01a0b5a55477f8fdca59e17c9ce2e58", subdir = "rust" }


### PR DESCRIPTION
# Summary
- **Categories**: `protocol-units`
- **Dependencies**: https://github.com/movementlabsxyz/aptos-core/pull/79

Integrate aptos-db patch to get log entries about merkle state db pruning.

# Changelog

* Added a few tracing events originating from the patched aptos_db crate,
   to observe pruner behavior.

# Testing

Checking logs of a running node.