### PR TITLE
Log transaction pruning in memseq

### DIFF
--- a/protocol-units/mempool/util/src/lib.rs
+++ b/protocol-units/mempool/util/src/lib.rs
@@ -59,10 +59,14 @@ pub trait MempoolTransactionOperations {
 		Ok(mempool_transactions)
 	}
 
+	/// Garbage-collects transactions that have been submitted before the
+	/// given timestamp.
+	///
+	/// Returns the number of removed transaction.
 	fn gc_mempool_transactions(
 		&self,
 		timestamp_threshold: u64,
-	) -> impl Future<Output = Result<(), anyhow::Error>> + Send + '_;
+	) -> impl Future<Output = Result<u64, anyhow::Error>> + Send + '_;
 
 	/// Checks whether the mempool has the transaction.
 	async fn has_transaction(

--- a/protocol-units/sequencing/memseq/sequencer/src/lib.rs
+++ b/protocol-units/sequencing/memseq/sequencer/src/lib.rs
@@ -7,6 +7,7 @@ pub use movement_types::{
 pub use sequencing_util::Sequencer;
 
 use tokio::sync::RwLock;
+use tracing::{debug, info};
 
 use std::collections::BTreeSet;
 use std::path::PathBuf;
@@ -125,7 +126,12 @@ impl<T: MempoolTransactionOperations> Sequencer for Memseq<T> {
 			.unwrap()
 			.as_secs()
 			.saturating_sub(gc_interval);
-		self.mempool.gc_mempool_transactions(timestamp_threshold).await?;
+		let gc_count = self.mempool.gc_mempool_transactions(timestamp_threshold).await?;
+		if gc_count != 0 {
+			info!("pruned {gc_count} transactions");
+		} else {
+			debug!("no transactions to prune")
+		}
 		tokio::time::sleep(Duration::from_secs(gc_interval)).await;
 		Ok(())
 	}
@@ -463,7 +469,7 @@ pub mod test {
 		async fn gc_mempool_transactions(
 			&self,
 			_timestamp_threshold: u64,
-		) -> Result<(), anyhow::Error> {
+		) -> Result<u64, anyhow::Error> {
 			Err(anyhow::anyhow!("Mock gc_mempool_transaction"))
 		}
 


### PR DESCRIPTION
# Summary
- **Categories**: `protocol-units`.

Add logs to report when transactions get pruned from the sequencer's mempool.