### PR TITLE
Remove excessive tonic dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7203,12 +7203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
-
-[[package]]
 name = "httparse"
 version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8370,7 +8364,6 @@ dependencies = [
  "tokio-stream",
  "tonic 0.11.0",
  "tonic-reflection",
- "tonic-web",
  "tracing",
  "zstd 0.13.2",
 ]
@@ -8395,8 +8388,6 @@ dependencies = [
  "prost 0.12.6",
  "tonic 0.11.0",
  "tonic-build",
- "tonic-reflection",
- "tonic-web",
 ]
 
 [[package]]
@@ -8467,8 +8458,6 @@ dependencies = [
  "tokio-stream",
  "toml 0.8.19",
  "tonic 0.11.0",
- "tonic-reflection",
- "tonic-web",
  "tracing",
  "tracing-subscriber 0.3.18",
 ]
@@ -8491,8 +8480,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic 0.11.0",
- "tonic-reflection",
- "tonic-web",
 ]
 
 [[package]]
@@ -14135,26 +14122,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic-web"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3b0e1cedbf19fdfb78ef3d672cb9928e0a91a9cb4629cc0c916e8cff8aaaa1"
-dependencies = [
- "base64 0.21.7",
- "bytes 1.7.2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "pin-project 1.1.5",
- "tokio-stream",
- "tonic 0.11.0",
- "tower-http",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14172,24 +14139,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
-dependencies = [
- "bitflags 2.6.0",
- "bytes 1.7.2",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-range-header",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,7 +280,6 @@ toml = "0.8"
 tonic = "0.11"
 tonic-build = { version = "0.11", features = ["prost"] }
 tonic-reflection = "0.11"
-tonic-web = "0.11"
 ### To try (experimental) std support, add `features = [ "std" ]` to risc0-zkvm
 tracing = "0.1.40"
 tracing-appender = "0.2"

--- a/protocol-units/da/m1/light-node-grpc/Cargo.toml
+++ b/protocol-units/da/m1/light-node-grpc/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "m1-da-light-node-grpc"
 version = { workspace = true }
-edition  = { workspace = true }
-license  = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
@@ -13,8 +13,6 @@ rust-version = { workspace = true }
 
 [dependencies]
 tonic = { workspace = true }
-tonic-reflection = { workspace = true }
-tonic-web = { workspace = true }
 prost = { workspace = true }
 
 [build-dependencies]

--- a/protocol-units/da/m1/light-node-verifier/Cargo.toml
+++ b/protocol-units/da/m1/light-node-verifier/Cargo.toml
@@ -16,8 +16,6 @@ integration-tests = []
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }
-tonic-reflection = { workspace = true }
-tonic-web = { workspace = true }
 prost = { workspace = true }
 m1-da-light-node-grpc = { workspace = true, features = [] }
 m1-da-light-node-util = { workspace = true }

--- a/protocol-units/da/m1/light-node/Cargo.toml
+++ b/protocol-units/da/m1/light-node/Cargo.toml
@@ -16,7 +16,6 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }
 tonic-reflection = { workspace = true }
-tonic-web = { workspace = true }
 prost = { workspace = true }
 m1-da-light-node-grpc = { workspace = true, features = ["server"] }
 m1-da-light-node-util = { workspace = true }

--- a/protocol-units/da/m1/util/Cargo.toml
+++ b/protocol-units/da/m1/util/Cargo.toml
@@ -19,8 +19,6 @@ path = "src/bin/wait_for_light_node.rs"
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }
-tonic-reflection = { workspace = true }
-tonic-web = { workspace = true }
 prost = { workspace = true }
 m1-da-light-node-grpc = { workspace = true, features = [] }
 celestia-rpc = { workspace = true }


### PR DESCRIPTION
# Summary
- **Categories**: `protocol-units`.

Remove tonic-web and tonic-reflection dependencies where they are not
required.

# Testing

All targets should build with the dependencies pruned.
