### PR TITLE
Client integration tests for framework bridge modules

### DIFF
--- a/protocol-units/bridge/config/src/common/movement.rs
+++ b/protocol-units/bridge/config/src/common/movement.rs
@@ -10,8 +10,8 @@ const DEFAULT_MVT_FAUCET_CONNECTION_PORT: u16 = 8081;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MovementConfig {
-	#[serde(default = "default_movement_signer_address")]
-	pub movement_signer_address: Ed25519PrivateKey,
+	#[serde(default = "default_movement_signer_key")]
+	pub movement_signer_key: Ed25519PrivateKey,
 	#[serde(default = "default_movement_native_address")]
 	pub movement_native_address: String,
 
@@ -31,8 +31,8 @@ pub struct MovementConfig {
 }
 
 // The default private key
-pub fn default_movement_signer_address() -> Ed25519PrivateKey {
-	match std::env::var("MOVEMENT_SIGNER_ADDRESS") {
+pub fn default_movement_signer_key() -> Ed25519PrivateKey {
+	match std::env::var("MOVEMENT_SIGNER_KEY") {
 		Ok(val) => Ed25519PrivateKey::from_encoded_string(&val).unwrap(),
 		Err(_) => Ed25519PrivateKey::generate(&mut rand::thread_rng()),
 	}
@@ -110,7 +110,7 @@ impl MovementConfig {
 impl Default for MovementConfig {
 	fn default() -> Self {
 		MovementConfig {
-			movement_signer_address: default_movement_signer_address(),
+			movement_signer_key: default_movement_signer_key(),
 			movement_native_address: default_movement_native_address(),
 			mvt_rpc_connection_protocol: default_mvt_rpc_connection_protocol(),
 			mvt_rpc_connection_hostname: default_mvt_rpc_connection_hostname(),

--- a/protocol-units/bridge/integration-tests/src/lib.rs
+++ b/protocol-units/bridge/integration-tests/src/lib.rs
@@ -175,33 +175,6 @@ impl TestHarness {
 		(HarnessMvtClient { movement_client, movement_process, rest_client, faucet_client }, config)
 	}
 
-	pub async fn new_with_suzuka(config: Config) -> (HarnessMvtClient, Config) {
-		// Clone the movement_native_address so it can be used without moving config.movement
-		MovementClient::movement_init(&config).await;
-	
-		let movement_client = MovementClient::new(&config.movement)
-		.await
-		.expect("Failed to create MovementClient");
-	
-		let node_connection_url = Url::from_str(&config.movement.mvt_rpc_connection_url())
-		.expect("Bad movement rpc url in config");
-		let rest_client = Client::new(node_connection_url.clone());
-	
-		let faucet_url = Url::from_str(&config.movement.mvt_faucet_connection_url())
-		.expect("Bad movement faucet url in config");
-		let faucet_client = Arc::new(RwLock::new(FaucetClient::new(
-		faucet_url.clone(),
-		node_connection_url.clone(),
-		)));
-
-		let movement_process = Command::new("sleep")
-		.arg("1000")
-		.spawn()
-		.expect("failed to spawn dummy process");
-
-		(HarnessMvtClient { movement_client, movement_process, rest_client, faucet_client }, config)
-	}
-
 	pub async fn new_only_eth(config: Config) -> (HarnessEthClient, Config) {
 		let (config, anvil) = bridge_setup::test_eth_setup(config)
 			.await

--- a/protocol-units/bridge/integration-tests/src/lib.rs
+++ b/protocol-units/bridge/integration-tests/src/lib.rs
@@ -176,19 +176,22 @@ impl TestHarness {
 	}
 
 	pub async fn new_with_suzuka(config: Config) -> (HarnessMvtClient, Config) {
+		// Clone the movement_native_address so it can be used without moving config.movement
+		MovementClient::movement_init(&config).await;
+	
 		let movement_client = MovementClient::new(&config.movement)
-			.await
-			.expect("Failed to create MovementClient");
-
+		.await
+		.expect("Failed to create MovementClient");
+	
 		let node_connection_url = Url::from_str(&config.movement.mvt_rpc_connection_url())
-			.expect("Bad movement rpc url in config");
+		.expect("Bad movement rpc url in config");
 		let rest_client = Client::new(node_connection_url.clone());
-
+	
 		let faucet_url = Url::from_str(&config.movement.mvt_faucet_connection_url())
-			.expect("Bad movement faucet url in config");
+		.expect("Bad movement faucet url in config");
 		let faucet_client = Arc::new(RwLock::new(FaucetClient::new(
-			faucet_url.clone(),
-			node_connection_url.clone(),
+		faucet_url.clone(),
+		node_connection_url.clone(),
 		)));
 
 		let movement_process = Command::new("sleep")

--- a/protocol-units/bridge/integration-tests/src/lib.rs
+++ b/protocol-units/bridge/integration-tests/src/lib.rs
@@ -16,8 +16,10 @@ use bridge_service::chains::movement::utils::MovementAddress;
 use bridge_service::chains::movement::{client::MovementClient, utils::MovementHash};
 use bridge_service::types::Amount;
 use bridge_service::{chains::bridge_contracts::BridgeContractResult, types::BridgeAddress};
+use bridge_setup::local;
 use rand::SeedableRng;
 use tokio::process::Command;
+use tokio::task;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use url::Url;
@@ -153,7 +155,7 @@ impl TestHarness {
 	}
 
 	pub async fn new_with_movement(config: Config) -> (HarnessMvtClient, Config) {
-		let (config, movement_process) = bridge_setup::test_mvt_setup(config)
+		let config = bridge_setup::test_mvt_setup(config)
 			.await
 			.expect("Failed to setup Movement config");
 
@@ -171,6 +173,12 @@ impl TestHarness {
 			faucet_url.clone(),
 			node_connection_url.clone(),
 		)));
+
+		let movement_process = Command::new("m1-da-light-node-celestia-bridge")  // Replace with the actual process name
+		.arg("--some-argument")  // You can pass arguments to the command if needed
+		.spawn()
+		.expect("Failed to start the movement process");
+	
 
 		(HarnessMvtClient { movement_client, movement_process, rest_client, faucet_client }, config)
 	}

--- a/protocol-units/bridge/integration-tests/tests/client_l1move_l2move.rs
+++ b/protocol-units/bridge/integration-tests/tests/client_l1move_l2move.rs
@@ -9,7 +9,7 @@ use bridge_integration_tests::utils as test_utils;
 use bridge_integration_tests::EthToMovementCallArgs;
 use bridge_integration_tests::HarnessMvtClient;
 use bridge_integration_tests::TestHarness;
-use bridge_service::chains::ethereum::types::EthAddress;
+use bridge_service::chains::{ethereum::types::EthAddress, movement::client::MovementClient};
 use bridge_service::chains::{
 	bridge_contracts::{BridgeContract, BridgeContractFramework}, ethereum::types::EthHash, movement::utils::MovementHash,
 };
@@ -66,9 +66,11 @@ async fn test_movement_client_should_successfully_call_lock_and_complete(
 	let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::DEBUG).try_init();
 
 	let config = Config::default();
-	let (mut mvt_client_harness, _config) = TestHarness::new_with_movement(config).await;
+	let (mut mvt_client_harness, _config) = TestHarness::new_with_suzuka(config).await;
 
 	let args = EthToMovementCallArgs::default();
+
+	let _ = MovementClient::update_bridge_operator(&mut mvt_client_harness.movement_client).await;
 
 	let test_result = async {
 		let coin_client = CoinClient::new(&mvt_client_harness.rest_client);
@@ -77,6 +79,7 @@ async fn test_movement_client_should_successfully_call_lock_and_complete(
 		{
 			let faucet_client = mvt_client_harness.faucet_client.write().unwrap();
 			faucet_client.fund(movement_client_signer.address(), 100_000_000).await?;
+
 		}
 
 		let balance = coin_client.get_account_balance(&movement_client_signer.address()).await?;

--- a/protocol-units/bridge/integration-tests/tests/client_l1move_l2move.rs
+++ b/protocol-units/bridge/integration-tests/tests/client_l1move_l2move.rs
@@ -1,0 +1,453 @@
+use alloy::{
+	primitives::{address, keccak256},
+	providers::Provider,
+};
+use anyhow::Result;
+use aptos_sdk::coin_client::CoinClient;
+use bridge_config::Config;
+use bridge_integration_tests::utils as test_utils;
+use bridge_integration_tests::EthToMovementCallArgs;
+use bridge_integration_tests::HarnessMvtClient;
+use bridge_integration_tests::TestHarness;
+use bridge_service::chains::ethereum::types::EthAddress;
+use bridge_service::chains::{
+	bridge_contracts::{BridgeContract, BridgeContractFramework}, ethereum::types::EthHash, movement::utils::MovementHash,
+};
+use bridge_service::types::{
+	Amount, AssetType, BridgeAddress, BridgeTransferId, HashLock, HashLockPreImage,
+};
+use tokio::time::{sleep, Duration};
+use tokio::{self};
+use tracing::info;
+
+#[tokio::test]
+async fn test_movement_client_build_and_fund_accounts() -> Result<(), anyhow::Error> {
+	let config = Config::default();
+	let (mut mvt_client_harness, _config) = TestHarness::new_with_movement(config).await;
+
+	//
+	let rest_client = mvt_client_harness.rest_client;
+	let coin_client = CoinClient::new(&rest_client);
+	let movement_client_signer = mvt_client_harness.movement_client.signer();
+
+	let faucet_client = mvt_client_harness.faucet_client.write().unwrap();
+
+	faucet_client.fund(movement_client_signer.address(), 100_000_000).await?;
+	println!("ICI after fund");
+	let balance = coin_client.get_account_balance(&movement_client_signer.address()).await?;
+	println!("ICI after ge tbalance");
+	assert!(
+		balance >= 100_000_000,
+		"Expected Movement Client to have at least 100_000_000, but found {}",
+		balance
+	);
+
+	if let Err(e) = mvt_client_harness.movement_process.kill().await {
+		eprintln!("Failed to kill child process: {:?}", e);
+	}
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn test_movement_client_should_publish_package() -> Result<(), anyhow::Error> {
+	let _ = tracing_subscriber::fmt().try_init();
+
+	let config = Config::default();
+	let (mut eth_client_harness, _config) = TestHarness::new_with_movement(config).await;
+	eth_client_harness.movement_process.kill().await?;
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn test_movement_client_should_successfully_call_lock_and_complete(
+) -> Result<(), anyhow::Error> {
+	let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::DEBUG).try_init();
+
+	let config = Config::default();
+	let (mut mvt_client_harness, _config) = TestHarness::new_with_movement(config).await;
+
+	let args = EthToMovementCallArgs::default();
+
+	let test_result = async {
+		let coin_client = CoinClient::new(&mvt_client_harness.rest_client);
+		let movement_client_signer = mvt_client_harness.movement_client.signer();
+
+		{
+			let faucet_client = mvt_client_harness.faucet_client.write().unwrap();
+			faucet_client.fund(movement_client_signer.address(), 100_000_000).await?;
+		}
+
+		let balance = coin_client.get_account_balance(&movement_client_signer.address()).await?;
+		assert!(
+			balance >= 100_000_000,
+			"Expected Movement Client to have at least 100_000_000, but found {}",
+			balance
+		);
+
+		BridgeContractFramework::lock_bridge_transfer(
+                                &mut mvt_client_harness.movement_client,
+				BridgeTransferId(args.bridge_transfer_id.0),
+				HashLock(args.hash_lock.0),
+				BridgeAddress(args.initiator.clone()),
+				BridgeAddress(args.recipient.clone().into()),
+				Amount(AssetType::Moveth(args.amount)),
+			)
+			.await
+			.expect("Failed to lock bridge transfer");
+
+		let bridge_transfer_id: [u8; 32] =
+			test_utils::extract_bridge_transfer_id(&mut mvt_client_harness.movement_client).await?;
+		info!("Bridge transfer id: {:?}", bridge_transfer_id);
+		let details = BridgeContractFramework::get_bridge_transfer_details_counterparty(
+			&mut mvt_client_harness.movement_client,
+			BridgeTransferId(MovementHash(bridge_transfer_id).0),
+		)
+		.await
+		.expect("Failed to get bridge transfer details")
+		.expect("Expected to find bridge transfer details, but got None");
+
+		assert_eq!(details.bridge_transfer_id.0, args.bridge_transfer_id.0);
+		assert_eq!(details.hash_lock.0, args.hash_lock.0);
+		assert_eq!(
+			&details.initiator_address.0 .0[32 - args.initiator.len()..],
+			&args.initiator,
+			"Initiator address does not match"
+		);
+		assert_eq!(details.recipient_address.0, args.recipient.0.to_vec());
+		assert_eq!(details.amount.0, AssetType::Moveth(args.amount));
+		assert_eq!(details.state, 1, "Bridge transfer is supposed to be locked but it's not.");
+
+		let secret = b"secret";
+		let mut padded_secret = [0u8; 32];
+		padded_secret[..secret.len()].copy_from_slice(secret);
+
+		BridgeContractFramework::counterparty_complete_bridge_transfer(
+			&mut mvt_client_harness.movement_client,
+			BridgeTransferId(args.bridge_transfer_id.0),
+			HashLockPreImage(padded_secret),
+		)
+		.await
+		.expect("Failed to complete bridge transfer");
+
+		let details = BridgeContractFramework::get_bridge_transfer_details_counterparty(
+			&mut mvt_client_harness.movement_client,
+			BridgeTransferId(args.bridge_transfer_id.0),
+		)
+		.await
+		.expect("Failed to get bridge transfer details")
+		.expect("Expected to find bridge transfer details, but got None");
+
+		assert_eq!(details.bridge_transfer_id.0, args.bridge_transfer_id.0);
+		assert_eq!(details.hash_lock.0, args.hash_lock.0);
+		assert_eq!(
+			&details.initiator_address.0 .0[32 - args.initiator.len()..],
+			&args.initiator,
+			"Initiator address does not match"
+		);
+		assert_eq!(details.recipient_address.0, args.recipient.0.to_vec());
+		assert_eq!(details.amount.0, AssetType::Moveth(args.amount));
+		assert_eq!(details.state, 2, "Bridge transfer is supposed to be completed but it's not.");
+
+		Ok(())
+	}
+	.await;
+
+	if let Err(e) = mvt_client_harness.movement_process.kill().await {
+		eprintln!("Failed to kill child process: {:?}", e);
+	}
+
+	test_result
+}
+
+#[tokio::test]
+async fn test_movement_client_should_successfully_call_lock_and_abort() -> Result<(), anyhow::Error>
+{
+	let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::DEBUG).try_init();
+
+	let config = Config::default();
+	let (mut mvt_client_harness, _config) = TestHarness::new_with_movement(config).await;
+
+	let args = EthToMovementCallArgs::default();
+
+	let test_result = async {
+		let coin_client = CoinClient::new(&mvt_client_harness.rest_client);
+		let movement_client_signer = mvt_client_harness.movement_client.signer();
+
+		{
+			let faucet_client = mvt_client_harness.faucet_client.write().unwrap();
+			faucet_client.fund(movement_client_signer.address(), 100_000_000).await?;
+		}
+
+		let balance = coin_client.get_account_balance(&movement_client_signer.address()).await?;
+		assert!(
+			balance >= 100_000_000,
+			"Expected Movement Client to have at least 100_000_000, but found {}",
+			balance
+		);
+
+		// Set the timelock to 1 second for testing
+		mvt_client_harness
+			.movement_client
+			.counterparty_set_timelock(1)
+			.await
+			.expect("Failed to set timelock");
+
+                BridgeContractFramework::lock_bridge_transfer(
+                        &mut mvt_client_harness.movement_client,
+                        BridgeTransferId(args.bridge_transfer_id.0),
+                        HashLock(args.hash_lock.0),
+                        BridgeAddress(args.initiator.clone()),
+                        BridgeAddress(args.recipient.clone()),
+                        Amount(AssetType::Moveth(args.amount)),
+			)
+			.await
+			.expect("Failed to lock bridge transfer");
+
+		let bridge_transfer_id: [u8; 32] =
+			test_utils::extract_bridge_transfer_id(&mut mvt_client_harness.movement_client).await?;
+		info!("Bridge transfer id: {:?}", bridge_transfer_id);
+		let details = BridgeContractFramework::get_bridge_transfer_details_counterparty(
+			&mut mvt_client_harness.movement_client,
+			BridgeTransferId(MovementHash(bridge_transfer_id).0),
+		)
+		.await
+		.expect("Failed to get bridge transfer details")
+		.expect("Expected to find bridge transfer details, but got None");
+
+		assert_eq!(details.bridge_transfer_id.0, args.bridge_transfer_id.0);
+		assert_eq!(details.hash_lock.0, args.hash_lock.0);
+		assert_eq!(
+			&details.initiator_address.0 .0[32 - args.initiator.len()..],
+			&args.initiator,
+			"Initiator address does not match"
+		);
+		assert_eq!(details.recipient_address.0, args.recipient.0.to_vec());
+		assert_eq!(details.amount.0, AssetType::Moveth(args.amount));
+		assert_eq!(details.state, 1, "Bridge transfer is supposed to be locked but it's not.");
+
+		sleep(Duration::from_secs(5)).await;
+
+                BridgeContractFramework::abort_bridge_transfer(&mut mvt_client_harness
+                        .movement_client, 
+                        BridgeTransferId(args.bridge_transfer_id.0))
+			.await
+			.expect("Failed to complete bridge transfer");
+
+		let abort_details = BridgeContractFramework::get_bridge_transfer_details_counterparty(
+			&mut mvt_client_harness.movement_client,
+			BridgeTransferId(args.bridge_transfer_id.0),
+		)
+		.await
+		.expect("Failed to get bridge transfer details")
+		.expect("Expected to find bridge transfer details, but got None");
+
+		assert_eq!(abort_details.bridge_transfer_id.0, args.bridge_transfer_id.0);
+		assert_eq!(abort_details.hash_lock.0, args.hash_lock.0);
+		assert_eq!(
+			&abort_details.initiator_address.0 .0[32 - args.initiator.len()..],
+			&args.initiator,
+			"Initiator address does not match"
+		);
+		assert_eq!(abort_details.recipient_address.0, args.recipient.0.to_vec());
+		assert_eq!(abort_details.amount.0, AssetType::Moveth(args.amount));
+
+		Ok(())
+	}
+	.await;
+
+	if let Err(e) = mvt_client_harness.movement_process.kill().await {
+		eprintln!("Failed to kill child process: {:?}", e);
+	}
+
+	test_result
+}
+
+#[tokio::test]
+async fn test_eth_client_should_build_and_fetch_accounts() {
+	let config = Config::default();
+	let (eth_client_harness, _config) = TestHarness::new_only_eth(config).await;
+
+	let expected_accounts = [
+		address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266"),
+		address!("70997970c51812dc3a010c7d01b50e0d17dc79c8"),
+		address!("3c44cdddb6a900fa2b585dd299e03d12fa4293bc"),
+		address!("90f79bf6eb2c4f870365e785982e1f101e93b906"),
+		address!("15d34aaf54267db7d7c367839aaf71a00a2c6a65"),
+		address!("9965507d1a55bcc2695c58ba16fb37d819b0a4dc"),
+		address!("976ea74026e726554db657fa54763abd0c3a0aa9"),
+		address!("14dc79964da2c08b23698b3d3cc7ca32193d9955"),
+		address!("23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8f"),
+		address!("a0ee7a142d267c1f36714e4a8f75612f20a79720"),
+	];
+
+	let provider = eth_client_harness.rpc_provider().await;
+	let accounts = provider.get_accounts().await.expect("Failed to get accounts");
+	assert_eq!(accounts.len(), expected_accounts.len());
+
+	for (account, expected) in accounts.iter().zip(expected_accounts.iter()) {
+		assert_eq!(account, expected);
+	}
+}
+
+#[tokio::test]
+async fn test_eth_client_should_deploy_initiator_contract() {
+	let config = Config::default();
+	let (_eth_client_harness, config) = TestHarness::new_only_eth(config).await;
+
+	assert!(config.eth.eth_initiator_contract != "Oxeee");
+	assert_eq!(
+		config.eth.eth_initiator_contract, "0x8464135c8F25Da09e49BC8782676a84730C318bC",
+		"Wrong initiator contract address."
+	);
+}
+
+#[tokio::test]
+async fn test_eth_client_should_successfully_call_initialize() {
+	let config = Config::default();
+	let (_eth_client_harness, config) = TestHarness::new_only_eth(config).await;
+	assert!(config.eth.eth_counterparty_contract != "0xccc");
+	assert_eq!(
+		config.eth.eth_counterparty_contract, "0x71C95911E9a5D330f4D621842EC243EE1343292e",
+		"Wrong initiator contract address."
+	);
+	assert!(config.eth.eth_weth_contract != "0xe3e3");
+	assert_eq!(
+		config.eth.eth_weth_contract, "0x948B3c65b89DF0B4894ABE91E6D02FE579834F8F",
+		"Wrong initiator contract address."
+	);
+}
+
+#[tokio::test]
+async fn test_eth_client_should_successfully_call_initiate_transfer_only_eth() {
+	let config = Config::default();
+	let (mut eth_client_harness, _config) = TestHarness::new_only_eth(config).await;
+
+	let signer_address: alloy::primitives::Address = eth_client_harness.signer_address();
+
+	let recipient = HarnessMvtClient::gen_aptos_account();
+	let hash_lock: [u8; 32] = keccak256("secret".to_string().as_bytes()).into();
+	eth_client_harness
+		.eth_client
+		.initiate_bridge_transfer(
+			BridgeAddress(EthAddress(signer_address)),
+			BridgeAddress(recipient),
+			HashLock(EthHash(hash_lock).0),
+			Amount(AssetType::EthAndWeth((1, 0))), // Eth
+		)
+		.await
+		.expect("Failed to initiate bridge transfer");
+}
+
+#[tokio::test]
+async fn test_eth_client_should_successfully_call_initiate_transfer_only_weth() {
+	let config = Config::default();
+	let (mut eth_client_harness, _config) = TestHarness::new_only_eth(config).await;
+
+	let signer_address: alloy::primitives::Address = eth_client_harness.signer_address();
+
+	let recipient = HarnessMvtClient::gen_aptos_account();
+	let hash_lock: [u8; 32] = keccak256("secret".to_string().as_bytes()).into();
+	eth_client_harness
+		.deposit_weth_and_approve(
+			BridgeAddress(EthAddress(signer_address)),
+			Amount(AssetType::EthAndWeth((0, 1))),
+		)
+		.await
+		.expect("Failed to deposit WETH");
+
+	eth_client_harness
+		.eth_client
+		.initiate_bridge_transfer(
+			BridgeAddress(EthAddress(signer_address)),
+			BridgeAddress(recipient),
+			HashLock(EthHash(hash_lock).0),
+			Amount(AssetType::EthAndWeth((0, 1))),
+		)
+		.await
+		.expect("Failed to initiate bridge transfer");
+}
+
+#[tokio::test]
+async fn test_eth_client_should_successfully_call_initiate_transfer_eth_and_weth() {
+	let config = Config::default();
+	let (mut eth_client_harness, _config) = TestHarness::new_only_eth(config).await;
+
+	let signer_address: alloy::primitives::Address = eth_client_harness.signer_address();
+
+	let recipient = HarnessMvtClient::gen_aptos_account();
+	let hash_lock: [u8; 32] = keccak256("secret".to_string().as_bytes()).into();
+	eth_client_harness
+		.deposit_weth_and_approve(
+			BridgeAddress(EthAddress(signer_address)),
+			Amount(AssetType::EthAndWeth((0, 1))),
+		)
+		.await
+		.expect("Failed to deposit WETH");
+
+	eth_client_harness
+		.eth_client
+		.initiate_bridge_transfer(
+			BridgeAddress(EthAddress(signer_address)),
+			BridgeAddress(recipient),
+			HashLock(EthHash(hash_lock).0),
+			Amount(AssetType::EthAndWeth((1, 1))),
+		)
+		.await
+		.expect("Failed to initiate bridge transfer");
+}
+
+#[tokio::test]
+#[ignore] // To be tested after this is merged in https://github.com/movementlabsxyz/movement/pull/209
+async fn test_client_should_successfully_get_bridge_transfer_id() {
+	let config = Config::default();
+	let (mut eth_client_harness, _config) = TestHarness::new_only_eth(config).await;
+
+	let signer_address: alloy::primitives::Address = eth_client_harness.signer_address();
+
+	let recipient = HarnessMvtClient::gen_aptos_account();
+	let hash_lock: [u8; 32] = keccak256("secret".to_string().as_bytes()).into();
+
+	eth_client_harness
+		.eth_client
+		.initiate_bridge_transfer(
+			BridgeAddress(EthAddress(signer_address)),
+			BridgeAddress(recipient),
+			HashLock(EthHash(hash_lock).0),
+			Amount(AssetType::EthAndWeth((1000, 0))), // Eth
+		)
+		.await
+		.expect("Failed to initiate bridge transfer");
+
+	//TODO: Here call get details with the captured event
+}
+
+#[tokio::test]
+#[ignore] // To be tested after this is merged in https://github.com/movementlabsxyz/movement/pull/209
+async fn test_eth_client_should_successfully_complete_transfer() {
+	let config = Config::default();
+	let (mut eth_client_harness, _config) = TestHarness::new_only_eth(config).await;
+
+	let signer_address: alloy::primitives::Address = eth_client_harness.signer_address();
+
+	let recipient = address!("70997970c51812dc3a010c7d01b50e0d17dc79c8");
+	let recipient_bytes: Vec<u8> = recipient.to_string().as_bytes().to_vec();
+
+	let secret = "secret".to_string();
+	let hash_lock = keccak256(secret.as_bytes());
+	let hash_lock: [u8; 32] = hash_lock.into();
+
+	eth_client_harness
+		.eth_client
+		.initiate_bridge_transfer(
+			BridgeAddress(EthAddress(signer_address)),
+			BridgeAddress(recipient_bytes),
+			HashLock(EthHash(hash_lock).0),
+			Amount(AssetType::EthAndWeth((42, 0))),
+		)
+		.await
+		.expect("Failed to initiate bridge transfer");
+
+	//TODO: Here call complete with the id captured from the event
+}

--- a/protocol-units/bridge/integration-tests/tests/client_l1move_l2move.rs
+++ b/protocol-units/bridge/integration-tests/tests/client_l1move_l2move.rs
@@ -66,7 +66,7 @@ async fn test_movement_client_should_successfully_call_lock_and_complete(
 	let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::DEBUG).try_init();
 
 	let config = Config::default();
-	let (mut mvt_client_harness, _config) = TestHarness::new_with_suzuka(config).await;
+	let (mut mvt_client_harness, _config) = TestHarness::new_with_movement(config).await;
 
 	let args = EthToMovementCallArgs::default();
 

--- a/protocol-units/bridge/integration-tests/tests/client_l2move_l1move.rs
+++ b/protocol-units/bridge/integration-tests/tests/client_l2move_l1move.rs
@@ -1,0 +1,242 @@
+use anyhow::Result;
+use bridge_config::Config;
+use bridge_integration_tests::utils;
+use bridge_integration_tests::utils as test_utils;
+use bridge_integration_tests::{MovementToEthCallArgs, TestHarness};
+use bridge_service::{
+	chains::{bridge_contracts::BridgeContract, movement::utils::MovementHash},
+	types::{BridgeTransferId, HashLockPreImage},
+};
+use tokio::time::{sleep, Duration};
+use tokio::{self};
+use tracing::info;
+
+#[tokio::test]
+async fn test_movement_client_build_and_fund_accounts() -> Result<(), anyhow::Error> {
+	let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::DEBUG).try_init();
+
+	let config = Config::default();
+	let (mut mvt_client_harness, _config) = TestHarness::new_with_movement(config).await;
+	let test_result = async {
+		test_utils::fund_and_check_balance(&mut mvt_client_harness, 100_000_000_000)
+			.await
+			.expect("Failed to fund accounts");
+		Ok(())
+	}
+	.await;
+
+	if let Err(e) = mvt_client_harness.movement_process.kill().await {
+		eprintln!("Failed to kill child process: {:?}", e);
+	}
+	test_result
+}
+
+#[tokio::test]
+async fn test_movement_client_initiate_transfer() -> Result<(), anyhow::Error> {
+	let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::DEBUG).try_init();
+
+	let config = Config::default();
+	let (mut mvt_client_harness, _config) = TestHarness::new_with_movement(config).await;
+
+	let args = MovementToEthCallArgs::default();
+
+	let test_result = async {
+		let sender_address = mvt_client_harness.movement_client.signer().address();
+		test_utils::fund_and_check_balance(&mut mvt_client_harness, 100_000_000_000).await?;
+		test_utils::initiate_bridge_transfer_helper(
+			&mut mvt_client_harness.movement_client,
+			args.initiator.0,
+			args.recipient.clone(),
+			args.hash_lock.0,
+			args.amount,
+			true,
+		)
+		.await
+		.expect("Failed to initiate bridge transfer");
+
+		let bridge_transfer_id: [u8; 32] =
+			test_utils::extract_bridge_transfer_id(&mut mvt_client_harness.movement_client).await?;
+		info!("Bridge transfer id: {:?}", bridge_transfer_id);
+		let details = BridgeContract::get_bridge_transfer_details_initiator(
+			&mut mvt_client_harness.movement_client,
+			BridgeTransferId(MovementHash(bridge_transfer_id).0),
+		)
+		.await
+		.expect("Failed to get bridge transfer details")
+		.expect("Expected to find bridge transfer details, but got None");
+
+		test_utils::assert_bridge_transfer_details(
+			&details,
+			MovementHash(bridge_transfer_id).0,
+			MovementHash(args.hash_lock.0).0,
+			sender_address,
+			args.recipient.clone(),
+			args.amount,
+			1,
+		);
+
+		Ok(())
+	}
+	.await;
+
+	if let Err(e) = mvt_client_harness.movement_process.kill().await {
+		eprintln!("Failed to kill child process: {:?}", e);
+	}
+
+	test_result
+}
+
+#[tokio::test]
+async fn test_movement_client_complete_transfer() -> Result<(), anyhow::Error> {
+	let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::DEBUG).try_init();
+
+	let default_config = Config::default();
+	let (mut mvt_client_harness, _config) = TestHarness::new_with_movement(default_config).await;
+
+	let args = MovementToEthCallArgs::default();
+
+	let test_result = async {
+		let sender_address = mvt_client_harness.movement_client.signer().address();
+		test_utils::fund_and_check_balance(&mut mvt_client_harness, 100_000_000_000).await?;
+		test_utils::initiate_bridge_transfer_helper(
+			&mut mvt_client_harness.movement_client,
+			args.initiator.0,
+			args.recipient.clone(),
+			args.hash_lock.0,
+			args.amount,
+			true,
+		)
+		.await
+		.expect("Failed to initiate bridge transfer");
+
+		let bridge_transfer_id: [u8; 32] =
+			test_utils::extract_bridge_transfer_id(&mut mvt_client_harness.movement_client).await?;
+		info!("Bridge transfer id: {:?}", bridge_transfer_id);
+		let details = BridgeContract::get_bridge_transfer_details_initiator(
+			&mut mvt_client_harness.movement_client,
+			BridgeTransferId(MovementHash(bridge_transfer_id).0),
+		)
+		.await
+		.expect("Failed to get bridge transfer details")
+		.expect("Expected to find bridge transfer details, but got None");
+
+		test_utils::assert_bridge_transfer_details(
+			&details,
+			MovementHash(bridge_transfer_id).0,
+			MovementHash(args.hash_lock.0).0,
+			sender_address,
+			args.recipient.clone(),
+			args.amount,
+			1,
+		);
+
+		let secret = b"secret";
+		let mut padded_secret = [0u8; 32];
+		padded_secret[..secret.len()].copy_from_slice(secret);
+
+		BridgeContract::initiator_complete_bridge_transfer(
+			&mut mvt_client_harness.movement_client,
+			BridgeTransferId(MovementHash(bridge_transfer_id).0),
+			HashLockPreImage(padded_secret),
+		)
+		.await
+		.expect("Failed to complete bridge transfer");
+
+		let details = BridgeContract::get_bridge_transfer_details_initiator(
+			&mut mvt_client_harness.movement_client,
+			BridgeTransferId(MovementHash(bridge_transfer_id).0),
+		)
+		.await
+		.expect("Failed to get bridge transfer details")
+		.expect("Expected to find bridge transfer details, but got None");
+
+		assert_eq!(details.state, 2, "Bridge transfer should be completed.");
+
+		Ok(())
+	}
+	.await;
+
+	if let Err(e) = mvt_client_harness.movement_process.kill().await {
+		eprintln!("Failed to kill child process: {:?}", e);
+	}
+
+	test_result
+}
+
+#[tokio::test]
+async fn test_movement_client_refund_transfer() -> Result<(), anyhow::Error> {
+	let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::DEBUG).try_init();
+
+	let config = Config::default();
+	let (mut mvt_client_harness, _config) = TestHarness::new_with_movement(config).await;
+
+	let args = MovementToEthCallArgs::default();
+
+	let test_result = async {
+		let sender_address = mvt_client_harness.movement_client.signer().address();
+		test_utils::fund_and_check_balance(&mut mvt_client_harness, 100_000_000_000).await?;
+
+		let ledger_info = mvt_client_harness.rest_client.get_ledger_information().await?;
+		println!("Ledger info: {:?}", ledger_info);
+
+		test_utils::initiate_bridge_transfer_helper(
+			&mut mvt_client_harness.movement_client,
+			args.initiator.0,
+			args.recipient.clone(),
+			args.hash_lock.0,
+			args.amount,
+			true,
+		)
+		.await
+		.expect("Failed to initiate bridge transfer");
+
+		let bridge_transfer_id: [u8; 32] =
+			test_utils::extract_bridge_transfer_id(&mut mvt_client_harness.movement_client).await?;
+		info!("Bridge transfer id: {:?}", bridge_transfer_id);
+		let details = BridgeContract::get_bridge_transfer_details_initiator(
+			&mut mvt_client_harness.movement_client,
+			BridgeTransferId(MovementHash(bridge_transfer_id).0),
+		)
+		.await
+		.expect("Failed to get bridge transfer details")
+		.expect("Expected to find bridge transfer details, but got None");
+
+		utils::assert_bridge_transfer_details(
+			&details,
+			MovementHash(bridge_transfer_id).0,
+			MovementHash(args.hash_lock.0).0,
+			sender_address,
+			args.recipient.clone(),
+			args.amount,
+			1,
+		);
+
+		sleep(Duration::from_secs(2)).await;
+
+		BridgeContract::refund_bridge_transfer(
+			&mut mvt_client_harness.movement_client,
+			BridgeTransferId(MovementHash(bridge_transfer_id).0),
+		)
+		.await
+		.expect("Failed to complete bridge transfer");
+
+		let details = BridgeContract::get_bridge_transfer_details_initiator(
+			&mut mvt_client_harness.movement_client,
+			BridgeTransferId(MovementHash(bridge_transfer_id).0),
+		)
+		.await
+		.expect("Failed to get bridge transfer details")
+		.expect("Expected to find bridge transfer details, but got None");
+
+		assert_eq!(details.state, 3, "Bridge transfer should be refunded.");
+
+		Ok(())
+	}
+	.await;
+
+	if let Err(e) = mvt_client_harness.movement_process.kill().await {
+		eprintln!("Failed to kill child process: {:?}", e);
+	}
+
+	test_result
+}

--- a/protocol-units/bridge/move-modules/sources/update_bridge_operator.move
+++ b/protocol-units/bridge/move-modules/sources/update_bridge_operator.move
@@ -1,0 +1,8 @@
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::atomic_bridge_configuration;
+    fun main(core_resources: &signer, new_operator: address) {
+        let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @aptos_framework);
+        atomic_bridge_configuration::update_bridge_operator(&framework_signer, new_operator);
+    }
+}

--- a/protocol-units/bridge/service/src/chains/bridge_contracts.rs
+++ b/protocol-units/bridge/service/src/chains/bridge_contracts.rs
@@ -164,6 +164,58 @@ pub trait BridgeContract<A>: Clone + Unpin + Send + Sync {
 }
 
 #[async_trait::async_trait]
+pub trait BridgeContractFramework<A>: Clone + Unpin + Send + Sync {
+	async fn initiate_bridge_transfer(
+		&mut self,
+		initiator_address: BridgeAddress<A>,
+		recipient_address: BridgeAddress<Vec<u8>>,
+		hash_lock: HashLock,
+		amount: Amount,
+	) -> BridgeContractResult<()>;
+
+	async fn initiator_complete_bridge_transfer(
+		&mut self,
+		bridge_transfer_id: BridgeTransferId,
+		secret: HashLockPreImage,
+	) -> BridgeContractResult<()>;
+
+	async fn counterparty_complete_bridge_transfer(
+		&mut self,
+		bridge_transfer_id: BridgeTransferId,
+		secret: HashLockPreImage,
+	) -> BridgeContractResult<()>;
+
+	async fn refund_bridge_transfer(
+		&mut self,
+		bridge_transfer_id: BridgeTransferId,
+	) -> BridgeContractResult<()>;
+
+	async fn get_bridge_transfer_details_initiator(
+		&mut self,
+		bridge_transfer_id: BridgeTransferId,
+	) -> BridgeContractResult<Option<BridgeTransferDetails<A>>>;
+
+	async fn get_bridge_transfer_details_counterparty(
+		&mut self,
+		bridge_transfer_id: BridgeTransferId,
+	) -> BridgeContractResult<Option<BridgeTransferDetails<A>>>;
+
+	async fn lock_bridge_transfer(
+		&mut self,
+		bridge_transfer_id: BridgeTransferId,
+		hash_lock: HashLock,
+		initiator: BridgeAddress<Vec<u8>>,
+		recipient: BridgeAddress<A>,
+		amount: Amount,
+	) -> BridgeContractResult<()>;
+
+	async fn abort_bridge_transfer(
+		&mut self,
+		bridge_transfer_id: BridgeTransferId,
+	) -> BridgeContractResult<()>;
+}
+
+#[async_trait::async_trait]
 pub trait BridgeContractWETH9: Clone + Unpin + Send + Sync {
 	async fn deposit_weth(&mut self, amount: Amount) -> BridgeContractWETH9Result<()>;
 }

--- a/protocol-units/bridge/service/src/chains/movement/client.rs
+++ b/protocol-units/bridge/service/src/chains/movement/client.rs
@@ -73,49 +73,6 @@ impl MovementClient {
 			signer: Arc::new(signer),
 		})
 	}
-	pub async fn movement_init(config: &Config) { 
-		let mut process = Command::new("movement")
-		.args(&["init"])
-		.stdin(Stdio::piped())
-		.stdout(Stdio::piped())
-		.stderr(Stdio::piped())
-		.spawn()
-		.expect("Failed to execute command");
-
-		let private_key_hex = hex::encode(config.movement.movement_signer_key.to_bytes());
-		println!("Private key hex: {:?}\n", private_key_hex);
-		
-		let stdin: &mut std::process::ChildStdin =
-			process.stdin.as_mut().expect("Failed to open stdin");
-
-		let movement_dir = PathBuf::from(".movement");
-
-		if movement_dir.exists() {
-			stdin.write_all(b"yes\n").expect("Failed to write to stdin");
-		}
-		
-		stdin.write_all(b"custom\n").expect("Failed to write to stdin");
-		stdin.write_all(b"http://localhost:30731/v1\n").expect("Failed to write to stdin");
-		stdin.write_all(b"http://localhost:30732\n").expect("Failed to write to stdin");
-		let _ = stdin.write_all(format!("{}\n", private_key_hex).as_bytes());
-		let addr_output = process.wait_with_output().expect("Failed to read command output");
-
-		if !addr_output.stdout.is_empty() {
-			println!("Address stdout: {}", String::from_utf8_lossy(&addr_output.stdout));
-		}
-
-		if !addr_output.stderr.is_empty() {
-			eprintln!("Address stderr: {}", String::from_utf8_lossy(&addr_output.stderr));
-		}
-		let addr_output_str = String::from_utf8_lossy(&addr_output.stderr);
-
-		let address = addr_output_str
-			.split_whitespace()
-			.find(|word| word.starts_with("0x"))
-			.expect("Failed to extract the Movement account address");
-
-		println!("Extracted address: {}", address);
-	}
 
 	pub fn rest_client(&self) -> &Client {
 		&self.rest_client

--- a/protocol-units/bridge/setup/src/lib.rs
+++ b/protocol-units/bridge/setup/src/lib.rs
@@ -30,3 +30,12 @@ pub async fn test_mvt_setup(
 	local::init_local_movement_node(&mut config.movement)?;
 	Ok((config, movement_task))
 }
+
+pub async fn test_suzuka_setup(
+	mut config: Config,
+) -> Result<Config, anyhow::Error> {
+	let movement_task = local::setup_movement_node(&mut config.movement).await?;
+	local::init_local_movement_node(&mut config.movement)?;
+	Ok(config)
+}
+

--- a/protocol-units/bridge/setup/src/lib.rs
+++ b/protocol-units/bridge/setup/src/lib.rs
@@ -25,9 +25,9 @@ pub async fn test_eth_setup(mut config: Config) -> Result<(Config, AnvilInstance
 
 pub async fn test_mvt_setup(
 	mut config: Config,
-) -> Result<(Config, tokio::process::Child), anyhow::Error> {
-	let movement_task = local::setup_movement_node(&mut config.movement).await?;
+) -> Result<Config, anyhow::Error> {
+	// let movement_task = local::setup_movement_node(&mut config.movement).await?;
 	local::init_local_movement_node(&mut config.movement)?;
-	Ok((config, movement_task))
+	Ok(config)
 }
 

--- a/protocol-units/bridge/setup/src/lib.rs
+++ b/protocol-units/bridge/setup/src/lib.rs
@@ -31,11 +31,3 @@ pub async fn test_mvt_setup(
 	Ok((config, movement_task))
 }
 
-pub async fn test_suzuka_setup(
-	mut config: Config,
-) -> Result<Config, anyhow::Error> {
-	let movement_task = local::setup_movement_node(&mut config.movement).await?;
-	local::init_local_movement_node(&mut config.movement)?;
-	Ok(config)
-}
-

--- a/protocol-units/bridge/setup/src/local.rs
+++ b/protocol-units/bridge/setup/src/local.rs
@@ -133,7 +133,7 @@ pub async fn setup_movement_node(
 
 	let mut rng = ::rand::rngs::StdRng::from_seed([3u8; 32]);
 	let signer = LocalAccount::generate(&mut rng);
-	config.movement_signer_address = signer.private_key().clone();
+	config.movement_signer_key = signer.private_key().clone();
 
 	Ok(child)
 }
@@ -159,7 +159,7 @@ pub fn init_local_movement_node(config: &mut MovementConfig) -> Result<(), anyho
 
 	stdin.write_all(b"local\n").expect("Failed to write to stdin");
 
-	let private_key_bytes = config.movement_signer_address.to_bytes();
+	let private_key_bytes = config.movement_signer_key.to_bytes();
 	let private_key_hex = format!("0x{}", private_key_bytes.encode_hex::<String>());
 	let _ = stdin.write_all(format!("{}\n", private_key_hex).as_bytes());
 

--- a/protocol-units/bridge/setup/src/local.rs
+++ b/protocol-units/bridge/setup/src/local.rs
@@ -142,10 +142,12 @@ pub fn init_local_movement_node(config: &mut MovementConfig) -> Result<(), anyho
 	let mut process = Command::new("movement") //--network
 		.args(&[
 			"init",
+			"--network", 
+			"custom",
 			"--rest-url",
-			&config.mvt_rpc_connection_url(),
+			"http://127.0.0.1:30731",
 			"--faucet-url",
-			&config.mvt_faucet_connection_url(),
+			"http://127.0.0.1:30732",
 			"--assume-yes",
 		])
 		.stdin(Stdio::piped())


### PR DESCRIPTION
# Summary
Add client integration tests calling framework bridge modules

# Changelog

- Created `BridgeContractFramework` trait and impl, with functions calling the bridge framework modules
- Added test files `client_l1move_l2move.rs` and `client_l2move_l1move.rs` into integration tests directory, calling `BridgeContractFramework` functions.

# Testing

1. Run 

```
CELESTIA_LOG_LEVEL=FATAL MAPTOS_PRIVATE_KEY=<PRIVATE_KEY> nix develop --command bash  -c "just suzuka-full-node native build.celestia-local.indexer.hasura.indexer-test -t=false"
```

with a private key you control.

This will create your `config.json`

Then run 

```
rust_backtrace=1 MOVEMENT_SIGNER_KEY="0x0b1ed5beb9f7f6c649e2d65fc11bab37bc97bc9988c70fe07bd71730fe46bd0a" cargo test --test client_l1move_l2move test_movement_client_should_successfully_call_lock_and_complete -- --nocapture --test-threads=1
```

(for example to run the lock and complete test).

# Outstanding issues
- Currently when running tests, the function `init_local_movement_node` in `local.rs` fails with  

```
STDERR: Setup is complete, you can now use the localnet!
Testnet is up and running!
Movement node startup complete message received.
Move init Publish stdout: {
  "Error": "API error: HTTP error 404 Not Found: error decoding response body: invalid type: integer `404`, expected struct AptosError at line 1 column 3"
}

Move init Publish stderr: Configuring for profile default
Choose network from [devnet, testnet, local, custom | defaults to devnet]. For testnet, start over and run movement init --skip-faucet
Enter your private key as a hex literal (0x...) [Current: None | No input: Generate new key (or keep one if present)]

thread 'test_movement_client_should_successfully_call_lock_and_complete' panicked at protocol-units/bridge/setup/src/local.rs:178:10:
Failed to extract the Movement account address
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
FAILED

failures:

failures:
    test_movement_client_should_successfully_call_lock_and_complete
```

For context, here's where `local::init_local_movement_node` is called:

```pub async fn test_mvt_setup(
	mut config: Config,
) -> Result<(Config, tokio::process::Child), anyhow::Error> {
	let movement_task = local::setup_movement_node(&mut config.movement).await?;
	local::init_local_movement_node(&mut config.movement)?;
	Ok((config, movement_task))
}
```
