### PR TITLE
Removes Helios Container Build from the CI Workflow

### DIFF
--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -842,7 +842,8 @@ jobs:
           ./scripts/movement/manifest bridge-setup
 
   helios-build:
-    if: github.event.label.name == 'cicd:suzuka-containers' ||  github.ref == 'refs/heads/main'
+    if: false
+    # if: github.event.label.name == 'cicd:bridge-containers' ||  github.ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**:  `cicd`

1. Removes Helios Container Build from the CI Workflow.
2. Use of Helios `docker-compose` overlay should is now deprecated. 

# Outstanding issues
1. Possibly provide alternative to `helios` overlay as `eth-remote` to more directly specify current usage.