### PR TITLE
Elevate Chain Id Config

### DIFF
--- a/docker/compose/suzuka-full-node/docker-compose.yml
+++ b/docker/compose/suzuka-full-node/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     container_name: setup
     command: sh -c 'echo "No setup type specified."'
     environment:
-      - DOT_MOVEMENT_PATH=/.movement
+      DOT_MOVEMENT_PATH: /.movement
+      MAPTOS_CHAIN_ID: ${MAPTOS_CHAIN_ID:-27}
     volumes:
       - ${DOT_MOVEMENT_PATH}:/.movement
 

--- a/docs/movement-node/run/manual/follower-node/README.md
+++ b/docs/movement-node/run/manual/follower-node/README.md
@@ -27,6 +27,7 @@ First create, an environment file for the follower node. The example below is fo
 ```bash
 CONTAINER_REV=<latest-commit-hash>
 DOT_MOVEMENT_PATH=./.movement
+MAPTOS_CHAIN_ID=250 # change this to the chain id of the network you are running
 MOVEMENT_SYNC="follower::mtnet-l-sync-bucket-sync<=>{maptos,maptos-storage,suzuka-da-db}/**" # change to the sync bucket for the network you are running
 M1_DA_LIGHT_NODE_CONNECTION_PROTOCOL=https
 M1_DA_LIGHT_NODE_CONNECTION_HOSTNAME="m1-da-light-node.testnet.movementlabs.xyz" # changes this to the hostname of the m1_da_light_node_service on network you are running


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**: `misc`.

`MAPTOS_CHAIN_ID` environment variable does not apply to compose services. This fixes that. 

## Testing
Run `MAPTO_CHAIN_ID=250 just suzuka-full-node docker-compose local` with any recent container REV. Then assert that the chain id at `localhost:30731` is indeed 250. 

