### PR TITLE
Validation Gas Fees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -794,7 +794,7 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -807,7 +807,7 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -817,7 +817,7 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-logger",
  "aptos-types",
@@ -831,7 +831,7 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -873,7 +873,7 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "hex",
@@ -912,7 +912,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -921,7 +921,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -956,7 +956,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -977,7 +977,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "futures",
  "rustversion",
@@ -987,7 +987,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "shadow-rs",
 ]
@@ -995,7 +995,7 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1009,7 +1009,7 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -1020,7 +1020,7 @@ dependencies = [
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -1032,7 +1032,7 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1063,7 +1063,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1090,7 +1090,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1143,7 +1143,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1153,7 +1153,7 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
@@ -1195,13 +1195,12 @@ dependencies = [
  "serde",
  "static_assertions",
  "status-line",
- "tracing",
 ]
 
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1221,7 +1220,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer-schemas"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-schemadb",
@@ -1235,7 +1234,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1266,7 +1265,7 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-infallible",
  "aptos-metrics-core",
@@ -1277,7 +1276,7 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -1293,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-consensus-types",
@@ -1325,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-block-partitioner",
  "aptos-config",
@@ -1355,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -1377,7 +1376,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1397,7 +1396,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-runtimes",
  "core_affinity",
@@ -1410,7 +1409,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1444,7 +1443,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -1458,7 +1457,7 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -1526,7 +1525,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "either",
  "move-core-types",
@@ -1535,7 +1534,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -1550,7 +1549,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -1570,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
@@ -1583,17 +1582,17 @@ dependencies = [
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 
 [[package]]
 name = "aptos-indexer"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1625,7 +1624,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1637,7 +1636,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-metrics-core",
  "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors)",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d)",
  "aptos-runtimes",
  "aptos-storage-interface",
  "aptos-types",
@@ -1663,7 +1662,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-table-info"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1694,11 +1693,11 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-utils"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d)",
  "async-trait",
  "backoff",
  "base64 0.13.1",
@@ -1726,12 +1725,12 @@ dependencies = [
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1759,7 +1758,7 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1769,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
@@ -1813,7 +1812,7 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1826,7 +1825,7 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1836,7 +1835,7 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-infallible",
  "aptos-log-derive",
@@ -1860,7 +1859,7 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
@@ -1873,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -1913,7 +1912,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-types",
  "async-trait",
@@ -1926,7 +1925,7 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-infallible",
  "bytes 1.7.2",
@@ -1937,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -1946,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -1977,7 +1976,7 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -1998,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2015,7 +2014,7 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
@@ -2032,7 +2031,7 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2077,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2088,7 +2087,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-build-info",
  "aptos-infallible",
@@ -2104,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2114,7 +2113,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -2127,7 +2126,7 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -2140,7 +2139,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-config",
  "aptos-types",
@@ -2165,7 +2164,7 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -2187,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -2199,7 +2198,7 @@ dependencies = [
 [[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "ipnet",
 ]
@@ -2207,7 +2206,7 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -2218,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "aptos-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2232,7 +2231,7 @@ dependencies = [
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -2255,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-config",
  "rocksdb",
@@ -2264,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "rayon",
  "tokio",
@@ -2273,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2290,7 +2289,7 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-crypto",
  "aptos-drop-helper",
@@ -2309,7 +2308,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -2331,7 +2330,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2349,11 +2348,11 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d)",
  "bcs 0.1.4",
  "crossbeam-channel",
  "once_cell",
@@ -2367,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-crypto",
  "aptos-infallible",
@@ -2388,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -2399,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2410,7 +2409,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2458,7 +2457,7 @@ dependencies = [
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -2476,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -2485,7 +2484,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -2498,7 +2497,7 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2555,12 +2554,12 @@ dependencies = [
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
@@ -2576,7 +2575,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2626,7 +2625,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-cached-packages",
  "aptos-crypto",
@@ -2647,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -2662,7 +2661,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2684,7 +2683,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -8591,7 +8590,7 @@ dependencies = [
  "aptos-language-e2e-tests",
  "aptos-logger",
  "aptos-mempool",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d)",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
@@ -8935,7 +8934,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -8952,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -8967,12 +8966,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -8987,7 +8986,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-spec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "once_cell",
  "quote",
@@ -8997,7 +8996,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -9009,7 +9008,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "fail",
  "move-binary-format",
@@ -9023,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "clap 4.5.19",
@@ -9038,7 +9037,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "clap 4.5.19",
@@ -9068,7 +9067,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "difference",
@@ -9085,7 +9084,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -9111,7 +9110,7 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -9142,7 +9141,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -9167,7 +9166,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -9186,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "clap 4.5.19",
@@ -9203,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "clap 4.5.19",
@@ -9222,7 +9221,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -9234,7 +9233,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -9250,7 +9249,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -9268,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "hex",
@@ -9281,7 +9280,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -9294,7 +9293,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "codespan",
@@ -9320,7 +9319,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "clap 4.5.19",
@@ -9354,7 +9353,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "atty",
@@ -9381,7 +9380,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9410,7 +9409,7 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -9427,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "hex",
@@ -9454,7 +9453,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "abstract-domain-derive",
  "codespan-reporting",
@@ -9473,7 +9472,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "hex",
@@ -9496,7 +9495,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "once_cell",
  "serde",
@@ -9505,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "better_any",
  "bytes 1.7.2",
@@ -9520,7 +9519,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "better_any",
@@ -9548,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "better_any",
  "bytes 1.7.2",
@@ -9572,7 +9571,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "anyhow",
  "bytes 1.7.2",
@@ -9587,7 +9586,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd#70be3926ff79ff4cdb0cee928f717fafcd41ecdd"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d#6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d"
 dependencies = [
  "bcs 0.1.4",
  "derivative",
@@ -13232,7 +13231,7 @@ name = "suzuka-client"
 version = "0.0.2"
 dependencies = [
  "anyhow",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=70be3926ff79ff4cdb0cee928f717fafcd41ecdd)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d)",
  "aptos-sdk",
  "aptos-types",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,40 +114,40 @@ serde_yaml = "0.9.34"
 ## Aptos dependencies
 ### We use a forked version so that we can override dependency versions. This is required
 ### to be avoid dependency conflicts with other Sovereign Labs crates.
-aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd", features = [
+aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d", features = [
     "cloneable-private-keys",
 ] }
-aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
-aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
+aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
+aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "6000acc3bfc60dde2b304e7ecbb8d63aaa301c1d" }
 
 # Indexer
 processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "1d1d7c72a01a0b5a55477f8fdca59e17c9ce2e58", subdir = "rust" }

--- a/protocol-units/execution/opt-executor/src/executor/mod.rs
+++ b/protocol-units/execution/opt-executor/src/executor/mod.rs
@@ -60,6 +60,10 @@ impl Executor {
 		&self.config
 	}
 
+	pub fn node_config(&self) -> &NodeConfig {
+		&self.node_config
+	}
+
 	pub fn has_executed_transaction(
 		&self,
 		transaction_hash: HashValue,


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**: `protocol-units`
- **Associated PRs**: https://github.com/movementlabsxyz/aptos-core/pull/81

Integrates `validation_only` gas fee into `maptos_opt_executor` and adds tests. 


# Testing

1. Unit and e2e tests covering gas charges. 

# Outstanding issues
1. Tests are still WIP. 