### PR TITLE
fix: move erc20 transferFrom, update tests

### DIFF
--- a/protocol-units/bridge/contracts/src/AtomicBridgeInitiatorMOVE.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeInitiatorMOVE.sol
@@ -11,7 +11,7 @@ contract AtomicBridgeInitiatorMOVE is IAtomicBridgeInitiatorMOVE, OwnableUpgrade
         INITIALIZED,
         COMPLETED,
         REFUNDED
-    }   
+    }
 
     struct BridgeTransfer {
         uint256 amount;
@@ -28,7 +28,7 @@ contract AtomicBridgeInitiatorMOVE is IAtomicBridgeInitiatorMOVE, OwnableUpgrade
     // Total MOVE token pool balance
     uint256 public poolBalance;
 
-    address public counterpartyAddress; 
+    address public counterpartyAddress;
     ERC20Upgradeable public moveToken;
     uint256 private nonce;
 
@@ -37,9 +37,9 @@ contract AtomicBridgeInitiatorMOVE is IAtomicBridgeInitiatorMOVE, OwnableUpgrade
 
     // Initialize the contract with MOVE token address, owner, custom time lock duration, and initial pool balance
     function initialize(
-        address _moveToken, 
-        address owner, 
-        uint256 _timeLockDuration, 
+        address _moveToken,
+        address owner,
+        uint256 _timeLockDuration,
         uint256 _initialPoolBalance
     ) public initializer {
         if (_moveToken == address(0)) {
@@ -71,7 +71,7 @@ contract AtomicBridgeInitiatorMOVE is IAtomicBridgeInitiatorMOVE, OwnableUpgrade
             revert ZeroAmount();
         }
 
-        // Transfer MOVE tokens from the user to the contract
+        // Transfer the MOVE tokens from the user to the contract
         if (!moveToken.transferFrom(originator, address(this), moveAmount)) {
             revert MOVETransferFailed();
         }

--- a/protocol-units/bridge/contracts/test/AtomicBridgeInitiator.t.sol
+++ b/protocol-units/bridge/contracts/test/AtomicBridgeInitiator.t.sol
@@ -212,4 +212,3 @@ contract AtomicBridgeInitiatorWethTest is Test {
         assertEq(weth.balanceOf(originator), 1 ether, "WETH balance mismatch");
     }
 }
-

--- a/protocol-units/bridge/contracts/test/AtomicBridgeInitiatorMOVE.t.sol
+++ b/protocol-units/bridge/contracts/test/AtomicBridgeInitiatorMOVE.t.sol
@@ -16,7 +16,7 @@ contract AtomicBridgeInitiatorMOVETest is Test {
     TransparentUpgradeableProxy public proxy;
     AtomicBridgeInitiatorMOVE public atomicBridgeInitiatorMOVE;
 
-    address public originator =  address(1);
+    address public originator = address(1);
     bytes32 public recipient = keccak256(abi.encodePacked(address(2)));
     bytes32 public hashLock = keccak256(abi.encodePacked("secret"));
     uint256 public amount = 1 ether;
@@ -49,17 +49,22 @@ contract AtomicBridgeInitiatorMOVETest is Test {
 
     function testInitiateBridgeTransferWithMove() public {
         uint256 moveAmount = 100 * 10**8;
-        moveToken.transfer(originator, moveAmount); 
-        vm.startPrank(originator);
 
+        // Transfer moveAmount tokens to the originator and check initial balance
+        moveToken.transfer(originator, moveAmount); 
+        uint256 initialBalance = moveToken.balanceOf(originator);
+
+        vm.startPrank(originator);
         moveToken.approve(address(atomicBridgeInitiatorMOVE), moveAmount);
 
+        // Initiate the bridge transfer
         bytes32 bridgeTransferId = atomicBridgeInitiatorMOVE.initiateBridgeTransfer(
             moveAmount, 
             recipient, 
             hashLock 
         );
 
+        // Verify the bridge transfer details
         (
             uint256 transferAmount,
             address transferOriginator,
@@ -76,6 +81,10 @@ contract AtomicBridgeInitiatorMOVETest is Test {
         assertGt(transferTimeLock, block.timestamp);
         assertEq(uint8(transferState), uint8(AtomicBridgeInitiatorMOVE.MessageState.INITIALIZED));
 
+        // Check the originator's MOVE balance after initiating the transfer
+        uint256 finalBalance = moveToken.balanceOf(originator);
+        assertEq(finalBalance, initialBalance - moveAmount);
+
         vm.stopPrank();
     }
 
@@ -84,11 +93,14 @@ contract AtomicBridgeInitiatorMOVETest is Test {
         bytes32 testHashLock = keccak256(abi.encodePacked(secret));
         uint256 moveAmount = 100 * 10**8; // 100 MOVEToken
 
+        // Transfer moveAmount tokens to the originator and check initial balance
         moveToken.transfer(originator, moveAmount); 
-        vm.startPrank(originator);
+        uint256 initialBalance = moveToken.balanceOf(originator);
 
+        vm.startPrank(originator);
         moveToken.approve(address(atomicBridgeInitiatorMOVE), moveAmount);
 
+        // Initiate the bridge transfer
         bytes32 bridgeTransferId = atomicBridgeInitiatorMOVE.initiateBridgeTransfer(
             moveAmount, 
             recipient, 
@@ -98,6 +110,8 @@ contract AtomicBridgeInitiatorMOVETest is Test {
         vm.stopPrank();
 
         atomicBridgeInitiatorMOVE.completeBridgeTransfer(bridgeTransferId, secret);
+
+        // Verify the bridge transfer details after completion
         (
             uint256 completedAmount,
             address completedOriginator,
@@ -113,15 +127,23 @@ contract AtomicBridgeInitiatorMOVETest is Test {
         assertEq(completedHashLock, testHashLock);
         assertGt(completedTimeLock, block.timestamp);
         assertEq(uint8(completedState), uint8(AtomicBridgeInitiatorMOVE.MessageState.COMPLETED));
+
+        // Ensure no changes to the originator's balance after the transfer is completed
+        uint256 finalBalance = moveToken.balanceOf(originator);
+        assertEq(finalBalance, initialBalance - moveAmount);
     }
 
     function testRefundBridgeTransfer() public {
         uint256 moveAmount = 100 * 10**8; // 100 MOVEToken
-        moveToken.transfer(originator, moveAmount); // Transfer tokens to originator
-        vm.startPrank(originator);
 
+        // Transfer moveAmount tokens to the originator and check initial balance
+        moveToken.transfer(originator, moveAmount);
+        uint256 initialBalance = moveToken.balanceOf(originator);
+
+        vm.startPrank(originator);
         moveToken.approve(address(atomicBridgeInitiatorMOVE), moveAmount);
 
+        // Initiate the bridge transfer
         bytes32 bridgeTransferId = atomicBridgeInitiatorMOVE.initiateBridgeTransfer(
             moveAmount, 
             recipient, 
@@ -138,10 +160,14 @@ contract AtomicBridgeInitiatorMOVETest is Test {
         atomicBridgeInitiatorMOVE.refundBridgeTransfer(bridgeTransferId);
         vm.stopPrank();
 
+        // Owner refunds the transfer
         vm.expectEmit();
         emit IAtomicBridgeInitiatorMOVE.BridgeTransferRefunded(bridgeTransferId);
         atomicBridgeInitiatorMOVE.refundBridgeTransfer(bridgeTransferId);
 
-        assertEq(moveToken.balanceOf(originator), moveAmount, "MOVE balance mismatch");
+        // Verify that the originator receives the refund and the balance is restored
+        uint256 finalBalance = moveToken.balanceOf(originator);
+        assertEq(finalBalance, initialBalance, "MOVE balance mismatch");
     }
 }
+


### PR DESCRIPTION
# Summary
The solidity MOVE initiator contract was missing `transferFrom` call on the initiator side, these are present in the WETH contracts, so probably why we missed it.

# Changelog
- Adds the missing call
- Adds missing unit test logic

# Testing
CI solidity-tests check should pass

# Outstanding issues
