### PR TITLE
feat: configure-bridge .sh

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,163 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1729273024,
+        "narHash": "sha256-Mb5SemVsootkn4Q2IiY0rr9vrXdCCpQ9HnZeD/J3uXs=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "fa8b7445ddadc37850ed222718ca86622be01967",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "foundry": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1729156209,
+        "narHash": "sha256-eMTx3a2PkW41vCWzSiC36yN1RAItdRgYtQnuj9OSYjo=",
+        "owner": "shazow",
+        "repo": "foundry.nix",
+        "rev": "f533e2c70e520adb695c9917be21d514c15b1c4d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shazow",
+        "repo": "foundry.nix",
+        "rev": "f533e2c70e520adb695c9917be21d514c15b1c4d",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1666753130,
+        "narHash": "sha256-Wff1dGPFSneXJLI2c0kkdWTgxnQ416KE6X4KnFkgPYQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f540aeda6f677354f1e7144ab04352f61aaa0118",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1726671079,
+        "narHash": "sha256-7iV7wI5qNmKoWBf3F6xT5aeZmwHcUO2Q+627wPnhqoA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2ac40064487f7dfae54f188705e8ed9173993e79",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2ac40064487f7dfae54f188705e8ed9173993e79",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1718428119,
+        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "foundry": "foundry",
+        "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1719886738,
+        "narHash": "sha256-6eaaoJUkr4g9J/rMC4jhj3Gv8Sa62rvlpjFe3xZaSjM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "db12d0c6ef002f16998723b5dd619fa7b8997086",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "db12d0c6ef002f16998723b5dd619fa7b8997086",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/scripts/services/bridge/configure-bridge.sh
+++ b/scripts/services/bridge/configure-bridge.sh
@@ -44,6 +44,7 @@ if [ "$EXECUTE_MOVE" == "true" ]; then
     --package-dir protocol-units/bridge/move-modules/
     --profile default \
     --assume-yes 
+    
   # First script: enable_bridge_feature
   movement move run-script \
     --compiled-script-path protocol-units/bridge/move-modules/build/bridge-modules/bytecode_scripts/enable_bridge_feature.mv \

--- a/scripts/services/bridge/configure-bridge.sh
+++ b/scripts/services/bridge/configure-bridge.sh
@@ -2,6 +2,7 @@
 
 # Check if execute_move argument is set to true
 EXECUTE_MOVE=$1
+BRIDGE_OPERATOR_ADDRESS=$2
 
 # Define the directory and file paths
 MOVEMENT_DIR="./.movement"
@@ -10,9 +11,10 @@ CONFIG_FILE="$MOVEMENT_DIR/config.yaml"
 NEW_ACCOUNT="0xA550C18"
 
 # Ensure the correct number of arguments
-if [ -z "$EXECUTE_MOVE" ]; then
-  echo "Usage: $0 <execute_move>"
+if [ -z "$EXECUTE_MOVE" ] || [ -z "$BRIDGE_OPERATOR_ADDRESS" ]; then
+  echo "Usage: $0 <execute_move> <bridge_operator_address>"
   echo "Where <execute_move> is either 'true' or 'false'"
+  echo "And <bridge_operator_address> is the address of the bridge operator"
   exit 1
 fi
 
@@ -41,7 +43,7 @@ echo "Account field updated with value: ${NEW_ACCOUNT}"
 if [ "$EXECUTE_MOVE" == "true" ]; then
   echo "Executing Move scripts..."
   movement move compile \
-    --package-dir protocol-units/bridge/move-modules/ \
+    --package-dir protocol-units/bridge/move-modules/
     
   # First script: enable_bridge_feature
   movement move run-script \
@@ -58,8 +60,9 @@ if [ "$EXECUTE_MOVE" == "true" ]; then
   # Third script: update_bridge_operator 
   movement move run-script \
     --compiled-script-path protocol-units/bridge/move-modules/build/bridge-modules/bytecode_scripts/update_bridge_operator.mv \
+    --args address:${BRIDGE_OPERATOR_ADDRESS} \
     --profile default \
-    --assume-yes 2>&1 | tee store_mint_burn_caps_output.log
+    --assume-yes 2>&1 | tee update_bridge_operator_output.log
 
   echo "Move scripts executed."
 else

--- a/scripts/services/bridge/configure-bridge.sh
+++ b/scripts/services/bridge/configure-bridge.sh
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
 
+# Check if execute_move argument is set to true
+EXECUTE_MOVE=$1
+
 # Define the directory and file paths
 MOVEMENT_DIR="./.movement"
 CONFIG_FILE="$MOVEMENT_DIR/config.yaml"
 
 NEW_ACCOUNT="0xA550C18"
+
+# Ensure the correct number of arguments
+if [ -z "$EXECUTE_MOVE" ]; then
+  echo "Usage: $0 <execute_move>"
+  echo "Where <execute_move> is either 'true' or 'false'"
+  exit 1
+fi
 
 if [ ! -d "$MOVEMENT_DIR" ]; then
   echo "Error: Directory $MOVEMENT_DIR not found."
@@ -27,8 +37,15 @@ fi
 
 echo "Account field updated with value: ${NEW_ACCOUNT}"
 
-## Execute feature enable move script
-movement move run-script \
-  --compiled-script-path protocol-units/bridge/move-modules/build/bridge-modules/bytecode_scripts/enable_bridge_feature.mv \
-  --profile default \
-  --assume-yes > enable_bridge_feature_output.log 2> enable_bridge_feature_error.log
+# Execute the Move feature script if execute_move is true
+if [ "$EXECUTE_MOVE" == "true" ]; then
+  echo "Executing Move script..."
+  movement move run-script \
+    --compiled-script-path protocol-units/bridge/move-modules/build/bridge-modules/bytecode_scripts/enable_bridge_feature.mv \
+    --profile default \
+    --assume-yes > enable_bridge_feature_output.log 2> enable_bridge_feature_error.log
+  echo "Move script executed."
+else
+  echo "Skipping Move script execution."
+fi
+

--- a/scripts/services/bridge/configure-bridge.sh
+++ b/scripts/services/bridge/configure-bridge.sh
@@ -26,3 +26,9 @@ else
 fi
 
 echo "Account field updated with value: ${NEW_ACCOUNT}"
+
+## Execute feature enable move script
+movement move run-script \
+  --compiled-script-path protocol-units/bridge/move-modules/build/bridge-modules/bytecode_scripts/enable_bridge_feature.mv \
+  --profile default \
+  --assume-yes > enable_bridge_feature_output.log 2> enable_bridge_feature_error.log

--- a/scripts/services/bridge/configure-bridge.sh
+++ b/scripts/services/bridge/configure-bridge.sh
@@ -55,6 +55,12 @@ if [ "$EXECUTE_MOVE" == "true" ]; then
     --profile default \
     --assume-yes 2>&1 | tee store_mint_burn_caps_output.log
 
+  # Third script: update_bridge_operator 
+  movement move run-script \
+    --compiled-script-path protocol-units/bridge/move-modules/build/bridge-modules/bytecode_scripts/update_bridge_operator.mv \
+    --profile default \
+    --assume-yes 2>&1 | tee store_mint_burn_caps_output.log
+
   echo "Move scripts executed."
 else
   echo "Skipping Move script execution."

--- a/scripts/services/bridge/configure-bridge.sh
+++ b/scripts/services/bridge/configure-bridge.sh
@@ -40,7 +40,10 @@ echo "Account field updated with value: ${NEW_ACCOUNT}"
 # Execute the Move scripts if execute_move is true
 if [ "$EXECUTE_MOVE" == "true" ]; then
   echo "Executing Move scripts..."
-
+  movement move compile \ 
+    --package-dir protocol-units/bridge/move-modules/
+    --profile default \
+    --assume-yes 
   # First script: enable_bridge_feature
   movement move run-script \
     --compiled-script-path protocol-units/bridge/move-modules/build/bridge-modules/bytecode_scripts/enable_bridge_feature.mv \

--- a/scripts/services/bridge/configure-bridge.sh
+++ b/scripts/services/bridge/configure-bridge.sh
@@ -45,13 +45,13 @@ if [ "$EXECUTE_MOVE" == "true" ]; then
   movement move run-script \
     --compiled-script-path protocol-units/bridge/move-modules/build/bridge-modules/bytecode_scripts/enable_bridge_feature.mv \
     --profile default \
-    --assume-yes > enable_bridge_feature_output.log 2> enable_bridge_feature_error.log
+    --assume-yes 2>&1 | tee enable_bridge_feature_output.log
 
   # Second script: store_mint_burn_caps
   movement move run-script \
     --compiled-script-path protocol-units/bridge/move-modules/build/bridge-modules/bytecode_scripts/store_mint_burn_caps.mv \
     --profile default \
-    --assume-yes > store_mint_burn_caps_output.log 2> store_mint_burn_caps_error.log
+    --assume-yes 2>&1 | tee store_mint_burn_caps_output.log
 
   echo "Move scripts executed."
 else

--- a/scripts/services/bridge/configure-bridge.sh
+++ b/scripts/services/bridge/configure-bridge.sh
@@ -37,14 +37,23 @@ fi
 
 echo "Account field updated with value: ${NEW_ACCOUNT}"
 
-# Execute the Move feature script if execute_move is true
+# Execute the Move scripts if execute_move is true
 if [ "$EXECUTE_MOVE" == "true" ]; then
-  echo "Executing Move script..."
+  echo "Executing Move scripts..."
+
+  # First script: enable_bridge_feature
   movement move run-script \
     --compiled-script-path protocol-units/bridge/move-modules/build/bridge-modules/bytecode_scripts/enable_bridge_feature.mv \
     --profile default \
     --assume-yes > enable_bridge_feature_output.log 2> enable_bridge_feature_error.log
-  echo "Move script executed."
+
+  # Second script: store_mint_burn_caps
+  movement move run-script \
+    --compiled-script-path protocol-units/bridge/move-modules/build/bridge-modules/bytecode_scripts/store_mint_burn_caps.mv \
+    --profile default \
+    --assume-yes > store_mint_burn_caps_output.log 2> store_mint_burn_caps_error.log
+
+  echo "Move scripts executed."
 else
   echo "Skipping Move script execution."
 fi

--- a/scripts/services/bridge/configure-bridge.sh
+++ b/scripts/services/bridge/configure-bridge.sh
@@ -41,7 +41,7 @@ echo "Account field updated with value: ${NEW_ACCOUNT}"
 if [ "$EXECUTE_MOVE" == "true" ]; then
   echo "Executing Move scripts..."
   movement move compile \ 
-    --package-dir protocol-units/bridge/move-modules/
+    --package-dir protocol-units/bridge/move-modules/ \
     --profile default \
     --assume-yes 
     

--- a/scripts/services/bridge/configure-bridge.sh
+++ b/scripts/services/bridge/configure-bridge.sh
@@ -40,10 +40,8 @@ echo "Account field updated with value: ${NEW_ACCOUNT}"
 # Execute the Move scripts if execute_move is true
 if [ "$EXECUTE_MOVE" == "true" ]; then
   echo "Executing Move scripts..."
-  movement move compile \ 
+  movement move compile \
     --package-dir protocol-units/bridge/move-modules/ \
-    --profile default \
-    --assume-yes 
     
   # First script: enable_bridge_feature
   movement move run-script \
@@ -61,4 +59,3 @@ if [ "$EXECUTE_MOVE" == "true" ]; then
 else
   echo "Skipping Move script execution."
 fi
-

--- a/scripts/services/bridge/configure-bridge.sh
+++ b/scripts/services/bridge/configure-bridge.sh
@@ -4,16 +4,13 @@
 MOVEMENT_DIR="./.movement"
 CONFIG_FILE="$MOVEMENT_DIR/config.yaml"
 
-# The new account value you want to set
 NEW_ACCOUNT="0xA550C18"
 
-# Check if the .movement directory exists
 if [ ! -d "$MOVEMENT_DIR" ]; then
   echo "Error: Directory $MOVEMENT_DIR not found."
   exit 1
 fi
 
-# Check if the config.yaml file exists
 if [ ! -f "$CONFIG_FILE" ]; then
   echo "Error: File $CONFIG_FILE not found."
   exit 1
@@ -29,4 +26,3 @@ else
 fi
 
 echo "Account field updated with value: ${NEW_ACCOUNT}"
-

--- a/scripts/services/bridge/configure-bridge.sh
+++ b/scripts/services/bridge/configure-bridge.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Define the directory and file paths
+MOVEMENT_DIR="./.movement"
+CONFIG_FILE="$MOVEMENT_DIR/config.yaml"
+
+# The new account value you want to set
+NEW_ACCOUNT="0xA550C18"
+
+# Check if the .movement directory exists
+if [ ! -d "$MOVEMENT_DIR" ]; then
+  echo "Error: Directory $MOVEMENT_DIR not found."
+  exit 1
+fi
+
+# Check if the config.yaml file exists
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "Error: File $CONFIG_FILE not found."
+  exit 1
+fi
+
+# Use sed to update the account field in the config.yaml file
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS (BSD sed)
+    sed -i '' "s/^    account: .*/    account: ${NEW_ACCOUNT}/" "$CONFIG_FILE"
+else
+    # Linux (GNU sed)
+    sed -i "s/^    account: .*/    account: ${NEW_ACCOUNT}/" "$CONFIG_FILE"
+fi
+
+echo "Account field updated with value: ${NEW_ACCOUNT}"
+


### PR DESCRIPTION
# Summary
Creates a script for configuring the bridge relayer once it's running. Boolean arg sets whether move scripts should be run, as these are only required to be run once. 

Note that if they are run a second time on the same network an error will be thrown:
```
"Error": "Simulation failed with status: Move abort in 0x1::transaction_fee: ECOPY_CAPS_SHOT(0x7)
```
This is expected and it indicates the the user already has the mint and burn capabilities. 

# Testing
1. Local suzuka-node should be running
2. At workspace root run 
`./scripts/services/bridge/configure-bridge.sh true`
