### PR TITLE
Remove done transfer from state management.

### DIFF
--- a/protocol-units/bridge/service/src/lib.rs
+++ b/protocol-units/bridge/service/src/lib.rs
@@ -201,25 +201,29 @@ impl Runtime {
 				let (new_state, action_kind) =
 					state.transition_from_initiator_completed(event_transfer_id);
 				state = new_state;
-				//transfer done remove the state.
-				if state.state == TransferStateType::Done {
-					self.swap_state_map.remove(&event_transfer_id);
-				}
+
 				(action_kind, state.init_chain)
 			}
 			BridgeContractEvent::Cancelled(_) => {
-				todo!()
+				let (new_state, action_kind) = state.transition_from_cancelled(event_transfer_id);
+				state = new_state;
+
+				(action_kind, state.init_chain)
 			}
 			BridgeContractEvent::Refunded(_) => {
-				todo!()
+				let (new_state, action_kind) = state.transition_from_refunded(event_transfer_id);
+				state = new_state;
+
+				(action_kind, state.init_chain)
 			}
 		};
 
 		let action =
 			TransferAction { chain: chain_id, transfer_id: state.transfer_id, kind: action_kind };
 
-		self.swap_state_map.insert(state.transfer_id, state);
-
+		if state.state != TransferStateType::Done {
+			self.swap_state_map.insert(state.transfer_id, state);
+		}
 		Ok(action)
 	}
 

--- a/protocol-units/bridge/service/src/states.rs
+++ b/protocol-units/bridge/service/src/states.rs
@@ -130,6 +130,24 @@ impl TransferState {
 		(self, action_type)
 	}
 
+	pub fn transition_from_cancelled(
+		mut self,
+		_transfer_id: BridgeTransferId,
+	) -> (Self, TransferActionType) {
+		self.state = TransferStateType::Done;
+		let action_type = TransferActionType::NoAction;
+		(self, action_type)
+	}
+
+	pub fn transition_from_refunded(
+		mut self,
+		_transfer_id: BridgeTransferId,
+	) -> (Self, TransferActionType) {
+		self.state = TransferStateType::Done;
+		let action_type = TransferActionType::NoAction;
+		(self, action_type)
+	}
+
 	pub fn transition_to_refund(&self) -> (TransferStateType, TransferActionType) {
 		(TransferStateType::Refund, TransferActionType::RefundInitiator)
 	}


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

<!--
Add your summary text here. 
 -->
Remove from the state management the transfer when it's finished
# Changelog
Remove transfer from state
implenents some todo in the state change processing.

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->