### PR TITLE
Fix local build scripts for process-compose

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15538,8 +15538,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
-source = "git+https://github.com/gyscos/zstd-rs.git?rev=1779b385b42b08f958b767a37878dfa6a0b4f6a4#1779b385b42b08f958b767a37878dfa6a0b4f6a4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,8 +152,8 @@ aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/apto
 aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
 
 # Indexer
-processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "8e83cde3cb75fabdade9485e0af680cc4b73ca8e", subdir = "rust" }
-server-framework = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "8e83cde3cb75fabdade9485e0af680cc4b73ca8e", subdir = "rust" }
+processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "8e83cde3cb75fabdade9485e0af680cc4b73ca8e" }
+server-framework = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "8e83cde3cb75fabdade9485e0af680cc4b73ca8e" }
 
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
 ethereum-types = "0.14.1"
@@ -299,7 +299,13 @@ uuid = { version = "1.10.0", features = ["v4"] }
 tar = "0.4.41"
 flate2 = "1.0.31"
 blake-3 = "1.4.0"
-ecdsa = { version = "0.16.9", features = ["signing", "verifying", "der", "pem", "pkcs8"] }
+ecdsa = { version = "0.16.9", features = [
+    "signing",
+    "verifying",
+    "der",
+    "pem",
+    "pkcs8",
+] }
 regex = "1.10.6"
 globset = "0.4.15"
 glob = "0.3.1"
@@ -336,4 +342,3 @@ opt-level = 3
 [patch.crates-io]
 merlin = { git = "https://github.com/aptos-labs/merlin" }
 x25519-dalek = { git = "https://github.com/aptos-labs/x25519-dalek", branch = "zeroize_v1" }
-zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git", rev = "1779b385b42b08f958b767a37878dfa6a0b4f6a4" }

--- a/process-compose/suzuka-full-node/process-compose.feed.yml
+++ b/process-compose/suzuka-full-node/process-compose.feed.yml
@@ -1,0 +1,17 @@
+version: "3"
+
+environment:
+
+processes:
+
+  client-test-feed:
+    command: |
+      # loop the test examples 
+      while true; do
+        cargo test -p suzuka-client test_example_ || break
+      done
+    depends_on:
+      suzuka-full-node:
+        condition: process_healthy
+      suzuka-faucet:
+        condition: process_healthy

--- a/process-compose/suzuka-full-node/process-compose.yml
+++ b/process-compose/suzuka-full-node/process-compose.yml
@@ -44,8 +44,8 @@ processes:
   suzuka-full-node:
     command: |
       suzuka-full-node
-    env:
-      RUST_LOG: info,aptos-indexer=debug
+    environment:
+      - RUST_LOG=info
     depends_on:
       m1-da-light-node:
         condition: process_healthy

--- a/protocol-units/bridge/service/Cargo.toml
+++ b/protocol-units/bridge/service/Cargo.toml
@@ -19,7 +19,7 @@ futures.workspace = true
 futures-timer = "3.0.3"
 hex = { workspace = true }
 thiserror.workspace = true
-tokio = { workspace = true, version = "1.0.1", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 tokio-stream = "0.1.16"
 tracing.workspace = true
 rand.workspace = true

--- a/scripts/services/bridge/build
+++ b/scripts/services/bridge/build
@@ -5,17 +5,11 @@ echo "Building m1-da-light-node..."
 cargo build $CARGO_PROFILE_FLAGS -p m1-da-light-node --features "sequencer"
 echo "Built m1-da-light-node!"
 
-echo "Building m1-da-light-node-celestia-appd..."
-cargo build $CARGO_PROFILE_FLAGS --bin m1-da-light-node-celestia-appd
-echo "Built m1-da-light-node-celestia-appd!"
-
-echo "Building m1-da-light-node-celestia-bridge..."
-cargo build $CARGO_PROFILE_FLAGS --bin m1-da-light-node-celestia-bridge
-echo "Built m1-da-light-node-celestia-bridge!"
-
-echo "Building suzuka-config..."
-cargo build $CARGO_PROFILE_FLAGS --bin suzuka-full-node-setup
-echo "Built suzuka-config!"
+echo "Building m1-da-light-node-celestia-* runners..."
+cargo build $CARGO_PROFILE_FLAGS -p m1-da-light-node-runners \
+    --bin m1-da-light-node-celestia-appd \
+    --bin m1-da-light-node-celestia-bridge
+echo "Built m1-da-light-node-celestia-* runners!"
 
 echo "Building suzuka-full-node..."
 cargo build $CARGO_PROFILE_FLAGS -p suzuka-full-node
@@ -30,7 +24,7 @@ cargo build $CARGO_PROFILE_FLAGS -p suzuka-full-node-setup
 echo "Built suzuka-full-node-setup!"
 
 echo "Building wait-for-celestia-light-node..."
-cargo build $CARGO_PROFILE_FLAGS --bin wait-for-celestia-light-node
+cargo build $CARGO_PROFILE_FLAGS -p m1-da-light-node-util --bin wait-for-celestia-light-node
 echo "Built wait-for-celestia-light-node!"
 
 echo "Building Bridge..."

--- a/scripts/services/m1-da-light-node/build
+++ b/scripts/services/m1-da-light-node/build
@@ -16,14 +16,6 @@ echo "Building m1-da-light-node..."
 cargo build $CARGO_PROFILE_FLAGS -p m1-da-light-node --features "sequencer"
 echo "Built m1-da-light-node!"
 
-echo "Building m1-da-light-node-celestia-appd..."
-cargo build $CARGO_PROFILE_FLAGS --bin m1-da-light-node-celestia-appd
-echo "Built m1-da-light-node-celestia-appd!"
-
-echo "Building m1-da-light-node-celestia-bridge..."
-cargo build $CARGO_PROFILE_FLAGS --bin m1-da-light-node-celestia-bridge
-echo "Built m1-da-light-node-celestia-bridge!"
-
-echo "Building m1-da-light-node-celestia-light..."
-cargo build $CARGO_PROFILE_FLAGS --bin m1-da-light-node-celestia-light
-echo "Built m1-da-light-node-celestia-light!"
+echo "Building m1-da-light-node-runners..."
+cargo build $CARGO_PROFILE_FLAGS -p m1-da-light-node-runners
+echo "Built m1-da-light-node-runners!"

--- a/scripts/services/monza-full-node/build
+++ b/scripts/services/monza-full-node/build
@@ -2,7 +2,7 @@
 set -e
 
 echo "Building monza-config..."
-cargo build $CARGO_PROFILE_FLAGS --bin monza-full-node-setup
+cargo build $CARGO_PROFILE_FLAGS -p monza-full-node-setup
 echo "Built monza-config!"
 
 echo "Building monza-full-node..."

--- a/scripts/services/suzuka-full-node/build
+++ b/scripts/services/suzuka-full-node/build
@@ -5,17 +5,11 @@ echo "Building m1-da-light-node..."
 cargo build $CARGO_PROFILE_FLAGS -p m1-da-light-node --features "sequencer"
 echo "Built m1-da-light-node!"
 
-echo "Building m1-da-light-node-celestia-appd..."
-cargo build $CARGO_PROFILE_FLAGS --bin m1-da-light-node-celestia-appd
-echo "Built m1-da-light-node-celestia-appd!"
-
-echo "Building m1-da-light-node-celestia-bridge..."
-cargo build $CARGO_PROFILE_FLAGS --bin m1-da-light-node-celestia-bridge
-echo "Built m1-da-light-node-celestia-bridge!"
-
-echo "Building suzuka-config..."
-cargo build $CARGO_PROFILE_FLAGS --bin suzuka-full-node-setup
-echo "Built suzuka-config!"
+echo "Building m1-da-light-node-celestia-* runners..."
+cargo build $CARGO_PROFILE_FLAGS -p m1-da-light-node-runners \
+    --bin m1-da-light-node-celestia-appd \
+    --bin m1-da-light-node-celestia-bridge
+echo "Built m1-da-light-node-celestia-* runners!"
 
 echo "Building suzuka-full-node..."
 cargo build $CARGO_PROFILE_FLAGS -p suzuka-full-node
@@ -30,5 +24,5 @@ cargo build $CARGO_PROFILE_FLAGS -p suzuka-full-node-setup
 echo "Built suzuka-full-node-setup!"
 
 echo "Building wait-for-celestia-light-node..."
-cargo build $CARGO_PROFILE_FLAGS --bin wait-for-celestia-light-node
+cargo build $CARGO_PROFILE_FLAGS -p m1-da-light-node-util --bin wait-for-celestia-light-node
 echo "Built wait-for-celestia-light-node!"

--- a/scripts/services/wait-for-celestia-light-node/build
+++ b/scripts/services/wait-for-celestia-light-node/build
@@ -13,5 +13,5 @@ else
 fi
 
 echo "Building wait-for-celestia-light-node..."
-cargo build $CARGO_PROFILE_FLAGS --bin wait-for-celestia-light-node
+cargo build $CARGO_PROFILE_FLAGS -p m1-da-light-node-util --bin wait-for-celestia-light-node
 echo "Built wait-for-celestia-light-node!"


### PR DESCRIPTION
# Summary
- **Categories**: `scripts`.

* Reduce recompile-the-world tendencies by always selecting the package when building binaries (if the binaries need to be specifically selected at all, rather than just built as package's default targets).
* Fix cargo warnings.
* Cherry-pick a few process-compose changes from #697.