### PR TITLE
bump aptos-core revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,16 +11,6 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "abstract-domain-derive"
-version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "proc-macro2",
@@ -822,38 +812,24 @@ checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-gas-algebra",
  "aptos-gas-meter",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-gas-schedule",
+ "aptos-vm-types",
+ "move-binary-format",
 ]
 
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
-]
-
-[[package]]
-name = "aptos-aggregator"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "bcs 0.1.4",
- "claims",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
+ "aptos-types",
 ]
 
 [[package]]
@@ -861,34 +837,34 @@ name = "aptos-aggregator"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-logger",
+ "aptos-types",
  "bcs 0.1.4",
  "claims",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-types",
 ]
 
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "aptos-api-types",
  "aptos-bcs-utils",
  "aptos-build-info",
  "aptos-config",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-global-constants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
+ "aptos-gas-schedule",
+ "aptos-global-constants",
+ "aptos-logger",
  "aptos-mempool",
  "aptos-metrics-core",
- "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-runtimes",
  "aptos-storage-interface",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "aptos-vm",
  "async-trait",
  "bcs 0.1.4",
@@ -900,7 +876,7 @@ dependencies = [
  "itertools 0.12.1",
  "mime",
  "mini-moka",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types",
  "num_cpus",
  "once_cell",
  "paste",
@@ -915,25 +891,25 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "aptos-config",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
+ "aptos-framework",
+ "aptos-logger",
  "aptos-openapi",
  "aptos-resource-viewer",
  "aptos-storage-interface",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "aptos-vm",
  "async-trait",
  "bcs 0.1.4",
  "bytes 1.8.0",
  "hex",
  "indoc",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-binary-format",
+ "move-core-types",
  "once_cell",
  "poem",
  "poem-openapi",
@@ -945,19 +921,10 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "hex",
-]
-
-[[package]]
-name = "aptos-bitvec"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "serde",
- "serde_bytes",
 ]
 
 [[package]]
@@ -972,18 +939,18 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-aggregator",
  "aptos-drop-helper",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible",
+ "aptos-logger",
  "aptos-metrics-core",
  "aptos-mvhashmap",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "aptos-vm-logging",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-vm-types",
  "arc-swap",
  "bcs 0.1.4",
  "bytes 1.8.0",
@@ -993,9 +960,9 @@ dependencies = [
  "dashmap 5.5.3",
  "derivative",
  "fail",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-types",
  "num_cpus",
  "once_cell",
  "parking_lot",
@@ -1007,18 +974,18 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
+ "aptos-logger",
  "aptos-metrics-core",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "bcs 0.1.4",
  "clap 4.5.20",
  "dashmap 5.5.3",
  "itertools 0.12.1",
  "jemallocator",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types",
  "once_cell",
  "rand 0.7.3",
  "rayon",
@@ -1028,7 +995,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "futures",
  "rustversion",
@@ -1038,7 +1005,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "shadow-rs",
 ]
@@ -1046,24 +1013,24 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-framework",
  "aptos-package-builder",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "bcs 0.1.4",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types",
  "once_cell",
 ]
 
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible",
  "aptos-metrics-core",
  "futures",
 ]
@@ -1071,9 +1038,9 @@ dependencies = [
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger",
  "aptos-metrics-core",
  "lz4",
  "once_cell",
@@ -1083,16 +1050,16 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-global-constants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
+ "aptos-global-constants",
+ "aptos-logger",
  "aptos-secure-storage",
  "aptos-short-hex-str",
  "aptos-temppath",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "arr_macro",
  "bcs 0.1.4",
  "byteorder",
@@ -1114,17 +1081,17 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-bitvec",
+ "aptos-crypto",
+ "aptos-crypto-derive",
  "aptos-executor-types",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible",
+ "aptos-logger",
  "aptos-short-hex-str",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "bcs 0.1.4",
  "fail",
  "futures",
@@ -1141,11 +1108,11 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "aes-gcm",
  "anyhow",
- "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto-derive",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.4.2",
@@ -1189,67 +1156,6 @@ dependencies = [
  "tiny-keccak",
  "typenum",
  "x25519-dalek",
-]
-
-[[package]]
-name = "aptos-crypto"
-version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
-dependencies = [
- "aes-gcm",
- "anyhow",
- "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-groth16",
- "ark-std 0.4.0",
- "base64 0.13.1",
- "bcs 0.1.4",
- "blst",
- "bulletproofs",
- "bytes 1.8.0",
- "curve25519-dalek",
- "curve25519-dalek-ng",
- "digest 0.9.0",
- "ed25519-dalek",
- "ff 0.13.0",
- "hex",
- "hkdf 0.10.0",
- "libsecp256k1",
- "merlin",
- "more-asserts",
- "neptune",
- "num-bigint 0.3.3",
- "num-integer",
- "once_cell",
- "p256 0.13.2",
- "poseidon-ark",
- "rand 0.7.3",
- "rand_core 0.5.1",
- "ring 0.16.20",
- "serde",
- "serde-name",
- "serde_bytes",
- "sha2 0.10.8",
- "sha2 0.9.9",
- "sha3",
- "signature 2.2.0",
- "static_assertions",
- "thiserror",
- "tiny-keccak",
- "typenum",
- "x25519-dalek",
-]
-
-[[package]]
-name = "aptos-crypto-derive"
-version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1265,20 +1171,20 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
  "aptos-config",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
  "aptos-db-indexer",
  "aptos-db-indexer-schemas",
  "aptos-executor",
  "aptos-executor-types",
- "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-experimental-runtimes",
+ "aptos-infallible",
  "aptos-jellyfish-merkle",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger",
  "aptos-metrics-core",
  "aptos-proptest-helpers",
  "aptos-resource-viewer",
@@ -1287,7 +1193,7 @@ dependencies = [
  "aptos-scratchpad",
  "aptos-storage-interface",
  "aptos-temppath",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "arc-swap",
  "arr_macro",
  "bcs 0.1.4",
@@ -1298,7 +1204,7 @@ dependencies = [
  "hex",
  "itertools 0.12.1",
  "lru 0.7.8",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types",
  "num-derive",
  "once_cell",
  "proptest",
@@ -1313,32 +1219,32 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "aptos-config",
  "aptos-db-indexer-schemas",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger",
  "aptos-resource-viewer",
  "aptos-rocksdb-options",
  "aptos-schemadb",
  "aptos-storage-interface",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "bcs 0.1.4",
  "bytes 1.8.0",
  "dashmap 5.5.3",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types",
 ]
 
 [[package]]
 name = "aptos-db-indexer-schemas"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "aptos-schemadb",
  "aptos-storage-interface",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "bcs 0.1.4",
  "byteorder",
  "serde",
@@ -1347,42 +1253,11 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "bcs 0.1.4",
- "blst",
- "blstrs",
- "criterion",
- "ff 0.13.0",
- "group 0.13.0",
- "hex",
- "merlin",
- "more-asserts",
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
- "once_cell",
- "pairing",
- "rand 0.7.3",
- "rand_core 0.5.1",
- "rayon",
- "serde",
- "serde_bytes",
- "sha3",
- "static_assertions",
-]
-
-[[package]]
-name = "aptos-dkg"
-version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-crypto",
+ "aptos-crypto-derive",
  "bcs 0.1.4",
  "blst",
  "blstrs",
@@ -1409,9 +1284,9 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible",
  "aptos-metrics-core",
  "once_cell",
  "threadpool",
@@ -1420,14 +1295,14 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "aptos-channels",
  "aptos-id-generator",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible",
  "aptos-storage-interface",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "futures",
  "serde",
  "thiserror",
@@ -1436,22 +1311,22 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "aptos-consensus-types",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
  "aptos-drop-helper",
  "aptos-executor-service",
  "aptos-executor-types",
- "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-experimental-runtimes",
+ "aptos-infallible",
+ "aptos-logger",
  "aptos-metrics-core",
  "aptos-scratchpad",
  "aptos-sdk",
  "aptos-storage-interface",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "aptos-vm",
  "arr_macro",
  "bcs 0.1.4",
@@ -1459,7 +1334,7 @@ dependencies = [
  "dashmap 5.5.3",
  "fail",
  "itertools 0.12.1",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types",
  "once_cell",
  "rayon",
  "serde",
@@ -1468,19 +1343,19 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "aptos-block-partitioner",
  "aptos-config",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible",
  "aptos-language-e2e-tests",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger",
  "aptos-metrics-core",
  "aptos-node-resource-metrics",
  "aptos-push-metrics",
  "aptos-secure-net",
  "aptos-storage-interface",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "aptos-vm",
  "bcs 0.1.4",
  "clap 4.5.20",
@@ -1498,20 +1373,20 @@ dependencies = [
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
  "aptos-config",
  "aptos-consensus-types",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
  "aptos-db",
  "aptos-executor",
  "aptos-executor-types",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "aptos-vm",
  "aptos-vm-genesis",
  "rand 0.7.3",
@@ -1520,15 +1395,15 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
  "aptos-drop-helper",
  "aptos-scratchpad",
  "aptos-secure-net",
  "aptos-storage-interface",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "bcs 0.1.4",
  "criterion",
  "itertools 0.12.1",
@@ -1540,22 +1415,9 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "core_affinity",
- "libc",
- "num_cpus",
- "once_cell",
- "rayon",
-]
-
-[[package]]
-name = "aptos-experimental-runtimes"
-version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-runtimes",
  "core_affinity",
  "libc",
  "num_cpus",
@@ -1566,12 +1428,12 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "aptos-config",
  "aptos-faucet-metrics-server",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger",
  "aptos-metrics-core",
  "aptos-sdk",
  "async-trait",
@@ -1600,10 +1462,10 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger",
  "aptos-metrics-core",
  "once_cell",
  "poem",
@@ -1614,18 +1476,18 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-sdk-builder 0.2.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-aggregator",
+ "aptos-crypto",
+ "aptos-gas-algebra",
+ "aptos-gas-schedule",
+ "aptos-move-stdlib",
+ "aptos-native-interface",
+ "aptos-sdk-builder",
+ "aptos-types",
+ "aptos-vm-types",
  "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
@@ -1648,88 +1510,20 @@ dependencies = [
  "log",
  "lru 0.7.8",
  "merlin",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-cli 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-prover-boogie-backend 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "num-traits",
- "once_cell",
- "rand 0.7.3",
- "rand_core 0.5.1",
- "ripemd",
- "serde",
- "serde_bytes",
- "sha2 0.10.8",
- "sha2 0.9.9",
- "sha3",
- "siphasher",
- "smallvec",
- "tempfile",
- "thiserror",
- "tiny-keccak",
-]
-
-[[package]]
-name = "aptos-framework"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
-dependencies = [
- "anyhow",
- "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-sdk-builder 0.2.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "bcs 0.1.4",
- "better_any",
- "blake2-rfc",
- "bulletproofs",
- "byteorder",
- "clap 4.5.20",
- "codespan-reporting",
- "curve25519-dalek-ng",
- "either",
- "flate2",
- "hex",
- "itertools 0.12.1",
- "libsecp256k1",
- "log",
- "lru 0.7.8",
- "merlin",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-cli 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-prover-boogie-backend 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-cli",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-docgen",
+ "move-model",
+ "move-package",
+ "move-prover",
+ "move-prover-boogie-backend",
+ "move-prover-bytecode-pipeline",
+ "move-stackless-bytecode",
+ "move-vm-runtime",
+ "move-vm-types",
  "num-traits",
  "once_cell",
  "rand 0.7.3",
@@ -1750,51 +1544,42 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "either",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
-]
-
-[[package]]
-name = "aptos-gas-algebra"
-version = "0.0.1"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "either",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types",
 ]
 
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-gas-algebra",
+ "aptos-gas-schedule",
+ "aptos-logger",
+ "aptos-types",
+ "aptos-vm-types",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-types",
 ]
 
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-gas-algebra",
  "aptos-gas-meter",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
+ "aptos-vm-types",
  "handlebars",
  "inferno",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-types",
  "regex",
  "serde_json",
  "smallvec",
@@ -1803,33 +1588,15 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-global-constants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "paste",
- "rand 0.7.3",
-]
-
-[[package]]
-name = "aptos-gas-schedule"
-version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-global-constants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-gas-algebra",
+ "aptos-global-constants",
+ "move-core-types",
+ "move-vm-types",
  "paste",
  "rand 0.7.3",
 ]
-
-[[package]]
-name = "aptos-global-constants"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 
 [[package]]
 name = "aptos-global-constants"
@@ -1839,24 +1606,24 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 
 [[package]]
 name = "aptos-indexer"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "aptos-api",
  "aptos-api-types",
- "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-bitvec",
  "aptos-config",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger",
  "aptos-mempool",
  "aptos-metrics-core",
- "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-runtimes",
  "aptos-storage-interface",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "async-trait",
  "bcs 0.1.4",
  "bigdecimal",
@@ -1876,22 +1643,22 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "aptos-api",
  "aptos-api-types",
- "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-bitvec",
  "aptos-config",
  "aptos-indexer-grpc-utils",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger",
  "aptos-mempool",
  "aptos-metrics-core",
  "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors)",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-runtimes",
  "aptos-storage-interface",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "bcs 0.1.4",
  "bytes 1.8.0",
  "chrono",
@@ -1899,9 +1666,9 @@ dependencies = [
  "hex",
  "hyper 0.14.31",
  "itertools 0.12.1",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-binary-format",
+ "move-core-types",
+ "move-package",
  "once_cell",
  "serde",
  "serde_json",
@@ -1914,7 +1681,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-table-info"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1923,12 +1690,12 @@ dependencies = [
  "aptos-db-indexer",
  "aptos-indexer-grpc-fullnode",
  "aptos-indexer-grpc-utils",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger",
  "aptos-mempool",
- "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-runtimes",
  "aptos-schemadb",
  "aptos-storage-interface",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "flate2",
  "futures",
  "google-cloud-storage",
@@ -1945,11 +1712,11 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-utils"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "async-trait",
  "backoff",
  "base64 0.13.1",
@@ -1977,27 +1744,22 @@ dependencies = [
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-
-[[package]]
-name = "aptos-infallible"
-version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
+ "aptos-crypto-derive",
+ "aptos-experimental-runtimes",
+ "aptos-infallible",
+ "aptos-logger",
  "aptos-metrics-core",
  "aptos-storage-interface",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "arr_macro",
  "bcs 0.1.4",
  "byteorder",
@@ -2015,47 +1777,47 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
+ "aptos-types",
  "rand 0.7.3",
 ]
 
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
- "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-bitvec",
  "aptos-block-executor",
  "aptos-cached-packages",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
+ "aptos-framework",
+ "aptos-gas-algebra",
  "aptos-gas-meter",
  "aptos-gas-profiling",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-gas-schedule",
  "aptos-keygen",
  "aptos-proptest-helpers",
  "aptos-temppath",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "aptos-vm",
  "aptos-vm-genesis",
  "aptos-vm-logging",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-vm-types",
  "bcs 0.1.4",
  "bytes 1.8.0",
  "goldenfile",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-binary-format",
+ "move-command-line-common",
+ "move-core-types",
  "move-ir-compiler",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-model",
+ "move-vm-runtime",
+ "move-vm-types",
  "num_cpus",
  "once_cell",
  "petgraph 0.5.1",
@@ -2069,10 +1831,10 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
+ "aptos-types",
  "hex",
  "ledger-apdu",
  "ledger-transport-hid",
@@ -2082,16 +1844,6 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "aptos-log-derive"
-version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "proc-macro2",
@@ -2102,35 +1854,11 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-log-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-node-identity 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "backtrace",
- "chrono",
- "erased-serde",
- "futures",
- "hostname",
- "once_cell",
- "prometheus",
- "serde",
- "serde_json",
- "strum 0.24.1",
- "strum_macros 0.24.3",
- "tokio",
- "tracing",
- "tracing-subscriber 0.3.18",
-]
-
-[[package]]
-name = "aptos-logger"
-version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-log-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-node-identity 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-infallible",
+ "aptos-log-derive",
+ "aptos-node-identity",
  "backtrace",
  "chrono",
  "erased-serde",
@@ -2150,40 +1878,40 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-gas-algebra",
  "aptos-gas-meter",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-types",
 ]
 
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
  "aptos-consensus-types",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
  "aptos-event-notifications",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible",
+ "aptos-logger",
  "aptos-mempool-notifications",
  "aptos-metrics-core",
  "aptos-netcore",
  "aptos-network",
  "aptos-peer-monitoring-service-types",
- "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-runtimes",
  "aptos-short-hex-str",
  "aptos-storage-interface",
  "aptos-time-service",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "aptos-vm-validator",
  "bcs 0.1.4",
  "fail",
@@ -2203,9 +1931,9 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "async-trait",
  "futures",
  "serde",
@@ -2216,9 +1944,9 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible",
  "bytes 1.8.0",
  "futures",
  "once_cell",
@@ -2227,7 +1955,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -2236,28 +1964,13 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "sha2 0.9.9",
- "sha3",
- "smallvec",
-]
-
-[[package]]
-name = "aptos-move-stdlib"
-version = "0.1.1"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-gas-schedule",
+ "aptos-native-interface",
+ "move-core-types",
+ "move-vm-runtime",
+ "move-vm-types",
  "sha2 0.9.9",
  "sha3",
  "smallvec",
@@ -2282,39 +1995,22 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-aggregator",
+ "aptos-crypto",
+ "aptos-types",
+ "aptos-vm-types",
  "bytes 1.8.0",
  "claims",
  "crossbeam",
  "dashmap 5.5.3",
  "derivative",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-types",
  "serde",
-]
-
-[[package]]
-name = "aptos-native-interface"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "bcs 0.1.4",
- "bytes 1.8.0",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "smallvec",
 ]
 
 [[package]]
@@ -2322,26 +2018,26 @@ name = "aptos-native-interface"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-gas-algebra",
+ "aptos-gas-schedule",
+ "aptos-types",
  "bcs 0.1.4",
  "bytes 1.8.0",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-runtime",
+ "move-vm-types",
  "smallvec",
 ]
 
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "bytes 1.8.0",
  "futures",
  "pin-project 1.1.6",
@@ -2354,24 +2050,24 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-bitvec",
  "aptos-channels",
  "aptos-compression",
  "aptos-config",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
  "aptos-id-generator",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible",
+ "aptos-logger",
  "aptos-metrics-core",
  "aptos-netcore",
  "aptos-num-variants",
  "aptos-peer-monitoring-service-types",
  "aptos-short-hex-str",
  "aptos-time-service",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "arc-swap",
  "async-trait",
  "bcs 0.1.4",
@@ -2399,21 +2095,10 @@ dependencies = [
 [[package]]
 name = "aptos-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "claims",
- "once_cell",
-]
-
-[[package]]
-name = "aptos-node-identity"
-version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-types",
  "claims",
  "once_cell",
 ]
@@ -2421,11 +2106,11 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "aptos-build-info",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible",
+ "aptos-logger",
  "aptos-metrics-core",
  "cfg-if",
  "once_cell",
@@ -2437,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2447,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -2460,23 +2145,23 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-framework",
  "itertools 0.12.1",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-command-line-common",
+ "move-package",
  "tempfile",
 ]
 
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "aptos-config",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "bcs 0.1.4",
  "serde",
  "thiserror",
@@ -2498,7 +2183,7 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -2520,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -2532,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "ipnet",
 ]
@@ -2540,9 +2225,9 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger",
  "aptos-metrics-core",
  "ureq",
  "url",
@@ -2551,32 +2236,32 @@ dependencies = [
 [[package]]
 name = "aptos-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "aptos-vm",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-resource-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
+ "move-resource-viewer",
 ]
 
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "aptos-api-types",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
+ "aptos-infallible",
+ "aptos-logger",
+ "aptos-types",
  "bcs 0.1.4",
  "bytes 1.8.0",
  "hex",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -2588,19 +2273,10 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "aptos-config",
  "rocksdb",
-]
-
-[[package]]
-name = "aptos-runtimes"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "rayon",
- "tokio",
 ]
 
 [[package]]
@@ -2615,11 +2291,11 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible",
+ "aptos-logger",
  "aptos-metrics-core",
  "aptos-storage-interface",
  "dunce",
@@ -2632,14 +2308,14 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
  "aptos-drop-helper",
- "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-experimental-runtimes",
+ "aptos-infallible",
  "aptos-metrics-core",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "bitvec 1.0.1",
  "itertools 0.12.1",
  "once_cell",
@@ -2651,20 +2327,20 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-global-constants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
+ "aptos-global-constants",
  "aptos-ledger",
  "aptos-rest-client",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "base64 0.13.1",
  "bcs 0.1.4",
  "ed25519-dalek-bip32",
  "hex",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types",
  "rand_core 0.5.1",
  "serde_json",
  "tiny-bip39",
@@ -2673,32 +2349,14 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "bcs 0.1.4",
- "clap 4.5.20",
- "heck 0.4.1",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "once_cell",
- "serde-generate",
- "serde-reflection",
- "serde_yaml 0.8.26",
- "textwrap 0.15.2",
-]
-
-[[package]]
-name = "aptos-sdk-builder"
-version = "0.2.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-types",
  "bcs 0.1.4",
  "clap 4.5.20",
  "heck 0.4.1",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types",
  "once_cell",
  "serde-generate",
  "serde-reflection",
@@ -2709,11 +2367,11 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger",
  "aptos-metrics-core",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "bcs 0.1.4",
  "crossbeam-channel",
  "once_cell",
@@ -2727,11 +2385,11 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
+ "aptos-infallible",
+ "aptos-logger",
  "aptos-temppath",
  "aptos-time-service",
  "aptos-vault-client",
@@ -2748,7 +2406,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -2759,10 +2417,10 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible",
  "crossbeam",
  "rayon",
 ]
@@ -2770,21 +2428,21 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
+ "aptos-experimental-runtimes",
+ "aptos-logger",
  "aptos-metrics-core",
  "aptos-scratchpad",
  "aptos-secure-net",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "aptos-vm",
  "bcs 0.1.4",
  "crossbeam-channel",
  "dashmap 5.5.3",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types",
  "once_cell",
  "parking_lot",
  "proptest",
@@ -2818,17 +2476,17 @@ dependencies = [
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-gas-schedule",
+ "aptos-native-interface",
  "better_any",
  "bytes 1.8.0",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-table-extension 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-binary-format",
+ "move-core-types",
+ "move-table-extension",
+ "move-vm-runtime",
+ "move-vm-types",
  "sha3",
  "smallvec",
 ]
@@ -2836,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -2845,9 +2503,9 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible",
  "enum_dispatch",
  "futures",
  "pin-project 1.1.6",
@@ -2858,15 +2516,15 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-dkg 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-bitvec",
+ "aptos-crypto",
+ "aptos-crypto-derive",
+ "aptos-dkg",
+ "aptos-experimental-runtimes",
+ "aptos-infallible",
  "ark-bn254",
  "ark-ff 0.4.2",
  "ark-groth16",
@@ -2881,12 +2539,12 @@ dependencies = [
  "hex",
  "itertools 0.12.1",
  "jsonwebtoken 8.3.0",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-table-extension 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-binary-format",
+ "move-bytecode-verifier",
+ "move-core-types",
+ "move-table-extension",
+ "move-vm-runtime",
+ "move-vm-types",
  "num-bigint 0.3.3",
  "num-derive",
  "num-traits",
@@ -2913,71 +2571,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "aptos-types"
-version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
-dependencies = [
- "anyhow",
- "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-dkg 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "ark-bn254",
- "ark-ff 0.4.2",
- "ark-groth16",
- "ark-serialize 0.4.2",
- "arr_macro",
- "base64 0.13.1",
- "bcs 0.1.4",
- "bytes 1.8.0",
- "fixed",
- "fxhash",
- "hashbrown 0.14.5",
- "hex",
- "itertools 0.12.1",
- "jsonwebtoken 8.3.0",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-table-extension 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "num-bigint 0.3.3",
- "num-derive",
- "num-traits",
- "once_cell",
- "passkey-types",
- "poem-openapi",
- "poem-openapi-derive",
- "quick_cache",
- "rand 0.7.3",
- "rayon",
- "ring 0.16.20",
- "rsa 0.9.6",
- "serde",
- "serde-big-array",
- "serde_bytes",
- "serde_json",
- "serde_with",
- "serde_yaml 0.8.26",
- "strum 0.24.1",
- "strum_macros 0.24.3",
- "thiserror",
-]
-
-[[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
  "base64 0.13.1",
  "chrono",
  "native-tls",
@@ -2991,31 +2594,31 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-aggregator",
  "aptos-block-executor",
  "aptos-block-partitioner",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
+ "aptos-crypto-derive",
+ "aptos-experimental-runtimes",
+ "aptos-framework",
+ "aptos-gas-algebra",
  "aptos-gas-meter",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-gas-schedule",
+ "aptos-infallible",
+ "aptos-logger",
  "aptos-memory-usage-tracker",
  "aptos-metrics-core",
- "aptos-move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-move-stdlib",
  "aptos-mvhashmap",
- "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-native-interface",
  "aptos-table-natives",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "aptos-utils",
  "aptos-vm-logging",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-vm-types",
  "ark-bn254",
  "ark-groth16",
  "bcs 0.1.4",
@@ -3026,10 +2629,10 @@ dependencies = [
  "fail",
  "futures",
  "hex",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-runtime",
+ "move-vm-types",
  "num_cpus",
  "once_cell",
  "ouroboros",
@@ -3041,19 +2644,19 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "aptos-cached-packages",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
+ "aptos-framework",
+ "aptos-gas-schedule",
+ "aptos-types",
  "aptos-vm",
  "bcs 0.1.4",
  "bytes 1.8.0",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types",
+ "move-vm-runtime",
+ "move-vm-types",
  "once_cell",
  "rand 0.7.3",
  "serde",
@@ -3062,37 +2665,15 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
+ "aptos-logger",
  "aptos-metrics-core",
  "aptos-speculative-state-helper",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "arc-swap",
  "once_cell",
- "serde",
-]
-
-[[package]]
-name = "aptos-vm-types"
-version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "bcs 0.1.4",
- "bytes 1.8.0",
- "claims",
- "either",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "rand 0.7.3",
  "serde",
 ]
 
@@ -3102,18 +2683,18 @@ version = "0.0.1"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-aggregator",
+ "aptos-gas-algebra",
+ "aptos-gas-schedule",
+ "aptos-types",
  "bcs 0.1.4",
  "bytes 1.8.0",
  "claims",
  "either",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-runtime",
+ "move-vm-types",
  "rand 0.7.3",
  "serde",
 ]
@@ -3121,12 +2702,12 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger",
  "aptos-storage-interface",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "aptos-vm",
  "aptos-vm-logging",
  "fail",
@@ -4503,7 +4084,7 @@ version = "0.0.2"
 dependencies = [
  "alloy",
  "anyhow",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
  "aptos-sdk",
  "dot-movement",
  "godfig",
@@ -4533,11 +4114,11 @@ dependencies = [
  "alloy-network",
  "alloy-sol-types",
  "anyhow",
- "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-framework",
  "aptos-language-e2e-tests",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger",
  "aptos-sdk",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "bcs 0.1.4",
  "bridge-config",
  "bridge-grpc",
@@ -4572,7 +4153,7 @@ dependencies = [
  "aptos-api",
  "aptos-api-types",
  "aptos-sdk",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "async-stream",
  "async-trait",
  "bcs 0.1.4",
@@ -7620,9 +7201,9 @@ version = "0.0.2"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
- "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-framework",
  "aptos-sdk",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "bcs 0.1.4",
  "chrono",
  "futures",
@@ -8999,12 +8580,12 @@ dependencies = [
  "anyhow",
  "aptos-api",
  "aptos-config",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
  "aptos-db",
  "aptos-mempool",
  "aptos-proptest-helpers",
  "aptos-sdk",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "async-trait",
  "chrono",
  "futures",
@@ -9023,9 +8604,9 @@ name = "maptos-execution-util"
 version = "0.0.2"
 dependencies = [
  "anyhow",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
  "aptos-sdk",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "godfig",
  "hex",
  "m1-da-light-node-util",
@@ -9047,7 +8628,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-sdk",
  "aptos-storage-interface",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "chrono",
  "futures",
  "maptos-execution-util",
@@ -9065,33 +8646,33 @@ dependencies = [
  "anyhow",
  "aptos-api",
  "aptos-api-types",
- "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-bitvec",
  "aptos-block-executor",
  "aptos-cached-packages",
  "aptos-config",
  "aptos-consensus-types",
- "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto",
  "aptos-db",
  "aptos-executor",
  "aptos-executor-test-helpers",
  "aptos-executor-types",
  "aptos-faucet-core",
- "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-framework",
  "aptos-indexer",
  "aptos-indexer-grpc-fullnode",
  "aptos-indexer-grpc-table-info",
  "aptos-language-e2e-tests",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger",
  "aptos-mempool",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "aptos-vm",
  "aptos-vm-genesis",
  "aptos-vm-logging",
- "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-vm-types",
  "aptos-vm-validator",
  "async-trait",
  "bcs 0.1.4",
@@ -9427,50 +9008,18 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "bcs 0.1.4",
- "heck 0.4.1",
- "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "serde",
-]
-
-[[package]]
-name = "move-abigen"
-version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
  "heck 0.4.1",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-bytecode-verifier",
+ "move-command-line-common",
+ "move-core-types",
+ "move-model",
  "serde",
-]
-
-[[package]]
-name = "move-binary-format"
-version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "backtrace",
- "indexmap 1.9.3",
- "move-bytecode-spec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "ref-cast",
- "serde",
- "variant_count",
 ]
 
 [[package]]
@@ -9481,8 +9030,8 @@ dependencies = [
  "anyhow",
  "backtrace",
  "indexmap 1.9.3",
- "move-bytecode-spec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-spec",
+ "move-core-types",
  "ref-cast",
  "serde",
  "variant_count",
@@ -9491,27 +9040,7 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-
-[[package]]
-name = "move-borrow-graph"
-version = "0.0.1"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
-
-[[package]]
-name = "move-bytecode-source-map"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "bcs 0.1.4",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "serde",
-]
 
 [[package]]
 name = "move-bytecode-source-map"
@@ -9520,22 +9049,12 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-types",
+ "move-symbol-pool",
  "serde",
-]
-
-[[package]]
-name = "move-bytecode-spec"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "once_cell",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -9551,39 +9070,13 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "petgraph 0.5.1",
- "serde-reflection",
-]
-
-[[package]]
-name = "move-bytecode-utils"
-version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-core-types",
  "petgraph 0.5.1",
  "serde-reflection",
-]
-
-[[package]]
-name = "move-bytecode-verifier"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "fail",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-borrow-graph 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "petgraph 0.5.1",
- "serde",
- "typed-arena",
 ]
 
 [[package]]
@@ -9592,27 +9085,12 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "fail",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-borrow-graph 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-borrow-graph",
+ "move-core-types",
  "petgraph 0.5.1",
  "serde",
  "typed-arena",
-]
-
-[[package]]
-name = "move-bytecode-viewer"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "clap 4.5.20",
- "crossterm 0.26.1",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "regex",
- "tui",
 ]
 
 [[package]]
@@ -9623,41 +9101,11 @@ dependencies = [
  "anyhow",
  "clap 4.5.20",
  "crossterm 0.26.1",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-disassembler",
  "regex",
  "tui",
-]
-
-[[package]]
-name = "move-cli"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "clap 4.5.20",
- "codespan-reporting",
- "colored",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-coverage 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-errmapgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-unit-test 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-test-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "once_cell",
- "tempfile",
 ]
 
 [[package]]
@@ -9669,42 +9117,25 @@ dependencies = [
  "clap 4.5.20",
  "codespan-reporting",
  "colored",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-bytecode-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-coverage 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-errmapgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-unit-test 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-test-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-bytecode-viewer",
+ "move-command-line-common",
+ "move-compiler",
+ "move-compiler-v2",
+ "move-core-types",
+ "move-coverage",
+ "move-disassembler",
+ "move-docgen",
+ "move-errmapgen",
+ "move-model",
+ "move-package",
+ "move-prover",
+ "move-stdlib",
+ "move-unit-test",
+ "move-vm-runtime",
+ "move-vm-test-utils",
  "once_cell",
  "tempfile",
-]
-
-[[package]]
-name = "move-command-line-common"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "difference",
- "dirs-next",
- "hex",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "num-bigint 0.3.3",
- "once_cell",
- "serde",
- "sha2 0.9.9",
- "walkdir",
 ]
 
 [[package]]
@@ -9716,7 +9147,7 @@ dependencies = [
  "difference",
  "dirs-next",
  "hex",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types",
  "num-bigint 0.3.3",
  "once_cell",
  "serde",
@@ -9727,32 +9158,6 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "bcs 0.1.4",
- "clap 4.5.20",
- "codespan-reporting",
- "hex",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-borrow-graph 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-ir-to-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "once_cell",
- "petgraph 0.5.1",
- "regex",
- "sha3",
- "tempfile",
-]
-
-[[package]]
-name = "move-compiler"
-version = "0.0.1"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
@@ -9760,15 +9165,15 @@ dependencies = [
  "clap 4.5.20",
  "codespan-reporting",
  "hex",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-borrow-graph 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-ir-to-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-borrow-graph",
+ "move-bytecode-source-map",
+ "move-bytecode-verifier",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-to-bytecode",
+ "move-ir-types",
+ "move-symbol-pool",
  "once_cell",
  "petgraph 0.5.1",
  "regex",
@@ -9779,40 +9184,9 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "abstract-domain-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "anyhow",
- "bcs 0.1.4",
- "clap 4.5.20",
- "codespan-reporting",
- "ethnum",
- "flexi_logger",
- "im",
- "itertools 0.12.1",
- "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "num",
- "once_cell",
- "petgraph 0.5.1",
-]
-
-[[package]]
-name = "move-compiler-v2"
-version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "abstract-domain-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "abstract-domain-derive",
  "anyhow",
  "bcs 0.1.4",
  "clap 4.5.20",
@@ -9822,17 +9196,17 @@ dependencies = [
  "im",
  "itertools 0.12.1",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-bytecode-verifier",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-disassembler",
+ "move-ir-types",
+ "move-model",
+ "move-stackless-bytecode",
+ "move-symbol-pool",
  "num",
  "once_cell",
  "petgraph 0.5.1",
@@ -9841,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -9864,47 +9238,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "move-core-types"
-version = "0.0.4"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
-dependencies = [
- "anyhow",
- "bcs 0.1.4",
- "bytes 1.8.0",
- "ethnum",
- "hashbrown 0.14.5",
- "hex",
- "num",
- "once_cell",
- "primitive-types 0.10.1",
- "rand 0.8.5",
- "ref-cast",
- "serde",
- "serde_bytes",
- "thiserror",
- "uint",
-]
-
-[[package]]
-name = "move-coverage"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "bcs 0.1.4",
- "clap 4.5.20",
- "codespan",
- "colored",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "petgraph 0.5.1",
- "serde",
-]
-
-[[package]]
 name = "move-coverage"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
@@ -9914,30 +9247,13 @@ dependencies = [
  "clap 4.5.20",
  "codespan",
  "colored",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-types",
  "petgraph 0.5.1",
  "serde",
-]
-
-[[package]]
-name = "move-disassembler"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "clap 4.5.20",
- "colored",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-coverage 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
 ]
 
 [[package]]
@@ -9948,32 +9264,13 @@ dependencies = [
  "anyhow",
  "clap 4.5.20",
  "colored",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-coverage 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
-]
-
-[[package]]
-name = "move-docgen"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "clap 4.5.20",
- "codespan",
- "codespan-reporting",
- "itertools 0.12.1",
- "log",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "once_cell",
- "regex",
- "serde",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-coverage",
+ "move-ir-types",
 ]
 
 [[package]]
@@ -9987,23 +9284,11 @@ dependencies = [
  "codespan-reporting",
  "itertools 0.12.1",
  "log",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-compiler",
+ "move-core-types",
+ "move-model",
  "once_cell",
  "regex",
- "serde",
-]
-
-[[package]]
-name = "move-errmapgen"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "serde",
 ]
 
@@ -10013,75 +9298,44 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-command-line-common",
+ "move-core-types",
+ "move-model",
  "serde",
 ]
 
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
  "clap 4.5.20",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-ir-to-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-bytecode-verifier",
+ "move-command-line-common",
+ "move-ir-to-bytecode",
  "serde_json",
 ]
 
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "codespan-reporting",
- "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-ir-to-bytecode-syntax 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "ouroboros",
-]
-
-[[package]]
-name = "move-ir-to-bytecode"
-version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "codespan-reporting",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-ir-to-bytecode-syntax 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-to-bytecode-syntax",
+ "move-ir-types",
+ "move-symbol-pool",
  "ouroboros",
-]
-
-[[package]]
-name = "move-ir-to-bytecode-syntax"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "hex",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
 ]
 
 [[package]]
@@ -10091,23 +9345,10 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d
 dependencies = [
  "anyhow",
  "hex",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
-]
-
-[[package]]
-name = "move-ir-types"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "hex",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "once_cell",
- "serde",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-types",
+ "move-symbol-pool",
 ]
 
 [[package]]
@@ -10116,36 +9357,10 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "hex",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-command-line-common",
+ "move-core-types",
+ "move-symbol-pool",
  "once_cell",
- "serde",
-]
-
-[[package]]
-name = "move-model"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "codespan",
- "codespan-reporting",
- "internment",
- "itertools 0.12.1",
- "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "num",
- "num-traits",
- "once_cell",
- "regex",
  "serde",
 ]
 
@@ -10160,53 +9375,19 @@ dependencies = [
  "internment",
  "itertools 0.12.1",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-disassembler",
+ "move-ir-types",
+ "move-symbol-pool",
  "num",
  "num-traits",
  "once_cell",
  "regex",
  "serde",
-]
-
-[[package]]
-name = "move-package"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "clap 4.5.20",
- "colored",
- "itertools 0.12.1",
- "move-abigen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "named-lock",
- "once_cell",
- "petgraph 0.5.1",
- "regex",
- "serde",
- "serde_yaml 0.8.26",
- "sha2 0.9.9",
- "tempfile",
- "termcolor",
- "toml 0.7.8",
- "walkdir",
- "whoami",
 ]
 
 [[package]]
@@ -10218,17 +9399,17 @@ dependencies = [
  "clap 4.5.20",
  "colored",
  "itertools 0.12.1",
- "move-abigen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-abigen",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-bytecode-utils",
+ "move-command-line-common",
+ "move-compiler",
+ "move-compiler-v2",
+ "move-core-types",
+ "move-docgen",
+ "move-model",
+ "move-symbol-pool",
  "named-lock",
  "once_cell",
  "petgraph 0.5.1",
@@ -10246,33 +9427,6 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "atty",
- "clap 4.5.20",
- "codespan-reporting",
- "itertools 0.12.1",
- "log",
- "move-abigen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-errmapgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-prover-boogie-backend 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "once_cell",
- "serde",
- "simplelog",
- "toml 0.7.8",
-]
-
-[[package]]
-name = "move-prover"
-version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
@@ -10281,49 +9435,20 @@ dependencies = [
  "codespan-reporting",
  "itertools 0.12.1",
  "log",
- "move-abigen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-errmapgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-prover-boogie-backend 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-abigen",
+ "move-command-line-common",
+ "move-compiler",
+ "move-compiler-v2",
+ "move-docgen",
+ "move-errmapgen",
+ "move-model",
+ "move-prover-boogie-backend",
+ "move-prover-bytecode-pipeline",
+ "move-stackless-bytecode",
  "once_cell",
  "serde",
  "simplelog",
  "toml 0.7.8",
-]
-
-[[package]]
-name = "move-prover-boogie-backend"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "async-trait",
- "codespan",
- "codespan-reporting",
- "futures",
- "itertools 0.12.1",
- "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "num",
- "once_cell",
- "pretty",
- "rand 0.7.3",
- "regex",
- "serde",
- "tera",
- "tokio",
 ]
 
 [[package]]
@@ -10338,13 +9463,13 @@ dependencies = [
  "futures",
  "itertools 0.12.1",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-model",
+ "move-prover-bytecode-pipeline",
+ "move-stackless-bytecode",
  "num",
  "once_cell",
  "pretty",
@@ -10358,47 +9483,17 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "abstract-domain-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "anyhow",
- "codespan-reporting",
- "itertools 0.12.1",
- "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "serde",
-]
-
-[[package]]
-name = "move-prover-bytecode-pipeline"
-version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "abstract-domain-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "abstract-domain-derive",
  "anyhow",
  "codespan-reporting",
  "itertools 0.12.1",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "serde",
-]
-
-[[package]]
-name = "move-resource-viewer"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "hex",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-binary-format",
+ "move-core-types",
+ "move-model",
+ "move-stackless-bytecode",
  "serde",
 ]
 
@@ -10409,9 +9504,9 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d
 dependencies = [
  "anyhow",
  "hex",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
  "serde",
 ]
 
@@ -10432,62 +9527,20 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "abstract-domain-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "codespan-reporting",
- "ethnum",
- "im",
- "itertools 0.12.1",
- "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "num",
- "paste",
- "petgraph 0.5.1",
-]
-
-[[package]]
-name = "move-stackless-bytecode"
-version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
- "abstract-domain-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "abstract-domain-derive",
  "codespan-reporting",
  "ethnum",
  "im",
  "itertools 0.12.1",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-core-types",
+ "move-model",
  "num",
  "paste",
  "petgraph 0.5.1",
-]
-
-[[package]]
-name = "move-stdlib"
-version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "hex",
- "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-errmapgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "sha2 0.9.9",
- "sha3",
- "smallvec",
- "walkdir",
 ]
 
 [[package]]
@@ -10498,28 +9551,19 @@ dependencies = [
  "anyhow",
  "hex",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-errmapgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-docgen",
+ "move-errmapgen",
+ "move-prover",
+ "move-vm-runtime",
+ "move-vm-types",
  "sha2 0.9.9",
  "sha3",
  "smallvec",
  "walkdir",
-]
-
-[[package]]
-name = "move-symbol-pool"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "once_cell",
- "serde",
 ]
 
 [[package]]
@@ -10534,59 +9578,16 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "better_any",
- "bytes 1.8.0",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "sha3",
- "smallvec",
-]
-
-[[package]]
-name = "move-table-extension"
-version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "better_any",
  "bytes 1.8.0",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-runtime",
+ "move-vm-types",
  "sha3",
  "smallvec",
-]
-
-[[package]]
-name = "move-unit-test"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "better_any",
- "clap 4.5.20",
- "codespan-reporting",
- "colored",
- "itertools 0.12.1",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-resource-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-table-extension 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-test-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "once_cell",
- "rayon",
- "regex",
 ]
 
 [[package]]
@@ -10600,18 +9601,18 @@ dependencies = [
  "codespan-reporting",
  "colored",
  "itertools 0.12.1",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-resource-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-table-extension 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-test-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-ir-types",
+ "move-resource-viewer",
+ "move-stdlib",
+ "move-symbol-pool",
+ "move-table-extension",
+ "move-vm-runtime",
+ "move-vm-test-utils",
  "once_cell",
  "rayon",
  "regex",
@@ -10620,30 +9621,6 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "better_any",
- "bytes 1.8.0",
- "fail",
- "hashbrown 0.14.5",
- "lazy_static",
- "lru 0.7.8",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "once_cell",
- "parking_lot",
- "serde",
- "sha3",
- "tracing",
- "triomphe",
- "typed-arena",
-]
-
-[[package]]
-name = "move-vm-runtime"
-version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "better_any",
@@ -10652,10 +9629,10 @@ dependencies = [
  "hashbrown 0.14.5",
  "lazy_static",
  "lru 0.7.8",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-bytecode-verifier",
+ "move-core-types",
+ "move-vm-types",
  "once_cell",
  "parking_lot",
  "serde",
@@ -10668,47 +9645,16 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "anyhow",
- "bytes 1.8.0",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "once_cell",
- "serde",
-]
-
-[[package]]
-name = "move-vm-test-utils"
-version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "anyhow",
  "bytes 1.8.0",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
+ "move-vm-types",
  "once_cell",
  "serde",
-]
-
-[[package]]
-name = "move-vm-types"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
-dependencies = [
- "bcs 0.1.4",
- "derivative",
- "itertools 0.12.1",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "serde",
- "smallbitvec",
- "smallvec",
- "triomphe",
 ]
 
 [[package]]
@@ -10719,8 +9665,8 @@ dependencies = [
  "bcs 0.1.4",
  "derivative",
  "itertools 0.12.1",
- "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
- "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format",
+ "move-core-types",
  "serde",
  "smallbitvec",
  "smallvec",
@@ -10762,7 +9708,7 @@ name = "movement-types"
 version = "0.0.2"
 dependencies = [
  "anyhow",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "bcs 0.1.4",
  "blake3",
  "rand 0.7.3",
@@ -14350,9 +13296,9 @@ name = "suzuka-client"
 version = "0.0.2"
 dependencies = [
  "anyhow",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "aptos-sdk",
- "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types",
  "async-trait",
  "bcs 0.1.4",
  "buildtime-helpers",
@@ -14404,7 +13350,7 @@ dependencies = [
  "anyhow",
  "aptos-config",
  "aptos-faucet-core",
- "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger",
  "aptos-sdk",
  "clap 4.5.20",
  "dot-movement",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "abstract-domain-derive"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "addchain"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,11 +825,11 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-gas-algebra",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-gas-meter",
- "aptos-gas-schedule",
- "aptos-vm-types",
- "move-binary-format",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
 ]
 
 [[package]]
@@ -828,8 +838,8 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-crypto",
- "aptos-types",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
 ]
 
 [[package]]
@@ -837,13 +847,27 @@ name = "aptos-aggregator"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-logger",
- "aptos-types",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bcs 0.1.4",
  "claims",
- "move-binary-format",
- "move-core-types",
- "move-vm-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+]
+
+[[package]]
+name = "aptos-aggregator"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "bcs 0.1.4",
+ "claims",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
 ]
 
 [[package]]
@@ -856,15 +880,15 @@ dependencies = [
  "aptos-bcs-utils",
  "aptos-build-info",
  "aptos-config",
- "aptos-crypto",
- "aptos-gas-schedule",
- "aptos-global-constants",
- "aptos-logger",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-global-constants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-mempool",
  "aptos-metrics-core",
- "aptos-runtimes",
+ "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-storage-interface",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-vm",
  "async-trait",
  "bcs 0.1.4",
@@ -876,7 +900,7 @@ dependencies = [
  "itertools 0.12.1",
  "mime",
  "mini-moka",
- "move-core-types",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "num_cpus",
  "once_cell",
  "paste",
@@ -895,21 +919,21 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524dd
 dependencies = [
  "anyhow",
  "aptos-config",
- "aptos-crypto",
- "aptos-framework",
- "aptos-logger",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-openapi",
  "aptos-resource-viewer",
  "aptos-storage-interface",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-vm",
  "async-trait",
  "bcs 0.1.4",
  "bytes 1.8.0",
  "hex",
  "indoc",
- "move-binary-format",
- "move-core-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "once_cell",
  "poem",
  "poem-openapi",
@@ -937,20 +961,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-bitvec"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-aggregator",
+ "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-drop-helper",
- "aptos-infallible",
- "aptos-logger",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
  "aptos-mvhashmap",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-vm-logging",
- "aptos-vm-types",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "arc-swap",
  "bcs 0.1.4",
  "bytes 1.8.0",
@@ -960,9 +993,9 @@ dependencies = [
  "dashmap 5.5.3",
  "derivative",
  "fail",
- "move-binary-format",
- "move-core-types",
- "move-vm-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "num_cpus",
  "once_cell",
  "parking_lot",
@@ -976,16 +1009,16 @@ name = "aptos-block-partitioner"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-crypto",
- "aptos-logger",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bcs 0.1.4",
  "clap 4.5.20",
  "dashmap 5.5.3",
  "itertools 0.12.1",
  "jemallocator",
- "move-core-types",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "once_cell",
  "rand 0.7.3",
  "rayon",
@@ -1016,11 +1049,11 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-framework",
+ "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-package-builder",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bcs 0.1.4",
- "move-core-types",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "once_cell",
 ]
 
@@ -1030,7 +1063,7 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-infallible",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
  "futures",
 ]
@@ -1040,7 +1073,7 @@ name = "aptos-compression"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-logger",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
  "lz4",
  "once_cell",
@@ -1053,13 +1086,13 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-crypto",
- "aptos-global-constants",
- "aptos-logger",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-global-constants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-secure-storage",
  "aptos-short-hex-str",
  "aptos-temppath",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "arr_macro",
  "bcs 0.1.4",
  "byteorder",
@@ -1084,14 +1117,14 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-bitvec",
- "aptos-crypto",
- "aptos-crypto-derive",
+ "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-executor-types",
- "aptos-infallible",
- "aptos-logger",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-short-hex-str",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bcs 0.1.4",
  "fail",
  "futures",
@@ -1112,7 +1145,7 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524dd
 dependencies = [
  "aes-gcm",
  "anyhow",
- "aptos-crypto-derive",
+ "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.4.2",
@@ -1159,9 +1192,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-crypto"
+version = "0.0.3"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "aes-gcm",
+ "anyhow",
+ "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.4.2",
+ "ark-groth16",
+ "ark-std 0.4.0",
+ "base64 0.13.1",
+ "bcs 0.1.4",
+ "blst",
+ "bulletproofs",
+ "bytes 1.8.0",
+ "curve25519-dalek",
+ "curve25519-dalek-ng",
+ "digest 0.9.0",
+ "ed25519-dalek",
+ "ff 0.13.0",
+ "hex",
+ "hkdf 0.10.0",
+ "libsecp256k1",
+ "merlin",
+ "more-asserts",
+ "neptune",
+ "num-bigint 0.3.3",
+ "num-integer",
+ "once_cell",
+ "p256 0.13.2",
+ "poseidon-ark",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "ring 0.16.20",
+ "serde",
+ "serde-name",
+ "serde_bytes",
+ "sha2 0.10.8",
+ "sha2 0.9.9",
+ "sha3",
+ "signature 2.2.0",
+ "static_assertions",
+ "thiserror",
+ "tiny-keccak",
+ "typenum",
+ "x25519-dalek",
+]
+
+[[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "aptos-crypto-derive"
+version = "0.0.3"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1176,15 +1270,15 @@ dependencies = [
  "anyhow",
  "aptos-accumulator",
  "aptos-config",
- "aptos-crypto",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-db-indexer",
  "aptos-db-indexer-schemas",
  "aptos-executor",
  "aptos-executor-types",
- "aptos-experimental-runtimes",
- "aptos-infallible",
+ "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-jellyfish-merkle",
- "aptos-logger",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
  "aptos-proptest-helpers",
  "aptos-resource-viewer",
@@ -1193,7 +1287,7 @@ dependencies = [
  "aptos-scratchpad",
  "aptos-storage-interface",
  "aptos-temppath",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "arc-swap",
  "arr_macro",
  "bcs 0.1.4",
@@ -1204,7 +1298,7 @@ dependencies = [
  "hex",
  "itertools 0.12.1",
  "lru 0.7.8",
- "move-core-types",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "num-derive",
  "once_cell",
  "proptest",
@@ -1224,16 +1318,16 @@ dependencies = [
  "anyhow",
  "aptos-config",
  "aptos-db-indexer-schemas",
- "aptos-logger",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-resource-viewer",
  "aptos-rocksdb-options",
  "aptos-schemadb",
  "aptos-storage-interface",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bcs 0.1.4",
  "bytes 1.8.0",
  "dashmap 5.5.3",
- "move-core-types",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
 ]
 
 [[package]]
@@ -1244,7 +1338,7 @@ dependencies = [
  "anyhow",
  "aptos-schemadb",
  "aptos-storage-interface",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bcs 0.1.4",
  "byteorder",
  "serde",
@@ -1256,8 +1350,39 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-crypto",
- "aptos-crypto-derive",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "bcs 0.1.4",
+ "blst",
+ "blstrs",
+ "criterion",
+ "ff 0.13.0",
+ "group 0.13.0",
+ "hex",
+ "merlin",
+ "more-asserts",
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+ "once_cell",
+ "pairing",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "rayon",
+ "serde",
+ "serde_bytes",
+ "sha3",
+ "static_assertions",
+]
+
+[[package]]
+name = "aptos-dkg"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "bcs 0.1.4",
  "blst",
  "blstrs",
@@ -1286,7 +1411,7 @@ name = "aptos-drop-helper"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-infallible",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
  "once_cell",
  "threadpool",
@@ -1300,9 +1425,9 @@ dependencies = [
  "anyhow",
  "aptos-channels",
  "aptos-id-generator",
- "aptos-infallible",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-storage-interface",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "futures",
  "serde",
  "thiserror",
@@ -1315,18 +1440,18 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524dd
 dependencies = [
  "anyhow",
  "aptos-consensus-types",
- "aptos-crypto",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-drop-helper",
  "aptos-executor-service",
  "aptos-executor-types",
- "aptos-experimental-runtimes",
- "aptos-infallible",
- "aptos-logger",
+ "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
  "aptos-scratchpad",
  "aptos-sdk",
  "aptos-storage-interface",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-vm",
  "arr_macro",
  "bcs 0.1.4",
@@ -1334,7 +1459,7 @@ dependencies = [
  "dashmap 5.5.3",
  "fail",
  "itertools 0.12.1",
- "move-core-types",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "once_cell",
  "rayon",
  "serde",
@@ -1347,15 +1472,15 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524dd
 dependencies = [
  "aptos-block-partitioner",
  "aptos-config",
- "aptos-infallible",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-language-e2e-tests",
- "aptos-logger",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
  "aptos-node-resource-metrics",
  "aptos-push-metrics",
  "aptos-secure-net",
  "aptos-storage-interface",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-vm",
  "bcs 0.1.4",
  "clap 4.5.20",
@@ -1379,14 +1504,14 @@ dependencies = [
  "aptos-cached-packages",
  "aptos-config",
  "aptos-consensus-types",
- "aptos-crypto",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-db",
  "aptos-executor",
  "aptos-executor-types",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-vm",
  "aptos-vm-genesis",
  "rand 0.7.3",
@@ -1398,12 +1523,12 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-crypto",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-drop-helper",
  "aptos-scratchpad",
  "aptos-secure-net",
  "aptos-storage-interface",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bcs 0.1.4",
  "criterion",
  "itertools 0.12.1",
@@ -1417,7 +1542,20 @@ name = "aptos-experimental-runtimes"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-runtimes",
+ "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "core_affinity",
+ "libc",
+ "num_cpus",
+ "once_cell",
+ "rayon",
+]
+
+[[package]]
+name = "aptos-experimental-runtimes"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "core_affinity",
  "libc",
  "num_cpus",
@@ -1433,7 +1571,7 @@ dependencies = [
  "anyhow",
  "aptos-config",
  "aptos-faucet-metrics-server",
- "aptos-logger",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
  "aptos-sdk",
  "async-trait",
@@ -1465,7 +1603,7 @@ version = "2.0.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-logger",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
  "once_cell",
  "poem",
@@ -1479,15 +1617,15 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-aggregator",
- "aptos-crypto",
- "aptos-gas-algebra",
- "aptos-gas-schedule",
- "aptos-move-stdlib",
- "aptos-native-interface",
- "aptos-sdk-builder",
- "aptos-types",
- "aptos-vm-types",
+ "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-sdk-builder 0.2.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
@@ -1510,20 +1648,88 @@ dependencies = [
  "log",
  "lru 0.7.8",
  "merlin",
- "move-binary-format",
- "move-cli",
- "move-command-line-common",
- "move-compiler",
- "move-core-types",
- "move-docgen",
- "move-model",
- "move-package",
- "move-prover",
- "move-prover-boogie-backend",
- "move-prover-bytecode-pipeline",
- "move-stackless-bytecode",
- "move-vm-runtime",
- "move-vm-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-cli 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-prover-boogie-backend 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "num-traits",
+ "once_cell",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "ripemd",
+ "serde",
+ "serde_bytes",
+ "sha2 0.10.8",
+ "sha2 0.9.9",
+ "sha3",
+ "siphasher",
+ "smallvec",
+ "tempfile",
+ "thiserror",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "aptos-framework"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-sdk-builder 0.2.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "bcs 0.1.4",
+ "better_any",
+ "blake2-rfc",
+ "bulletproofs",
+ "byteorder",
+ "clap 4.5.20",
+ "codespan-reporting",
+ "curve25519-dalek-ng",
+ "either",
+ "flate2",
+ "hex",
+ "itertools 0.12.1",
+ "libsecp256k1",
+ "log",
+ "lru 0.7.8",
+ "merlin",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-cli 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-prover-boogie-backend 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "num-traits",
  "once_cell",
  "rand 0.7.3",
@@ -1547,7 +1753,16 @@ version = "0.0.1"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "either",
- "move-core-types",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+]
+
+[[package]]
+name = "aptos-gas-algebra"
+version = "0.0.1"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "either",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
 ]
 
 [[package]]
@@ -1555,14 +1770,14 @@ name = "aptos-gas-meter"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-gas-algebra",
- "aptos-gas-schedule",
- "aptos-logger",
- "aptos-types",
- "aptos-vm-types",
- "move-binary-format",
- "move-core-types",
- "move-vm-types",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
 ]
 
 [[package]]
@@ -1571,15 +1786,15 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-gas-algebra",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-gas-meter",
- "aptos-types",
- "aptos-vm-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "handlebars",
  "inferno",
- "move-binary-format",
- "move-core-types",
- "move-vm-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "regex",
  "serde_json",
  "smallvec",
@@ -1590,10 +1805,23 @@ name = "aptos-gas-schedule"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-gas-algebra",
- "aptos-global-constants",
- "move-core-types",
- "move-vm-types",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-global-constants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "paste",
+ "rand 0.7.3",
+]
+
+[[package]]
+name = "aptos-gas-schedule"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-global-constants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "paste",
  "rand 0.7.3",
 ]
@@ -1602,6 +1830,11 @@ dependencies = [
 name = "aptos-global-constants"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
+
+[[package]]
+name = "aptos-global-constants"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
 
 [[package]]
 name = "aptos-id-generator"
@@ -1616,14 +1849,14 @@ dependencies = [
  "anyhow",
  "aptos-api",
  "aptos-api-types",
- "aptos-bitvec",
+ "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-config",
- "aptos-logger",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-mempool",
  "aptos-metrics-core",
- "aptos-runtimes",
+ "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-storage-interface",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "async-trait",
  "bcs 0.1.4",
  "bigdecimal",
@@ -1648,17 +1881,17 @@ dependencies = [
  "anyhow",
  "aptos-api",
  "aptos-api-types",
- "aptos-bitvec",
+ "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-config",
  "aptos-indexer-grpc-utils",
- "aptos-logger",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-mempool",
  "aptos-metrics-core",
  "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors)",
  "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
- "aptos-runtimes",
+ "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-storage-interface",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bcs 0.1.4",
  "bytes 1.8.0",
  "chrono",
@@ -1666,9 +1899,9 @@ dependencies = [
  "hex",
  "hyper 0.14.31",
  "itertools 0.12.1",
- "move-binary-format",
- "move-core-types",
- "move-package",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "once_cell",
  "serde",
  "serde_json",
@@ -1690,12 +1923,12 @@ dependencies = [
  "aptos-db-indexer",
  "aptos-indexer-grpc-fullnode",
  "aptos-indexer-grpc-utils",
- "aptos-logger",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-mempool",
- "aptos-runtimes",
+ "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-schemadb",
  "aptos-storage-interface",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "flate2",
  "futures",
  "google-cloud-storage",
@@ -1747,19 +1980,24 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 
 [[package]]
+name = "aptos-infallible"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+
+[[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-crypto",
- "aptos-crypto-derive",
- "aptos-experimental-runtimes",
- "aptos-infallible",
- "aptos-logger",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
  "aptos-storage-interface",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "arr_macro",
  "bcs 0.1.4",
  "byteorder",
@@ -1779,8 +2017,8 @@ name = "aptos-keygen"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-crypto",
- "aptos-types",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "rand 0.7.3",
 ]
 
@@ -1791,33 +2029,33 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524dd
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
- "aptos-bitvec",
+ "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-block-executor",
  "aptos-cached-packages",
- "aptos-crypto",
- "aptos-framework",
- "aptos-gas-algebra",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-gas-meter",
  "aptos-gas-profiling",
- "aptos-gas-schedule",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-keygen",
  "aptos-proptest-helpers",
  "aptos-temppath",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-vm",
  "aptos-vm-genesis",
  "aptos-vm-logging",
- "aptos-vm-types",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bcs 0.1.4",
  "bytes 1.8.0",
  "goldenfile",
- "move-binary-format",
- "move-command-line-common",
- "move-core-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "move-ir-compiler",
- "move-model",
- "move-vm-runtime",
- "move-vm-types",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "num_cpus",
  "once_cell",
  "petgraph 0.5.1",
@@ -1833,8 +2071,8 @@ name = "aptos-ledger"
 version = "0.2.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-crypto",
- "aptos-types",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "hex",
  "ledger-apdu",
  "ledger-transport-hid",
@@ -1852,13 +2090,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-log-derive"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "aptos-logger"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-infallible",
- "aptos-log-derive",
- "aptos-node-identity",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-log-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-node-identity 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "backtrace",
+ "chrono",
+ "erased-serde",
+ "futures",
+ "hostname",
+ "once_cell",
+ "prometheus",
+ "serde",
+ "serde_json",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "aptos-logger"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-log-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-node-identity 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "backtrace",
  "chrono",
  "erased-serde",
@@ -1880,12 +2152,12 @@ name = "aptos-memory-usage-tracker"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-gas-algebra",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-gas-meter",
- "aptos-types",
- "move-binary-format",
- "move-core-types",
- "move-vm-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
 ]
 
 [[package]]
@@ -1898,20 +2170,20 @@ dependencies = [
  "aptos-channels",
  "aptos-config",
  "aptos-consensus-types",
- "aptos-crypto",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-event-notifications",
- "aptos-infallible",
- "aptos-logger",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-mempool-notifications",
  "aptos-metrics-core",
  "aptos-netcore",
  "aptos-network",
  "aptos-peer-monitoring-service-types",
- "aptos-runtimes",
+ "aptos-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-short-hex-str",
  "aptos-storage-interface",
  "aptos-time-service",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-vm-validator",
  "bcs 0.1.4",
  "fail",
@@ -1933,7 +2205,7 @@ name = "aptos-mempool-notifications"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "async-trait",
  "futures",
  "serde",
@@ -1946,7 +2218,7 @@ name = "aptos-memsocket"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-infallible",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bytes 1.8.0",
  "futures",
  "once_cell",
@@ -1966,11 +2238,26 @@ name = "aptos-move-stdlib"
 version = "0.1.1"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-gas-schedule",
- "aptos-native-interface",
- "move-core-types",
- "move-vm-runtime",
- "move-vm-types",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "sha2 0.9.9",
+ "sha3",
+ "smallvec",
+]
+
+[[package]]
+name = "aptos-move-stdlib"
+version = "0.1.1"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "sha2 0.9.9",
  "sha3",
  "smallvec",
@@ -1998,18 +2285,18 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-aggregator",
- "aptos-crypto",
- "aptos-types",
- "aptos-vm-types",
+ "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bytes 1.8.0",
  "claims",
  "crossbeam",
  "dashmap 5.5.3",
  "derivative",
- "move-binary-format",
- "move-core-types",
- "move-vm-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "serde",
 ]
 
@@ -2018,15 +2305,32 @@ name = "aptos-native-interface"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-gas-algebra",
- "aptos-gas-schedule",
- "aptos-types",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bcs 0.1.4",
  "bytes 1.8.0",
- "move-binary-format",
- "move-core-types",
- "move-vm-runtime",
- "move-vm-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "smallvec",
+]
+
+[[package]]
+name = "aptos-native-interface"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "bcs 0.1.4",
+ "bytes 1.8.0",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "smallvec",
 ]
 
@@ -2037,7 +2341,7 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524dd
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bytes 1.8.0",
  "futures",
  "pin-project 1.1.6",
@@ -2053,21 +2357,21 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-bitvec",
+ "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-channels",
  "aptos-compression",
  "aptos-config",
- "aptos-crypto",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-id-generator",
- "aptos-infallible",
- "aptos-logger",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
  "aptos-netcore",
  "aptos-num-variants",
  "aptos-peer-monitoring-service-types",
  "aptos-short-hex-str",
  "aptos-time-service",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "arc-swap",
  "async-trait",
  "bcs 0.1.4",
@@ -2098,7 +2402,18 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "claims",
+ "once_cell",
+]
+
+[[package]]
+name = "aptos-node-identity"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "claims",
  "once_cell",
 ]
@@ -2109,8 +2424,8 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "aptos-build-info",
- "aptos-infallible",
- "aptos-logger",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
  "cfg-if",
  "once_cell",
@@ -2148,10 +2463,10 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-framework",
+ "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "itertools 0.12.1",
- "move-command-line-common",
- "move-package",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "tempfile",
 ]
 
@@ -2161,7 +2476,7 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "aptos-config",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bcs 0.1.4",
  "serde",
  "thiserror",
@@ -2227,7 +2542,7 @@ name = "aptos-push-metrics"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-logger",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
  "ureq",
  "url",
@@ -2239,12 +2554,12 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-vm",
- "move-binary-format",
- "move-bytecode-utils",
- "move-core-types",
- "move-resource-viewer",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-resource-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
 ]
 
 [[package]]
@@ -2254,14 +2569,14 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524dd
 dependencies = [
  "anyhow",
  "aptos-api-types",
- "aptos-crypto",
- "aptos-infallible",
- "aptos-logger",
- "aptos-types",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bcs 0.1.4",
  "bytes 1.8.0",
  "hex",
- "move-core-types",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -2289,13 +2604,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-runtimes"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "rayon",
+ "tokio",
+]
+
+[[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-infallible",
- "aptos-logger",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
  "aptos-storage-interface",
  "dunce",
@@ -2310,12 +2634,12 @@ name = "aptos-scratchpad"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-crypto",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-drop-helper",
- "aptos-experimental-runtimes",
- "aptos-infallible",
+ "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bitvec 1.0.1",
  "itertools 0.12.1",
  "once_cell",
@@ -2331,16 +2655,16 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524dd
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
- "aptos-crypto",
- "aptos-global-constants",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-global-constants 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-ledger",
  "aptos-rest-client",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "base64 0.13.1",
  "bcs 0.1.4",
  "ed25519-dalek-bip32",
  "hex",
- "move-core-types",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "rand_core 0.5.1",
  "serde_json",
  "tiny-bip39",
@@ -2352,11 +2676,29 @@ version = "0.2.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bcs 0.1.4",
  "clap 4.5.20",
  "heck 0.4.1",
- "move-core-types",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "once_cell",
+ "serde-generate",
+ "serde-reflection",
+ "serde_yaml 0.8.26",
+ "textwrap 0.15.2",
+]
+
+[[package]]
+name = "aptos-sdk-builder"
+version = "0.2.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "bcs 0.1.4",
+ "clap 4.5.20",
+ "heck 0.4.1",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "once_cell",
  "serde-generate",
  "serde-reflection",
@@ -2369,7 +2711,7 @@ name = "aptos-secure-net"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-logger",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
  "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bcs 0.1.4",
@@ -2387,9 +2729,9 @@ name = "aptos-secure-storage"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-crypto",
- "aptos-infallible",
- "aptos-logger",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-temppath",
  "aptos-time-service",
  "aptos-vault-client",
@@ -2420,7 +2762,7 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-infallible",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "crossbeam",
  "rayon",
 ]
@@ -2431,18 +2773,18 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-crypto",
- "aptos-experimental-runtimes",
- "aptos-logger",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
  "aptos-scratchpad",
  "aptos-secure-net",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-vm",
  "bcs 0.1.4",
  "crossbeam-channel",
  "dashmap 5.5.3",
- "move-core-types",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "once_cell",
  "parking_lot",
  "proptest",
@@ -2478,15 +2820,15 @@ name = "aptos-table-natives"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-gas-schedule",
- "aptos-native-interface",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "better_any",
  "bytes 1.8.0",
- "move-binary-format",
- "move-core-types",
- "move-table-extension",
- "move-vm-runtime",
- "move-vm-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-table-extension 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "sha3",
  "smallvec",
 ]
@@ -2505,7 +2847,7 @@ name = "aptos-time-service"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-infallible",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "enum_dispatch",
  "futures",
  "pin-project 1.1.6",
@@ -2519,12 +2861,12 @@ version = "0.0.3"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-bitvec",
- "aptos-crypto",
- "aptos-crypto-derive",
- "aptos-dkg",
- "aptos-experimental-runtimes",
- "aptos-infallible",
+ "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-dkg 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "ark-bn254",
  "ark-ff 0.4.2",
  "ark-groth16",
@@ -2539,12 +2881,12 @@ dependencies = [
  "hex",
  "itertools 0.12.1",
  "jsonwebtoken 8.3.0",
- "move-binary-format",
- "move-bytecode-verifier",
- "move-core-types",
- "move-table-extension",
- "move-vm-runtime",
- "move-vm-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-table-extension 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "num-bigint 0.3.3",
  "num-derive",
  "num-traits",
@@ -2571,6 +2913,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-types"
+version = "0.0.3"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-dkg 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "ark-bn254",
+ "ark-ff 0.4.2",
+ "ark-groth16",
+ "ark-serialize 0.4.2",
+ "arr_macro",
+ "base64 0.13.1",
+ "bcs 0.1.4",
+ "bytes 1.8.0",
+ "fixed",
+ "fxhash",
+ "hashbrown 0.14.5",
+ "hex",
+ "itertools 0.12.1",
+ "jsonwebtoken 8.3.0",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-table-extension 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "num-bigint 0.3.3",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "passkey-types",
+ "poem-openapi",
+ "poem-openapi-derive",
+ "quick_cache",
+ "rand 0.7.3",
+ "rayon",
+ "ring 0.16.20",
+ "rsa 0.9.6",
+ "serde",
+ "serde-big-array",
+ "serde_bytes",
+ "serde_json",
+ "serde_with",
+ "serde_yaml 0.8.26",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
+ "thiserror",
+]
+
+[[package]]
 name = "aptos-utils"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
@@ -2580,7 +2977,7 @@ name = "aptos-vault-client"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-crypto",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "base64 0.13.1",
  "chrono",
  "native-tls",
@@ -2597,28 +2994,28 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-aggregator",
+ "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-block-executor",
  "aptos-block-partitioner",
- "aptos-crypto",
- "aptos-crypto-derive",
- "aptos-experimental-runtimes",
- "aptos-framework",
- "aptos-gas-algebra",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-crypto-derive 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-experimental-runtimes 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-gas-meter",
- "aptos-gas-schedule",
- "aptos-infallible",
- "aptos-logger",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-infallible 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-memory-usage-tracker",
  "aptos-metrics-core",
- "aptos-move-stdlib",
+ "aptos-move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-mvhashmap",
- "aptos-native-interface",
+ "aptos-native-interface 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-table-natives",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-utils",
  "aptos-vm-logging",
- "aptos-vm-types",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "ark-bn254",
  "ark-groth16",
  "bcs 0.1.4",
@@ -2629,10 +3026,10 @@ dependencies = [
  "fail",
  "futures",
  "hex",
- "move-binary-format",
- "move-core-types",
- "move-vm-runtime",
- "move-vm-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "num_cpus",
  "once_cell",
  "ouroboros",
@@ -2647,16 +3044,16 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "aptos-cached-packages",
- "aptos-crypto",
- "aptos-framework",
- "aptos-gas-schedule",
- "aptos-types",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-vm",
  "bcs 0.1.4",
  "bytes 1.8.0",
- "move-core-types",
- "move-vm-runtime",
- "move-vm-types",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "once_cell",
  "rand 0.7.3",
  "serde",
@@ -2667,11 +3064,11 @@ name = "aptos-vm-logging"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "aptos-crypto",
- "aptos-logger",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-metrics-core",
  "aptos-speculative-state-helper",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "arc-swap",
  "once_cell",
  "serde",
@@ -2683,18 +3080,40 @@ version = "0.0.1"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-aggregator",
- "aptos-gas-algebra",
- "aptos-gas-schedule",
- "aptos-types",
+ "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bcs 0.1.4",
  "bytes 1.8.0",
  "claims",
  "either",
- "move-binary-format",
- "move-core-types",
- "move-vm-runtime",
- "move-vm-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "rand 0.7.3",
+ "serde",
+]
+
+[[package]]
+name = "aptos-vm-types"
+version = "0.0.1"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "aptos-aggregator 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-gas-algebra 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-gas-schedule 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "bcs 0.1.4",
+ "bytes 1.8.0",
+ "claims",
+ "either",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "rand 0.7.3",
  "serde",
 ]
@@ -2705,9 +3124,9 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "aptos-logger",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-storage-interface",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-vm",
  "aptos-vm-logging",
  "fail",
@@ -4084,7 +4503,7 @@ version = "0.0.2"
 dependencies = [
  "alloy",
  "anyhow",
- "aptos-crypto",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-sdk",
  "dot-movement",
  "godfig",
@@ -4114,11 +4533,11 @@ dependencies = [
  "alloy-network",
  "alloy-sol-types",
  "anyhow",
- "aptos-framework",
+ "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "aptos-language-e2e-tests",
- "aptos-logger",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-sdk",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bcs 0.1.4",
  "bridge-config",
  "bridge-grpc",
@@ -4153,7 +4572,7 @@ dependencies = [
  "aptos-api",
  "aptos-api-types",
  "aptos-sdk",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "async-stream",
  "async-trait",
  "bcs 0.1.4",
@@ -7201,9 +7620,9 @@ version = "0.0.2"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
- "aptos-framework",
+ "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "aptos-sdk",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bcs 0.1.4",
  "chrono",
  "futures",
@@ -8580,12 +8999,12 @@ dependencies = [
  "anyhow",
  "aptos-api",
  "aptos-config",
- "aptos-crypto",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-db",
  "aptos-mempool",
  "aptos-proptest-helpers",
  "aptos-sdk",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "async-trait",
  "chrono",
  "futures",
@@ -8604,9 +9023,9 @@ name = "maptos-execution-util"
 version = "0.0.2"
 dependencies = [
  "anyhow",
- "aptos-crypto",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-sdk",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "godfig",
  "hex",
  "m1-da-light-node-util",
@@ -8628,7 +9047,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-sdk",
  "aptos-storage-interface",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "chrono",
  "futures",
  "maptos-execution-util",
@@ -8646,33 +9065,33 @@ dependencies = [
  "anyhow",
  "aptos-api",
  "aptos-api-types",
- "aptos-bitvec",
+ "aptos-bitvec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-block-executor",
  "aptos-cached-packages",
  "aptos-config",
  "aptos-consensus-types",
- "aptos-crypto",
+ "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-db",
  "aptos-executor",
  "aptos-executor-test-helpers",
  "aptos-executor-types",
  "aptos-faucet-core",
- "aptos-framework",
+ "aptos-framework 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "aptos-indexer",
  "aptos-indexer-grpc-fullnode",
  "aptos-indexer-grpc-table-info",
  "aptos-language-e2e-tests",
- "aptos-logger",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-mempool",
  "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-vm",
  "aptos-vm-genesis",
  "aptos-vm-logging",
- "aptos-vm-types",
+ "aptos-vm-types 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-vm-validator",
  "async-trait",
  "bcs 0.1.4",
@@ -9014,11 +9433,28 @@ dependencies = [
  "bcs 0.1.4",
  "heck 0.4.1",
  "log",
- "move-binary-format",
- "move-bytecode-verifier",
- "move-command-line-common",
- "move-core-types",
- "move-model",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "serde",
+]
+
+[[package]]
+name = "move-abigen"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "bcs 0.1.4",
+ "heck 0.4.1",
+ "log",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "serde",
 ]
 
@@ -9030,8 +9466,23 @@ dependencies = [
  "anyhow",
  "backtrace",
  "indexmap 1.9.3",
- "move-bytecode-spec",
- "move-core-types",
+ "move-bytecode-spec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "ref-cast",
+ "serde",
+ "variant_count",
+]
+
+[[package]]
+name = "move-binary-format"
+version = "0.0.3"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "backtrace",
+ "indexmap 1.9.3",
+ "move-bytecode-spec 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "ref-cast",
  "serde",
  "variant_count",
@@ -9043,17 +9494,37 @@ version = "0.0.1"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 
 [[package]]
+name = "move-borrow-graph"
+version = "0.0.1"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+
+[[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "move-binary-format",
- "move-command-line-common",
- "move-core-types",
- "move-ir-types",
- "move-symbol-pool",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "serde",
+]
+
+[[package]]
+name = "move-bytecode-source-map"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "bcs 0.1.4",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "serde",
 ]
 
@@ -9068,13 +9539,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-bytecode-spec"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "once_cell",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "move-binary-format",
- "move-core-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "petgraph 0.5.1",
+ "serde-reflection",
+]
+
+[[package]]
+name = "move-bytecode-utils"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "petgraph 0.5.1",
  "serde-reflection",
 ]
@@ -9085,9 +9578,23 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "fail",
- "move-binary-format",
- "move-borrow-graph",
- "move-core-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-borrow-graph 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "petgraph 0.5.1",
+ "serde",
+ "typed-arena",
+]
+
+[[package]]
+name = "move-bytecode-verifier"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "fail",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-borrow-graph 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "petgraph 0.5.1",
  "serde",
  "typed-arena",
@@ -9101,9 +9608,24 @@ dependencies = [
  "anyhow",
  "clap 4.5.20",
  "crossterm 0.26.1",
- "move-binary-format",
- "move-bytecode-source-map",
- "move-disassembler",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "regex",
+ "tui",
+]
+
+[[package]]
+name = "move-bytecode-viewer"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "clap 4.5.20",
+ "crossterm 0.26.1",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "regex",
  "tui",
 ]
@@ -9117,23 +9639,53 @@ dependencies = [
  "clap 4.5.20",
  "codespan-reporting",
  "colored",
- "move-binary-format",
- "move-bytecode-viewer",
- "move-command-line-common",
- "move-compiler",
- "move-compiler-v2",
- "move-core-types",
- "move-coverage",
- "move-disassembler",
- "move-docgen",
- "move-errmapgen",
- "move-model",
- "move-package",
- "move-prover",
- "move-stdlib",
- "move-unit-test",
- "move-vm-runtime",
- "move-vm-test-utils",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-coverage 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-errmapgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-unit-test 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-test-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "once_cell",
+ "tempfile",
+]
+
+[[package]]
+name = "move-cli"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "clap 4.5.20",
+ "codespan-reporting",
+ "colored",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-coverage 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-errmapgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-package 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-unit-test 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-test-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "once_cell",
  "tempfile",
 ]
@@ -9147,7 +9699,24 @@ dependencies = [
  "difference",
  "dirs-next",
  "hex",
- "move-core-types",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "num-bigint 0.3.3",
+ "once_cell",
+ "serde",
+ "sha2 0.9.9",
+ "walkdir",
+]
+
+[[package]]
+name = "move-command-line-common"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "difference",
+ "dirs-next",
+ "hex",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "num-bigint 0.3.3",
  "once_cell",
  "serde",
@@ -9165,15 +9734,41 @@ dependencies = [
  "clap 4.5.20",
  "codespan-reporting",
  "hex",
- "move-binary-format",
- "move-borrow-graph",
- "move-bytecode-source-map",
- "move-bytecode-verifier",
- "move-command-line-common",
- "move-core-types",
- "move-ir-to-bytecode",
- "move-ir-types",
- "move-symbol-pool",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-borrow-graph 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-ir-to-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "once_cell",
+ "petgraph 0.5.1",
+ "regex",
+ "sha3",
+ "tempfile",
+]
+
+[[package]]
+name = "move-compiler"
+version = "0.0.1"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "bcs 0.1.4",
+ "clap 4.5.20",
+ "codespan-reporting",
+ "hex",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-borrow-graph 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-ir-to-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "once_cell",
  "petgraph 0.5.1",
  "regex",
@@ -9186,7 +9781,7 @@ name = "move-compiler-v2"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "abstract-domain-derive",
+ "abstract-domain-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "anyhow",
  "bcs 0.1.4",
  "clap 4.5.20",
@@ -9196,17 +9791,48 @@ dependencies = [
  "im",
  "itertools 0.12.1",
  "log",
- "move-binary-format",
- "move-bytecode-source-map",
- "move-bytecode-verifier",
- "move-command-line-common",
- "move-compiler",
- "move-core-types",
- "move-disassembler",
- "move-ir-types",
- "move-model",
- "move-stackless-bytecode",
- "move-symbol-pool",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "num",
+ "once_cell",
+ "petgraph 0.5.1",
+]
+
+[[package]]
+name = "move-compiler-v2"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "abstract-domain-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "anyhow",
+ "bcs 0.1.4",
+ "clap 4.5.20",
+ "codespan-reporting",
+ "ethnum",
+ "flexi_logger",
+ "im",
+ "itertools 0.12.1",
+ "log",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "num",
  "once_cell",
  "petgraph 0.5.1",
@@ -9238,6 +9864,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-core-types"
+version = "0.0.4"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "bcs 0.1.4",
+ "bytes 1.8.0",
+ "ethnum",
+ "hashbrown 0.14.5",
+ "hex",
+ "num",
+ "once_cell",
+ "primitive-types 0.10.1",
+ "rand 0.8.5",
+ "ref-cast",
+ "serde",
+ "serde_bytes",
+ "thiserror",
+ "uint",
+]
+
+[[package]]
 name = "move-coverage"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
@@ -9247,11 +9895,30 @@ dependencies = [
  "clap 4.5.20",
  "codespan",
  "colored",
- "move-binary-format",
- "move-bytecode-source-map",
- "move-command-line-common",
- "move-core-types",
- "move-ir-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "petgraph 0.5.1",
+ "serde",
+]
+
+[[package]]
+name = "move-coverage"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "bcs 0.1.4",
+ "clap 4.5.20",
+ "codespan",
+ "colored",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "petgraph 0.5.1",
  "serde",
 ]
@@ -9264,13 +9931,30 @@ dependencies = [
  "anyhow",
  "clap 4.5.20",
  "colored",
- "move-binary-format",
- "move-bytecode-source-map",
- "move-command-line-common",
- "move-compiler",
- "move-core-types",
- "move-coverage",
- "move-ir-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-coverage 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+]
+
+[[package]]
+name = "move-disassembler"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "clap 4.5.20",
+ "colored",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-coverage 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
 ]
 
 [[package]]
@@ -9284,9 +9968,28 @@ dependencies = [
  "codespan-reporting",
  "itertools 0.12.1",
  "log",
- "move-compiler",
- "move-core-types",
- "move-model",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "once_cell",
+ "regex",
+ "serde",
+]
+
+[[package]]
+name = "move-docgen"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "clap 4.5.20",
+ "codespan",
+ "codespan-reporting",
+ "itertools 0.12.1",
+ "log",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "once_cell",
  "regex",
  "serde",
@@ -9298,9 +10001,21 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "anyhow",
- "move-command-line-common",
- "move-core-types",
- "move-model",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "serde",
+]
+
+[[package]]
+name = "move-errmapgen"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "serde",
 ]
 
@@ -9312,11 +10027,11 @@ dependencies = [
  "anyhow",
  "bcs 0.1.4",
  "clap 4.5.20",
- "move-binary-format",
- "move-bytecode-source-map",
- "move-bytecode-verifier",
- "move-command-line-common",
- "move-ir-to-bytecode",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-ir-to-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "serde_json",
 ]
 
@@ -9328,13 +10043,31 @@ dependencies = [
  "anyhow",
  "codespan-reporting",
  "log",
- "move-binary-format",
- "move-bytecode-source-map",
- "move-command-line-common",
- "move-core-types",
- "move-ir-to-bytecode-syntax",
- "move-ir-types",
- "move-symbol-pool",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-ir-to-bytecode-syntax 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "ouroboros",
+]
+
+[[package]]
+name = "move-ir-to-bytecode"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "codespan-reporting",
+ "log",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-ir-to-bytecode-syntax 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "ouroboros",
 ]
 
@@ -9345,10 +10078,23 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524dd
 dependencies = [
  "anyhow",
  "hex",
- "move-command-line-common",
- "move-core-types",
- "move-ir-types",
- "move-symbol-pool",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+]
+
+[[package]]
+name = "move-ir-to-bytecode-syntax"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "hex",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
 ]
 
 [[package]]
@@ -9357,9 +10103,22 @@ version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "hex",
- "move-command-line-common",
- "move-core-types",
- "move-symbol-pool",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "move-ir-types"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "hex",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "once_cell",
  "serde",
 ]
@@ -9375,14 +10134,40 @@ dependencies = [
  "internment",
  "itertools 0.12.1",
  "log",
- "move-binary-format",
- "move-bytecode-source-map",
- "move-command-line-common",
- "move-compiler",
- "move-core-types",
- "move-disassembler",
- "move-ir-types",
- "move-symbol-pool",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "num",
+ "num-traits",
+ "once_cell",
+ "regex",
+ "serde",
+]
+
+[[package]]
+name = "move-model"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "codespan",
+ "codespan-reporting",
+ "internment",
+ "itertools 0.12.1",
+ "log",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-disassembler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "num",
  "num-traits",
  "once_cell",
@@ -9399,17 +10184,51 @@ dependencies = [
  "clap 4.5.20",
  "colored",
  "itertools 0.12.1",
- "move-abigen",
- "move-binary-format",
- "move-bytecode-source-map",
- "move-bytecode-utils",
- "move-command-line-common",
- "move-compiler",
- "move-compiler-v2",
- "move-core-types",
- "move-docgen",
- "move-model",
- "move-symbol-pool",
+ "move-abigen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "named-lock",
+ "once_cell",
+ "petgraph 0.5.1",
+ "regex",
+ "serde",
+ "serde_yaml 0.8.26",
+ "sha2 0.9.9",
+ "tempfile",
+ "termcolor",
+ "toml 0.7.8",
+ "walkdir",
+ "whoami",
+]
+
+[[package]]
+name = "move-package"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "clap 4.5.20",
+ "colored",
+ "itertools 0.12.1",
+ "move-abigen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-source-map 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "named-lock",
  "once_cell",
  "petgraph 0.5.1",
@@ -9435,16 +10254,43 @@ dependencies = [
  "codespan-reporting",
  "itertools 0.12.1",
  "log",
- "move-abigen",
- "move-command-line-common",
- "move-compiler",
- "move-compiler-v2",
- "move-docgen",
- "move-errmapgen",
- "move-model",
- "move-prover-boogie-backend",
- "move-prover-bytecode-pipeline",
- "move-stackless-bytecode",
+ "move-abigen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-errmapgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-prover-boogie-backend 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "once_cell",
+ "serde",
+ "simplelog",
+ "toml 0.7.8",
+]
+
+[[package]]
+name = "move-prover"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "atty",
+ "clap 4.5.20",
+ "codespan-reporting",
+ "itertools 0.12.1",
+ "log",
+ "move-abigen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-compiler-v2 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-errmapgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-prover-boogie-backend 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "once_cell",
  "serde",
  "simplelog",
@@ -9463,13 +10309,42 @@ dependencies = [
  "futures",
  "itertools 0.12.1",
  "log",
- "move-binary-format",
- "move-command-line-common",
- "move-compiler",
- "move-core-types",
- "move-model",
- "move-prover-bytecode-pipeline",
- "move-stackless-bytecode",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "num",
+ "once_cell",
+ "pretty",
+ "rand 0.7.3",
+ "regex",
+ "serde",
+ "tera",
+ "tokio",
+]
+
+[[package]]
+name = "move-prover-boogie-backend"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "codespan",
+ "codespan-reporting",
+ "futures",
+ "itertools 0.12.1",
+ "log",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-prover-bytecode-pipeline 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "num",
  "once_cell",
  "pretty",
@@ -9485,15 +10360,32 @@ name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "abstract-domain-derive",
+ "abstract-domain-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "anyhow",
  "codespan-reporting",
  "itertools 0.12.1",
  "log",
- "move-binary-format",
- "move-core-types",
- "move-model",
- "move-stackless-bytecode",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "serde",
+]
+
+[[package]]
+name = "move-prover-bytecode-pipeline"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "abstract-domain-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "anyhow",
+ "codespan-reporting",
+ "itertools 0.12.1",
+ "log",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-stackless-bytecode 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "serde",
 ]
 
@@ -9504,9 +10396,22 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524dd
 dependencies = [
  "anyhow",
  "hex",
- "move-binary-format",
- "move-bytecode-utils",
- "move-core-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "serde",
+]
+
+[[package]]
+name = "move-resource-viewer"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "hex",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "serde",
 ]
 
@@ -9529,15 +10434,34 @@ name = "move-stackless-bytecode"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
- "abstract-domain-derive",
+ "abstract-domain-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "codespan-reporting",
  "ethnum",
  "im",
  "itertools 0.12.1",
  "log",
- "move-binary-format",
- "move-core-types",
- "move-model",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "num",
+ "paste",
+ "petgraph 0.5.1",
+]
+
+[[package]]
+name = "move-stackless-bytecode"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "abstract-domain-derive 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "codespan-reporting",
+ "ethnum",
+ "im",
+ "itertools 0.12.1",
+ "log",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-model 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "num",
  "paste",
  "petgraph 0.5.1",
@@ -9551,15 +10475,38 @@ dependencies = [
  "anyhow",
  "hex",
  "log",
- "move-binary-format",
- "move-command-line-common",
- "move-compiler",
- "move-core-types",
- "move-docgen",
- "move-errmapgen",
- "move-prover",
- "move-vm-runtime",
- "move-vm-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-errmapgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "sha2 0.9.9",
+ "sha3",
+ "smallvec",
+ "walkdir",
+]
+
+[[package]]
+name = "move-stdlib"
+version = "0.1.1"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "hex",
+ "log",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-docgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-errmapgen 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-prover 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "sha2 0.9.9",
  "sha3",
  "smallvec",
@@ -9576,16 +10523,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-symbol-pool"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "once_cell",
+ "serde",
+]
+
+[[package]]
 name = "move-table-extension"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077#62c33771d78524ddf71dc7308f5dce0588602077"
 dependencies = [
  "better_any",
  "bytes 1.8.0",
- "move-binary-format",
- "move-core-types",
- "move-vm-runtime",
- "move-vm-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "sha3",
+ "smallvec",
+]
+
+[[package]]
+name = "move-table-extension"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "better_any",
+ "bytes 1.8.0",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "sha3",
  "smallvec",
 ]
@@ -9601,18 +10572,46 @@ dependencies = [
  "codespan-reporting",
  "colored",
  "itertools 0.12.1",
- "move-binary-format",
- "move-bytecode-utils",
- "move-command-line-common",
- "move-compiler",
- "move-core-types",
- "move-ir-types",
- "move-resource-viewer",
- "move-stdlib",
- "move-symbol-pool",
- "move-table-extension",
- "move-vm-runtime",
- "move-vm-test-utils",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-resource-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-table-extension 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-test-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "once_cell",
+ "rayon",
+ "regex",
+]
+
+[[package]]
+name = "move-unit-test"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "better_any",
+ "clap 4.5.20",
+ "codespan-reporting",
+ "colored",
+ "itertools 0.12.1",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-command-line-common 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-compiler 0.0.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-ir-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-resource-viewer 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-stdlib 0.1.1 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-symbol-pool 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-table-extension 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-runtime 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-test-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "once_cell",
  "rayon",
  "regex",
@@ -9629,10 +10628,34 @@ dependencies = [
  "hashbrown 0.14.5",
  "lazy_static",
  "lru 0.7.8",
- "move-binary-format",
- "move-bytecode-verifier",
- "move-core-types",
- "move-vm-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "once_cell",
+ "parking_lot",
+ "serde",
+ "sha3",
+ "tracing",
+ "triomphe",
+ "typed-arena",
+]
+
+[[package]]
+name = "move-vm-runtime"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "better_any",
+ "bytes 1.8.0",
+ "fail",
+ "hashbrown 0.14.5",
+ "lazy_static",
+ "lru 0.7.8",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-verifier 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "once_cell",
  "parking_lot",
  "serde",
@@ -9649,10 +10672,25 @@ source = "git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524dd
 dependencies = [
  "anyhow",
  "bytes 1.8.0",
- "move-binary-format",
- "move-bytecode-utils",
- "move-core-types",
- "move-vm-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "move-vm-test-utils"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "anyhow",
+ "bytes 1.8.0",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-bytecode-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-vm-types 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "once_cell",
  "serde",
 ]
@@ -9665,8 +10703,24 @@ dependencies = [
  "bcs 0.1.4",
  "derivative",
  "itertools 0.12.1",
- "move-binary-format",
- "move-core-types",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
+ "serde",
+ "smallbitvec",
+ "smallvec",
+ "triomphe",
+]
+
+[[package]]
+name = "move-vm-types"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+dependencies = [
+ "bcs 0.1.4",
+ "derivative",
+ "itertools 0.12.1",
+ "move-binary-format 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "move-core-types 0.0.4 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
  "serde",
  "smallbitvec",
  "smallvec",
@@ -9708,7 +10762,7 @@ name = "movement-types"
 version = "0.0.2"
 dependencies = [
  "anyhow",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "bcs 0.1.4",
  "blake3",
  "rand 0.7.3",
@@ -13298,7 +14352,7 @@ dependencies = [
  "anyhow",
  "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-sdk",
- "aptos-types",
+ "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "async-trait",
  "bcs 0.1.4",
  "buildtime-helpers",
@@ -13350,7 +14404,7 @@ dependencies = [
  "anyhow",
  "aptos-config",
  "aptos-faucet-core",
- "aptos-logger",
+ "aptos-logger 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=62c33771d78524ddf71dc7308f5dce0588602077)",
  "aptos-sdk",
  "clap 4.5.20",
  "dot-movement",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,40 +116,40 @@ serde_yaml = "0.9.34"
 ## Aptos dependencies
 ### We use a forked version so that we can override dependency versions. This is required
 ### to be avoid dependency conflicts with other Sovereign Labs crates.
-aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077", features = [
+aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd", features = [
     "cloneable-private-keys",
 ] }
-aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
-aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "62c33771d78524ddf71dc7308f5dce0588602077" }
+aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
 
 # Indexer
 processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "8e83cde3cb75fabdade9485e0af680cc4b73ca8e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,40 +116,40 @@ serde_yaml = "0.9.34"
 ## Aptos dependencies
 ### We use a forked version so that we can override dependency versions. This is required
 ### to be avoid dependency conflicts with other Sovereign Labs crates.
-aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd", features = [
+aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e", features = [
     "cloneable-private-keys",
 ] }
-aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
 aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
-aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "388ada0b2d10318348aac4d55bd50f3b02e397cd" }
+aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
 
 # Indexer
 processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "8e83cde3cb75fabdade9485e0af680cc4b73ca8e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,40 +116,40 @@ serde_yaml = "0.9.34"
 ## Aptos dependencies
 ### We use a forked version so that we can override dependency versions. This is required
 ### to be avoid dependency conflicts with other Sovereign Labs crates.
-aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e", features = [
+aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f", features = [
     "cloneable-private-keys",
 ] }
-aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
 aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
-aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "7a0e210fe29e2c81c378568eba2b467a7ef6a56e" }
+aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
 
 # Indexer
 processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "8e83cde3cb75fabdade9485e0af680cc4b73ca8e" }


### PR DESCRIPTION
# Summary
- Framework at test rev (d9... enabling bypassing EIP-55 in the Movement-side `initiate_brige_transfer` call
- Other Aptos deps at the most recent rev (7a...)


# Testing
- Should enable bridge FE to call `initiate_bridge_transfer` on the Movement side. Please test before merging.

# Outstanding issues
