### PR TITLE
Testnet Transaction Health

### DIFF
--- a/docker/build/suzuka-client-e2e-simple-interaction/Dockerfile
+++ b/docker/build/suzuka-client-e2e-simple-interaction/Dockerfile
@@ -15,7 +15,7 @@ RUN rust_binary="./target/release/suzuka-client-e2e-simple-interaction"; dest_di
     grep '^/' | xargs -I {} dirname {} | sort | uniq | xargs -I {} \
     bash -c 'mkdir -p "$0/$1" && rsync -a --copy-links "$1/" "$0/$1/"' "$dest_dir" {}
 
-FROM scratch
+FROM alpine:latest
 
 # Copy the build artifact from the builder stage
 COPY --from=builder /tmp/build/target/release/suzuka-client-e2e-simple-interaction /app/suzuka-client-e2e-simple-interaction

--- a/docker/compose/suzuka-full-node/docker-compose.testnet-healthcheck.yml
+++ b/docker/compose/suzuka-full-node/docker-compose.testnet-healthcheck.yml
@@ -1,0 +1,39 @@
+services:
+
+  # runs the simple interaction client to healthcheck the full node over and over
+  suzuka-client-e2e-simple-interaction-healthcheck:
+    image: ghcr.io/movementlabsxyz/suzuka-client-e2e-simple-interaction:${CONTAINER_REV}
+    container_name: suzuka-client-e2e-simple-interaction
+    command: >
+      sh -c '
+        while true; do
+          /app/suzuka-client-e2e-simple-interaction
+        done
+      '
+    environment:
+      - DOT_MOVEMENT_PATH=/.movement
+    volumes:
+      - ${DOT_MOVEMENT_PATH}:/.movement
+    depends_on:
+      suzuka-faucet-service: # wait for all of the replicas to be ready
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "echo", "true"]
+      interval: 1m30s
+      timeout: 30s
+      retries: 5
+      start_period: 30s
+
+  # Here we use a dependent service to trigger application crash, i.e., throughout docker-compose 
+  suzuka-client-e2e-simple-interaction-healthcheck-watcher:
+    image: busybox
+    container_name: ledger-should-progress-watcher
+    command: >
+      sh -c '
+        while true; do
+          sleep 1000
+        done
+      '
+    depends_on:
+      suzuka-client-e2e-simple-interaction-healthcheck:
+        condition: service_healthy


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**: `networks`

A simple implementation of a health check that uses the existing containers, towards [MIP-26](https://github.com/movementlabsxyz/MIP/pull/26). 

Like #717 , this check will crash the docker-compose application on the whole if the test criteria aren't meant, thereby generating an outage that will be reported for monitoring.

A slightly more sophisticated approach might be to write the exit code of the looped check into the `DOT_MOVEMENT_PATH` at a well known file and serve this status in the watcher. 

A more sophisticated approach still would adjust the running modes of the `suzuka-client-e2e-simple-interaction` to include a `healthcheck` mode which would be run to serve this through the docker compose application. When we transition to  `k8s` and `helm` throughout our infra this will be needed. 