### PR TITLE
Instrument submitting blobs to Celestia RPC

### DIFF
--- a/protocol-units/da/m1/light-node/src/v1/passthrough.rs
+++ b/protocol-units/da/m1/light-node/src/v1/passthrough.rs
@@ -127,11 +127,14 @@ where
 
 	/// Submits a CelestiaBlob to the Celestia node.
 	pub async fn submit_celestia_blob(&self, blob: CelestiaBlob) -> Result<u64, anyhow::Error> {
-		let height = self
-			.default_client
-			.blob_submit(&[blob], GasPrice::default())
-			.await
-			.map_err(|e| anyhow::anyhow!("Failed submitting the blob: {}", e))?;
+		let height =
+			self.default_client
+				.blob_submit(&[blob], GasPrice::default())
+				.await
+				.map_err(|e| {
+					error!(error = %e, "failed to submit the blob");
+					anyhow::anyhow!("Failed submitting the blob: {}", e)
+				})?;
 
 		Ok(height)
 	}
@@ -141,11 +144,11 @@ where
 		&self,
 		blobs: &[CelestiaBlob],
 	) -> Result<u64, anyhow::Error> {
-		let height = self
-			.default_client
-			.blob_submit(blobs, GasPrice::default())
-			.await
-			.map_err(|e| anyhow::anyhow!("Failed submitting the blob: {}", e))?;
+		let height =
+			self.default_client.blob_submit(blobs, GasPrice::default()).await.map_err(|e| {
+				error!(error = %e, "failed to submit the blobs");
+				anyhow::anyhow!("Failed submitting the blob: {}", e)
+			})?;
 
 		Ok(height)
 	}
@@ -187,7 +190,7 @@ where
 		Ok(verified_blobs)
 	}
 
-	#[tracing::instrument(target = "movement_timing", level = "debug")]
+	#[tracing::instrument(target = "movement_timing", level = "info", skip(self))]
 	async fn get_blobs_at_height(&self, height: u64) -> Result<Vec<Blob>, anyhow::Error> {
 		let ir_blobs = self.get_ir_blobs_at_height(height).await?;
 		let mut blobs = Vec::new();

--- a/protocol-units/da/m1/light-node/src/v1/passthrough.rs
+++ b/protocol-units/da/m1/light-node/src/v1/passthrough.rs
@@ -132,7 +132,7 @@ where
 				.blob_submit(&[blob], GasPrice::default())
 				.await
 				.map_err(|e| {
-					error!(error = %e, "failed to submit the blob");
+					info!(error = %e, "failed to submit the blob");
 					anyhow::anyhow!("Failed submitting the blob: {}", e)
 				})?;
 
@@ -146,7 +146,7 @@ where
 	) -> Result<u64, anyhow::Error> {
 		let height =
 			self.default_client.blob_submit(blobs, GasPrice::default()).await.map_err(|e| {
-				error!(error = %e, "failed to submit the blobs");
+				info!(error = %e, "failed to submit the blobs");
 				anyhow::anyhow!("Failed submitting the blob: {}", e)
 			})?;
 
@@ -168,7 +168,7 @@ where
 		let blobs = self.default_client.blob_get_all(height, &[self.celestia_namespace]).await;
 
 		if let Err(e) = &blobs {
-			error!("Error getting blobs: {:?}", e);
+			info!(error = %e, "failed to get blobs at height {height}");
 		}
 
 		let blobs = blobs.unwrap_or_default();


### PR DESCRIPTION
# Summary
- **Categories**: `protocol-units`.

Add logging to better see problems between m1-da-light-node and Celestia RPC.

# Changelog

* m1-da-light-node: increased logging around Celestia RPC to help troubleshooting problems.

# Testing

Ran locally, seeing the errors and spans in the logs.