### PR TITLE
Hot Cold Set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7120,6 +7120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hot-cold-set"
+version = "0.0.2"
+dependencies = [
+ "anyhow",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "hound"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7124,6 +7124,8 @@ name = "hot-cold-set"
 version = "0.0.2"
 dependencies = [
  "anyhow",
+ "rocksdb",
+ "tempfile",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "protocol-units/bridge/integration-tests",
     "protocol-units/settlement/mcr/runner",
     "benches/*",
+    "protocol-units/storage/hot-cold-set",
 ]
 
 [workspace.package]

--- a/protocol-units/storage/hot-cold-set/Cargo.toml
+++ b/protocol-units/storage/hot-cold-set/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "hot-cold-set"
+version = { workspace = true }
+edition  = { workspace = true }
+license  = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+publish = { workspace = true }
+rust-version = { workspace = true }
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tokio = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/protocol-units/storage/hot-cold-set/Cargo.toml
+++ b/protocol-units/storage/hot-cold-set/Cargo.toml
@@ -15,6 +15,10 @@ rust-version = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
+rocksdb = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/protocol-units/storage/hot-cold-set/src/backend/mod.rs
+++ b/protocol-units/storage/hot-cold-set/src/backend/mod.rs
@@ -1,0 +1,1 @@
+pub mod rocksdb;

--- a/protocol-units/storage/hot-cold-set/src/backend/rocksdb/mod.rs
+++ b/protocol-units/storage/hot-cold-set/src/backend/rocksdb/mod.rs
@@ -1,0 +1,203 @@
+use crate::set::{
+	Cold, ColdError, ColdGuard, ColdGuardError, Hot, HotError, HotGuard, HotGuardError,
+	Recoverable, RecoveryError, TryAsMember,
+};
+use rocksdb::{Options, DB};
+
+pub struct HotSet {
+	/// The underlying RocksDB instance
+	pub rocksdb: DB,
+}
+
+pub struct ColdSet {
+	/// The underlying RocksDB instance
+	pub rocksdb: DB,
+}
+
+/// A hot guard for RocksDB
+pub struct RocksHotGuard;
+
+impl<M> HotGuard<M> for RocksHotGuard
+where
+	M: TryAsMember + Send,
+{
+	async fn rollback(&self, _members: &[M]) -> Result<(), HotGuardError> {
+		Ok(()) // Assume rollback is always successful for simplicity
+	}
+
+	async fn commit(&self, _members: &[M]) -> Result<(), HotGuardError> {
+		Ok(()) // Assume commit is always successful for simplicity
+	}
+}
+
+/// A Hot Set implementation using RocksDB
+impl HotSet {
+	pub fn new(path: &str) -> Self {
+		let mut options = Options::default();
+		options.create_if_missing(true);
+		let rocksdb = DB::open(&options, path).expect("Failed to open RocksDB for HotSet");
+		HotSet { rocksdb }
+	}
+}
+
+impl Recoverable for HotSet {
+	async fn recover(&self) -> Result<(), RecoveryError> {
+		todo!()
+	}
+}
+
+impl<M> Hot<M, RocksHotGuard> for HotSet
+where
+	M: TryAsMember + Send,
+{
+	async fn cardinality(&self) -> Result<u64, HotError> {
+		// Count the number of entries in the database
+		let count = self.rocksdb.iterator(rocksdb::IteratorMode::Start).count();
+		Ok(count as u64)
+	}
+
+	async fn ttl(&self) -> Result<u64, HotError> {
+		// Placeholder for TTL logic, RocksDB doesn't have native TTL.
+		Ok(60) // Dummy TTL value
+	}
+
+	async fn prepare_insert(&self, members: &[M]) -> Result<RocksHotGuard, HotError> {
+		// Prepare the insert by checking the keys
+		for member in members {
+			let converted_member = member.try_as_member().map_err(|_| HotError::Internal)?;
+			self.rocksdb
+				.put(converted_member.0, b"prepared")
+				.map_err(|_| HotError::Internal)?;
+		}
+		Ok(RocksHotGuard)
+	}
+
+	async fn contains(&self, members: &[M]) -> Result<bool, HotError> {
+		for member in members {
+			let converted_member = member.try_as_member().map_err(|_| HotError::Internal)?;
+			if let Err(_) = self.rocksdb.get(converted_member.0) {
+				return Ok(false);
+			}
+		}
+		Ok(true)
+	}
+
+	async fn maybe_contained(&self, members: &[M]) -> Result<bool, HotError> {
+		// todo: this will be replaced by a bloom filter in a future PR
+		self.contains(members).await
+	}
+
+	async fn gc(&self) -> Result<(), HotError> {
+		todo!()
+	}
+}
+
+/// A cold guard for RocksDB
+pub struct RocksColdGuard;
+
+impl<M> ColdGuard<M> for RocksColdGuard
+where
+	M: TryAsMember + Send,
+{
+	async fn rollback(&self, _members: &[M]) -> Result<(), ColdGuardError> {
+		Ok(()) // Assume rollback is always successful for simplicity
+	}
+
+	async fn commit(&self, _members: &[M]) -> Result<(), ColdGuardError> {
+		Ok(()) // Assume commit is always successful for simplicity
+	}
+}
+
+/// A Cold Set implementation using RocksDB
+impl ColdSet {
+	pub fn new(path: &str) -> Self {
+		let mut options = Options::default();
+		options.create_if_missing(true);
+		let rocksdb = DB::open(&options, path).expect("Failed to open RocksDB for ColdSet");
+		ColdSet { rocksdb }
+	}
+}
+
+impl Recoverable for ColdSet {
+	async fn recover(&self) -> Result<(), RecoveryError> {
+		todo!()
+	}
+}
+
+impl<M> Cold<M, RocksColdGuard> for ColdSet
+where
+	M: TryAsMember + Send,
+{
+	async fn prepare_insert(&self, members: &[M]) -> Result<RocksColdGuard, ColdError> {
+		// Prepare the insert in Cold set by writing keys as "prepared"
+		for member in members {
+			let converted_member = member.try_as_member().map_err(|_| ColdError::Internal)?;
+			self.rocksdb
+				.put(converted_member.0, b"prepared")
+				.map_err(|_| ColdError::Internal)?;
+		}
+		Ok(RocksColdGuard)
+	}
+
+	async fn contains(&self, members: &[M]) -> Result<bool, ColdError> {
+		for member in members {
+			let converted_member = member.try_as_member().map_err(|_| ColdError::Internal)?;
+			if let Err(_) = self.rocksdb.get(converted_member.0) {
+				return Ok(false);
+			}
+		}
+		Ok(true)
+	}
+
+	async fn maybe_contained(&self, members: &[M]) -> Result<bool, ColdError> {
+		self.contains(members).await
+	}
+}
+
+#[cfg(test)]
+pub mod test {
+	use super::*;
+	use crate::set::test::TestMember;
+	use crate::set::HotColdSet; // create the actual set against which we test with the HotColdSet struct.
+	use tempfile::TempDir;
+
+	#[tokio::test]
+	async fn test_hot_cold_set_with_rocksdb() -> Result<(), anyhow::Error> {
+		// Create temporary directories for testing RocksDB
+		let hot_temp_dir = TempDir::new().expect("Failed to create temporary directory for HotSet");
+		let cold_temp_dir =
+			TempDir::new().expect("Failed to create temporary directory for ColdSet");
+
+		let hot_path = hot_temp_dir.path().to_str().ok_or(anyhow::anyhow!(
+			"Failed to convert HotSet temporary directory path to string."
+		))?;
+		let cold_path = cold_temp_dir.path().to_str().ok_or(anyhow::anyhow!(
+			"Failed to convert ColdSet temporary directory path to string."
+		))?;
+
+		// Create a Hot and Cold set using RocksDB
+		let hot_set = HotSet::new(hot_path);
+		let cold_set = ColdSet::new(cold_path);
+
+		// Create the HotColdSet
+		let mut hot_cold_set = HotColdSet::new(hot_set, cold_set);
+
+		// Define some members
+		let members = vec![TestMember(1), TestMember(2)];
+
+		// Try inserting into both sets
+		let result = hot_cold_set.insert(members.clone()).await;
+
+		// Ensure the insertion was successful
+		assert!(result.is_ok(), "Insertion should succeed for reliable Hot and Cold sets.");
+
+		// Check both sets contain the members
+		let hot_contains = hot_cold_set.hot().contains(&members).await?;
+		let cold_contains = hot_cold_set.cold().contains(&members).await?;
+
+		assert!(hot_contains, "Hot set should contain the members.");
+		assert!(cold_contains, "Cold set should contain the members.");
+
+		Ok(())
+	}
+}

--- a/protocol-units/storage/hot-cold-set/src/lib.rs
+++ b/protocol-units/storage/hot-cold-set/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod backend;
+pub mod checkpoint_set;
+pub mod set;

--- a/protocol-units/storage/hot-cold-set/src/set/mod.rs
+++ b/protocol-units/storage/hot-cold-set/src/set/mod.rs
@@ -1,15 +1,15 @@
-// ! The [HotColdSet] struct describes a synchronization primitive used to ensure consistent inclusion of members between two sets, known as Hot and Cold sets.
-// ! The synchronization protocol is similar to a 3PC or 3-way handshake, consisting of multiple exchanges between Hot and Cold sets to commit the inclusion of a member where the application interacting with these sets via the [HotColdSet] struct is the coordinator.
-// !
-// ! The Hot set is considered hot for two reasons:
-// ! 1. It is written to first and read from first by the application.
-// ! 2. The Hot set can be garbage collected.
-// ! The Cold set is considered cold for two reasons:
-// ! 1. It is written to second and serves as a backup to the Hot set.
-// ! 2. The Cold set is append-only and is never garbage collected by the application.
-// !
-// ! Originally designed for event sets, this protocol can be extended to other contexts, such as synchronization of transactions.
-// ! Implementers should be cautious of failure points, as frequent commit failures will flag the system as inconsistent and induce recovery attempts when using the `rinsert` method.
+//! The [HotColdSet] struct describes a synchronization primitive used to ensure consistent inclusion of members between two sets, known as Hot and Cold sets.
+//! The synchronization protocol is similar to a 3PC or 3-way handshake, consisting of multiple exchanges between Hot and Cold sets to commit the inclusion of a member where the application interacting with these sets via the [HotColdSet] struct is the coordinator.
+//!
+//! The Hot set is considered hot for two reasons:
+//! 1. It is written to first and read from first by the application.
+//! 2. The Hot set can be garbage collected.
+//! The Cold set is considered cold for two reasons:
+//! 1. It is written to second and serves as a backup to the Hot set.
+//! 2. The Cold set is append-only and is never garbage collected by the application.
+//!
+//! Originally designed for event sets, this protocol can be extended to other contexts, such as synchronization of transactions.
+//! Implementers should be cautious of failure points, as frequent commit failures will flag the system as inconsistent and induce recovery attempts when using the `rinsert` method.
 use std::marker::PhantomData;
 use thiserror::Error;
 

--- a/protocol-units/storage/hot-cold-set/src/set/mod.rs
+++ b/protocol-units/storage/hot-cold-set/src/set/mod.rs
@@ -1,0 +1,287 @@
+// ! The [HotColdSet] struct describes a synchronization primitive used to ensure consistent inclusion of members between two sets, known as Hot and Cold sets.
+// ! The synchronization protocol is similar to a 3-way handshake, consisting of multiple exchanges between Hot and Cold sets to commit the inclusion of a member.
+// !
+// ! The Hot set is considered hot for two reasons:
+// ! 1. It is written to first and read from first by the application.
+// ! 2. The Hot set can be garbage collected.
+// ! The Cold set is considered cold for two reasons:
+// ! 1. It is written to second and serves as a backup to the Hot set.
+// ! 2. The Cold set is append-only and is never garbage collected by the application.
+// !
+// ! Originally designed for event sets, this protocol can be extended to other contexts, such as synchronization of transactions.
+// ! Implementers should be cautious of failure points, as frequent commit failures will flag the system as inconsistent and induce recovery attempts.
+use std::marker::PhantomData;
+use thiserror::Error;
+
+/// A member of the set is represented as a byte array.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Member(pub Vec<u8>);
+
+/// Error types for the Hot guard.
+#[derive(Debug, Error)]
+pub enum HotGuardError {
+	#[error("hot guard failed to rollback the insertion")]
+	FailedToRollback,
+	#[error("hot guard failed to commit the insertion")]
+	FailedToCommit,
+}
+
+/// A Hot guard responsible for rollback or commit operations.
+pub trait HotGuard<M> where M: TryInto<Member> {
+	/// Rollback the prepared insertion in the Hot set.
+	async fn rollback(&self, members: &[M]) -> Result<(), HotGuardError>;
+
+	/// Commit the prepared insertion in the Hot set.
+	async fn commit(&self, members: &[M]) -> Result<(), HotGuardError>;
+}
+
+#[derive(Debug, Error)]
+pub enum HotError {}
+
+/// The Hot portion of the set, optimized for fast access and size.
+/// The Hot set is garbage collected and typically uses structures like Bloom filters to probabilistically check membership.
+/// The Hot set supports asynchronous operations and should implement this trait with a type-specific guard.
+pub trait Hot<M, G>
+where
+	M: TryInto<Member>,
+	G: HotGuard<M>,
+{
+	/// Get the intended cardinality of the set.
+	async fn cardinality(&self) -> Result<u64, HotError>;
+
+	/// Get the time-to-live (TTL) of members in the set.
+	async fn ttl(&self) -> Result<u64, HotError>;
+
+	/// Prepare to insert a collection of members into the Hot set.
+    async fn prepare_insert(&self, members: &[M]) -> Result<G, HotError>;
+
+    /// Check if a collection of members is in the Hot set.
+    async fn contains(&self, members: &[M]) -> Result<bool, HotError>;
+
+    /// Check if the Hot set likely contained a collection of members.
+    async fn maybe_contained(&self, members: &[M]) -> Result<bool, HotError>;
+
+	/// Garbage collect the Hot set.
+	async fn gc(&self) -> Result<(), HotError>;
+}
+
+#[derive(Debug, Error)]
+pub enum ColdGuardError {
+	#[error("cold guard failed to commit the insertion")]
+	FailedToCommit,
+}
+
+/// A Cold guard responsible for commit and rollback operations in the Cold set.
+pub trait ColdGuard<M> where M: TryInto<Member> {
+	/// Rollback the prepared insertion in the Cold set.
+	async fn rollback(&self, members: &[M]) -> Result<(), ColdGuardError>;
+
+	/// Commit the prepared insertion in the Cold set.
+	async fn commit(&self, members: &[M]) -> Result<(), ColdGuardError>;
+}
+
+#[derive(Debug, Error)]
+pub enum ColdError {}
+
+/// The Cold portion of the set is append-only and intended for long-term storage.
+/// The Cold set serves as a backup and is never garbage collected by the application.
+pub trait Cold<M, G>
+where
+	M: TryInto<Member>,
+	G: ColdGuard<M>,
+{
+	/// Prepare to insert a collection of members into the Hot set.
+    async fn prepare_insert(&self, members: &[M]) -> Result<G, HotError>;
+
+    /// Check if a collection of members is in the Hot set.
+    async fn contains(&self, members: &[M]) -> Result<bool, HotError>;
+
+    /// Check if the Hot set likely contained a collection of members.
+    async fn maybe_contained(&self, members: &[M]) -> Result<bool, HotError>;
+
+}
+
+/// Describes a partial insertion state in which the Hot or both Hot and Cold sets were partially committed.
+#[derive(Debug)]
+pub enum InsertionPartial {
+	Hot,
+	Both,
+}
+
+/// Error types for the Hot-Cold set operations.
+#[derive(Debug, Error)]
+pub enum HotColdError<M>
+where
+	M: TryInto<Member>,
+{
+	#[error("hot-cold set is inconsistent (partially committed)")]
+	Inconsistent(InsertionPartial, Vec<M>),
+	#[error("failed to insert member")]
+	FailedToInsert,
+}
+
+/// The `HotColdSet` struct ensures synchronized inclusion of members between the Hot and Cold sets.
+pub struct HotColdSet<M, HG, CG, H, C>
+where
+	M: TryInto<Member>,
+	HG: HotGuard<M>,
+	CG: ColdGuard<M>,
+	H: Hot<M, HG>,
+	C: Cold<M, CG>,
+{
+	_member_marker: PhantomData<M>,
+	_hot_guard_marker: PhantomData<HG>,
+	_cold_guard_marker: PhantomData<CG>,
+	hot: H,
+	cold: C,
+}
+
+impl<M, HG, CG, H, C> HotColdSet<M, HG, CG, H, C>
+where
+	M: TryInto<Member>,
+	HG: HotGuard<M>,
+	CG: ColdGuard<M>,
+	H: Hot<M, HG>,
+	C: Cold<M, CG>,
+{
+
+    /// Create a new Hot-Cold Set with the given Hot and Cold sets.
+    pub fn new(hot: H, cold: C) -> Self {
+        HotColdSet {
+            _member_marker: PhantomData,
+            _hot_guard_marker: PhantomData,
+            _cold_guard_marker: PhantomData,
+            hot,
+            cold,
+        }
+    }
+
+	/// Get the Hot set.
+	pub fn hot(&self) -> &H {
+		&self.hot
+	}
+
+	/// Get the Cold set.
+	pub fn cold(&self) -> &C {
+		&self.cold
+	}
+
+	/// Insert a member into both the Hot and Cold sets, ensuring consistency.
+	pub async fn insert<I>(&self, members: Vec<M>) -> Result<(), HotColdError<M>> {
+		// SYN: Prepare to insert the member into the Hot set.
+		let hot_guard = self
+			.hot()
+			.prepare_insert(&members)
+			.await
+			.map_err(|_| HotColdError::FailedToInsert)?;
+
+		// ACK: Prepare to insert the member into the Cold set.
+		match self.cold().prepare_insert(&members).await {
+			Ok(cold_guard) => {
+				// SYN-ACK: Commit the Hot set.
+				match hot_guard.commit(&members).await {
+					Ok(_) => {
+						// Commit the Cold set.
+
+						cold_guard.commit(&members).await.map_err(|_| {
+							// If this fails, then...
+							// (a) the hot set is considered partially committed because it was prepared and committed while the cold set was only prepared, i.e., its state should actually be rolled back.
+							// (b) the cold set is considered partially committed because it was prepared but not committed and not successfully rolled back.
+							HotColdError::Inconsistent(InsertionPartial::Both, members)
+						})?;
+						Ok(())
+					}
+					Err(_) => {
+						// If Hot set commit fails, attempt to rollback the Cold set.
+						match cold_guard.rollback(&members).await {
+							Ok(_) => {
+								// If the rollback succeeded, then the hot set should still be reported as partially committed.
+								Err(HotColdError::Inconsistent(InsertionPartial::Hot, members))
+							}
+							Err(_) => {
+								// If this fails, then...
+								// (a) the hot set is considered partially committed because it was prepared but never committed.
+								// (b) the cold set is also considered partially committed because it was prepared but not committed and not successfully rolled back.
+								Err(HotColdError::Inconsistent(InsertionPartial::Both, members))
+							}
+						}
+					}
+				}
+			}
+			Err(_) => {
+				// If Cold set insertion fails, rollback the Hot set.
+				hot_guard
+					.rollback(&members)
+					.await
+					.map_err(|_| 
+				        // If this fails, then the hot set is considered partially committed because it was prepared but never committed and not successfully rolled back.
+                        // Meanwhile, the cold set was never successfully prepared, so it is not considered partially committed.
+                        HotColdError::Inconsistent(InsertionPartial::Hot, members)
+                    )?;
+                // If we did rollback successfully, then this is just a failed insert.
+				Err(HotColdError::FailedToInsert)
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+    pub struct TestMember(u8);
+
+    impl TryInto<Member> for TestMember {
+
+        type Error = ();
+
+        fn try_into(self) -> Result<Member, ()> {
+            Ok(Member(vec![self.0]))
+        }
+    }
+
+    pub struct ReliableHot {
+        cardinality: u64,
+        ttl: u64,
+        set: HashSet<Member>,
+    }
+
+    pub struct ReliableHotGuard;
+
+    pub struct ReliableCold {
+        set: HashSet<Member>,
+    }
+
+    pub struct ReliableColdGuard;
+
+    pub struct UnreliableCommitHot {
+        cardinality: u64,
+        ttl: u64,
+        set: HashSet<Member>,
+    }
+
+    pub struct UnreliableCommitHotGuard;
+
+    pub struct UnreliableCommitCold {
+        set: HashSet<Member>,
+    }
+
+    pub struct UnreliableCommitColdGuard;
+
+    pub struct UnreliableRollbackHot {
+        cardinality: u64,
+        ttl: u64,
+        set: HashSet<Member>,
+    }
+
+    pub struct UnreliableRollbackHotGuard;
+
+    pub struct UnreliableRollbackCold {
+        set: HashSet<Member>,
+    }
+
+    pub struct UnreliableRollbackColdGuard;
+
+}


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**: `protocol-units`

The Hold-Cold Set protocol is best described in the doc comment on the [hot_cold_set::set](https://github.com/movementlabsxyz/movement/blob/l-monninger/hot-cold/protocol-units/storage/hot-cold-set/src/set/mod.rs) module. It is roughly a 3PC protocol for synchronizing set inclusion. Its initial motivation was to create means for writing to a "hot" set used by the application which should not grow indefinitely and a "cold" set that backs up the set used by application which may be periodically groomed by an operator. 

This PR introduces the protocol and a simple `rocksdb` implementation.

Forthcoming PRs will introduce:
- The `HotColdCheckpointSet` which is intended to store members as in a Hot-Cold Set as they are tagged for different checkpoints.
- A completed `rocksb` implementation containing a persisted bloom filter as the probabilistic storage used by the Hot Set. 
- A poem API from `HotColdSet` and `HotColdCheckpointSet` abstraction.
- A gRPC API from `HotColdSet` and `HotColdCheckpointSet` abstraction.
- An integration with the `bridge-service` to write to the sets and serve the necessary APIs. 

This are omitted here as they are incomplete and for the sake of some brevity. 


# Testing

1. Unit tests for the general protocol are provided against reliable and unreliable structs.
2. `rocksdb` implementation is unit tested. 

# Outstanding issues
1. See forthcoming PRs. 
2. Unit tests have not yet been added to the CI. 