### PR TITLE
Indexer add INDEXER_STARTING_VERSION env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,7 +1961,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=1d1d7c72a01a0b5a55477f8fdca59e17c9ce2e58#1d1d7c72a01a0b5a55477f8fdca59e17c9ce2e58"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=8e83cde3cb75fabdade9485e0af680cc4b73ca8e#8e83cde3cb75fabdade9485e0af680cc4b73ca8e"
 dependencies = [
  "chrono",
 ]
@@ -11099,13 +11099,13 @@ dependencies = [
 [[package]]
 name = "processor"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=1d1d7c72a01a0b5a55477f8fdca59e17c9ce2e58#1d1d7c72a01a0b5a55477f8fdca59e17c9ce2e58"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=8e83cde3cb75fabdade9485e0af680cc4b73ca8e#8e83cde3cb75fabdade9485e0af680cc4b73ca8e"
 dependencies = [
  "ahash 0.8.11",
  "allocative",
  "allocative_derive",
  "anyhow",
- "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=1d1d7c72a01a0b5a55477f8fdca59e17c9ce2e58)",
+ "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=8e83cde3cb75fabdade9485e0af680cc4b73ca8e)",
  "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=338f9a1bcc06f62ce4a4994f1642b9a61b631ee0)",
  "async-trait",
  "bcs 0.1.4",
@@ -12649,7 +12649,7 @@ dependencies = [
 [[package]]
 name = "server-framework"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=1d1d7c72a01a0b5a55477f8fdca59e17c9ce2e58#1d1d7c72a01a0b5a55477f8fdca59e17c9ce2e58"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=8e83cde3cb75fabdade9485e0af680cc4b73ca8e#8e83cde3cb75fabdade9485e0af680cc4b73ca8e"
 dependencies = [
  "anyhow",
  "aptos-system-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,8 +150,8 @@ aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/apto
 aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "70be3926ff79ff4cdb0cee928f717fafcd41ecdd" }
 
 # Indexer
-processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "1d1d7c72a01a0b5a55477f8fdca59e17c9ce2e58", subdir = "rust" }
-server-framework = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "1d1d7c72a01a0b5a55477f8fdca59e17c9ce2e58", subdir = "rust" }
+processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "8e83cde3cb75fabdade9485e0af680cc4b73ca8e", subdir = "rust" }
+server-framework = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "8e83cde3cb75fabdade9485e0af680cc4b73ca8e", subdir = "rust" }
 
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
 ethereum-types = "0.14.1"

--- a/networks/suzuka/indexer/src/main.rs
+++ b/networks/suzuka/indexer/src/main.rs
@@ -89,6 +89,9 @@ fn build_processor_conf(
 	let default_sleep_time_between_request: u64 = std::env::var("SLEEP_TIME_BETWEEN_REQUEST_MS")
 		.map(|t| t.parse().unwrap_or(10))
 		.unwrap_or(10);
+	let starting_version: u64 = std::env::var("INDEXER_STARTING_VERSION")
+		.map(|t| t.parse().unwrap_or(0))
+		.unwrap_or(0);
 	//create config file
 	let indexer_config_content = format!(
 		"processor_config:
@@ -98,6 +101,7 @@ indexer_grpc_data_service_address: {}
 indexer_grpc_http2_ping_interval_in_secs: {}
 indexer_grpc_http2_ping_timeout_in_secs: {}
 auth_token: \"{}\"
+starting_version: {}
 default_sleep_time_between_request: {}",
 		processor_name,
 		maptos_config.indexer_processor.postgres_connection_string,
@@ -105,6 +109,7 @@ default_sleep_time_between_request: {}",
 		maptos_config.indexer.maptos_indexer_grpc_inactivity_timeout,
 		maptos_config.indexer.maptos_indexer_grpc_inactivity_ping_interval,
 		maptos_config.indexer_processor.indexer_processor_auth_token,
+		starting_version,
 		default_sleep_time_between_request,
 	);
 

--- a/networks/suzuka/indexer/src/main.rs
+++ b/networks/suzuka/indexer/src/main.rs
@@ -89,9 +89,13 @@ fn build_processor_conf(
 	let default_sleep_time_between_request: u64 = std::env::var("SLEEP_TIME_BETWEEN_REQUEST_MS")
 		.map(|t| t.parse().unwrap_or(10))
 		.unwrap_or(10);
-	let starting_version: u64 = std::env::var("INDEXER_STARTING_VERSION")
+
+	// If the starting version is not defined, don't put a default value in the conf.
+	let starting_version_entry = std::env::var("INDEXER_STARTING_VERSION")
 		.map(|t| t.parse().unwrap_or(0))
-		.unwrap_or(0);
+		.map(|t| format!("starting_version: {}", t))
+		.unwrap_or(String::new());
+
 	//create config file
 	let indexer_config_content = format!(
 		"processor_config:
@@ -101,16 +105,16 @@ indexer_grpc_data_service_address: {}
 indexer_grpc_http2_ping_interval_in_secs: {}
 indexer_grpc_http2_ping_timeout_in_secs: {}
 auth_token: \"{}\"
-starting_version: {}
-default_sleep_time_between_request: {}",
+default_sleep_time_between_request: {}
+{}",
 		processor_name,
 		maptos_config.indexer_processor.postgres_connection_string,
 		indexer_grpc_data_service_address,
 		maptos_config.indexer.maptos_indexer_grpc_inactivity_timeout,
 		maptos_config.indexer.maptos_indexer_grpc_inactivity_ping_interval,
 		maptos_config.indexer_processor.indexer_processor_auth_token,
-		starting_version,
 		default_sleep_time_between_request,
+		starting_version_entry,
 	);
 
 	//let indexer_config_path = dot_movement.get_path().join("indexer_config.yaml");


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

<!--
Add your summary text here. 
 -->
Add the INDEXER_STARTING_VERSION environment variable to define the start version of the first Tx requested by the indexer when it starts.
# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->
CELESTIA_LOG_LEVEL=FATAL nix develop --extra-experimental-features nix-command --extra-experimental-features flakes --command bash  -c "just suzuka-full-node native build.setup.celestia-local.indexer.hasura.indexer-test --keep-tui"
# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->