### PR TITLE
Bridge: change Eth monitoring to manual pull

### DIFF
--- a/protocol-units/bridge/integration-tests/tests/client_eth_movement.rs
+++ b/protocol-units/bridge/integration-tests/tests/client_eth_movement.rs
@@ -4,21 +4,28 @@ use alloy::{
 };
 use anyhow::Result;
 use aptos_sdk::coin_client::CoinClient;
+use aptos_sdk::types::LocalAccount;
 use bridge_config::Config;
 use bridge_integration_tests::utils as test_utils;
 use bridge_integration_tests::EthToMovementCallArgs;
 use bridge_integration_tests::HarnessMvtClient;
 use bridge_integration_tests::TestHarness;
+use bridge_service::chains::bridge_contracts::BridgeContractEvent;
+use bridge_service::chains::ethereum::event_monitoring::EthMonitoring;
 use bridge_service::chains::ethereum::types::EthAddress;
+use bridge_service::chains::movement::utils::MovementAddress;
 use bridge_service::chains::{
 	bridge_contracts::BridgeContract, ethereum::types::EthHash, movement::utils::MovementHash,
 };
 use bridge_service::types::{
 	Amount, AssetType, BridgeAddress, BridgeTransferId, HashLock, HashLockPreImage,
 };
+use futures::StreamExt;
+use std::io::BufRead;
 use tokio::time::{sleep, Duration};
 use tokio::{self};
 use tracing::info;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::test]
 async fn test_movement_client_build_and_fund_accounts() -> Result<(), anyhow::Error> {
@@ -114,8 +121,7 @@ async fn test_movement_client_should_successfully_call_lock_and_complete(
 		assert_eq!(details.bridge_transfer_id.0, args.bridge_transfer_id.0);
 		assert_eq!(details.hash_lock.0, args.hash_lock.0);
 		assert_eq!(
-			&details.initiator_address.0,
-			&args.initiator,
+			&details.initiator_address.0, &args.initiator,
 			"Initiator address does not match"
 		);
 		assert_eq!(details.recipient_address.0, args.recipient);
@@ -145,8 +151,7 @@ async fn test_movement_client_should_successfully_call_lock_and_complete(
 		assert_eq!(details.bridge_transfer_id.0, args.bridge_transfer_id.0);
 		assert_eq!(details.hash_lock.0, args.hash_lock.0);
 		assert_eq!(
-			&details.initiator_address.0,
-			&args.initiator,
+			&details.initiator_address.0, &args.initiator,
 			"Initiator address does not match"
 		);
 		assert_eq!(details.recipient_address.0, args.recipient);
@@ -224,8 +229,7 @@ async fn test_movement_client_should_successfully_call_lock_and_abort() -> Resul
 		assert_eq!(details.bridge_transfer_id.0, args.bridge_transfer_id.0);
 		assert_eq!(details.hash_lock.0, args.hash_lock.0);
 		assert_eq!(
-			&details.initiator_address.0,
-			&args.initiator,
+			&details.initiator_address.0, &args.initiator,
 			"Initiator address does not match"
 		);
 		assert_eq!(details.recipient_address.0, args.recipient);
@@ -251,8 +255,7 @@ async fn test_movement_client_should_successfully_call_lock_and_abort() -> Resul
 		assert_eq!(abort_details.bridge_transfer_id.0, args.bridge_transfer_id.0);
 		assert_eq!(abort_details.hash_lock.0, args.hash_lock.0);
 		assert_eq!(
-			&abort_details.initiator_address.0,
-			&args.initiator,
+			&abort_details.initiator_address.0, &args.initiator,
 			"Initiator address does not match"
 		);
 		assert_eq!(abort_details.recipient_address.0, args.recipient);
@@ -455,4 +458,104 @@ async fn test_eth_client_should_successfully_complete_transfer() {
 		.expect("Failed to initiate bridge transfer");
 
 	//TODO: Here call complete with the id captured from the event
+}
+
+#[tokio::test]
+async fn test_eth_client_lock_then_complete_transfer() -> Result<(), anyhow::Error> {
+	tracing_subscriber::fmt()
+		.with_env_filter(
+			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+		)
+		.init();
+
+	let config = Config::default();
+	let (mut eth_client_harness, config, mut anvil) =
+		TestHarness::new_only_eth(config.clone()).await;
+
+	println!("Config :{config:?}",);
+
+	let mut eth_monitoring = EthMonitoring::build(&config.eth).await.unwrap();
+
+	let signer_address: alloy::primitives::Address = eth_client_harness.signer_address();
+
+	let recipient_privkey = LocalAccount::generate(&mut rand::rngs::OsRng);
+	let recipient_address = MovementAddress(recipient_privkey.address());
+	let recipient_bytes: Vec<u8> = recipient_address.into();
+
+	let secret = "secret".to_string();
+	let hash_lock = keccak256(secret.as_bytes());
+	let hash_lock: [u8; 32] = hash_lock.into();
+
+	println!("Before initiate_bridge_transfer");
+
+	eth_client_harness
+		.eth_client
+		.initiate_bridge_transfer(
+			BridgeAddress(EthAddress(signer_address)),
+			BridgeAddress(recipient_bytes.clone()),
+			HashLock(EthHash(hash_lock).0),
+			Amount(AssetType::EthAndWeth((42, 0))),
+		)
+		.await
+		.expect("Failed to initiate bridge transfer");
+
+	// Wait for InitialtorCompleted event
+	tracing::info!("Wait for Bridge Initiated event.");
+	let bridge_transfer_id;
+	loop {
+		let event =
+			tokio::time::timeout(std::time::Duration::from_secs(30), eth_monitoring.next()).await?;
+		if let Some(Ok(BridgeContractEvent::Initiated(detail))) = event {
+			bridge_transfer_id = detail.bridge_transfer_id;
+			break;
+		} else {
+			println!("wrong event {event:?}",);
+		}
+	}
+	println!("Initialte Event ok. Before lock_bridge_transfer");
+
+	//let bridge_transfer_id = BridgeTransferId::gen_unique_hash(&mut rand::rngs::OsRng);
+
+	// let secret = b"secret";
+	// let mut padded_secret = [0u8; 32];
+	// padded_secret[..secret.len()].copy_from_slice(secret);
+
+	// BridgeContract::counterparty_complete_bridge_transfer(
+	// 	&mut eth_client_harness.eth_client,
+	// 	bridge_transfer_id,
+	// 	HashLockPreImage(padded_secret),
+	// )
+	// .await
+	// .expect("Failed to complete bridge transfer");
+
+	// let res = eth_client_harness
+	// 	.eth_client
+	// 	.lock_bridge_transfer(
+	// 		BridgeTransferId([3; 32]),
+	// 		HashLock([1; 32]),
+	// 		BridgeAddress(vec![2; 32]),
+	// 		BridgeAddress(EthAddress(signer_address)),
+	// 		Amount(AssetType::EthAndWeth((0, 42))),
+	// 	)
+	// 	.await;
+	//println!("{res:?}",);
+	loop {
+		let event =
+			tokio::time::timeout(std::time::Duration::from_secs(30), eth_monitoring.next()).await?;
+		if let Some(Ok(BridgeContractEvent::Locked(detail))) = event {
+			break;
+		}
+	}
+
+	let stdout = anvil.child_mut().stdout.take().unwrap();
+	let mut reader = std::io::BufReader::new(stdout).lines();
+	while let Some(Ok(line)) = reader.next() {
+		println!(">:{:?}", line);
+		// writer.write_all(line.as_bytes()).await?;
+		// writer.write_all(b"\n").await?;
+		// output.push_str(&line);
+		// output.push('\n');
+	}
+
+	Ok(())
 }

--- a/protocol-units/bridge/integration-tests/tests/client_eth_movement.rs
+++ b/protocol-units/bridge/integration-tests/tests/client_eth_movement.rs
@@ -514,31 +514,6 @@ async fn test_eth_client_lock_then_complete_transfer() -> Result<(), anyhow::Err
 	}
 	println!("Initialte Event ok. Before lock_bridge_transfer");
 
-	//let bridge_transfer_id = BridgeTransferId::gen_unique_hash(&mut rand::rngs::OsRng);
-
-	// let secret = b"secret";
-	// let mut padded_secret = [0u8; 32];
-	// padded_secret[..secret.len()].copy_from_slice(secret);
-
-	// BridgeContract::counterparty_complete_bridge_transfer(
-	// 	&mut eth_client_harness.eth_client,
-	// 	bridge_transfer_id,
-	// 	HashLockPreImage(padded_secret),
-	// )
-	// .await
-	// .expect("Failed to complete bridge transfer");
-
-	// let res = eth_client_harness
-	// 	.eth_client
-	// 	.lock_bridge_transfer(
-	// 		BridgeTransferId([3; 32]),
-	// 		HashLock([1; 32]),
-	// 		BridgeAddress(vec![2; 32]),
-	// 		BridgeAddress(EthAddress(signer_address)),
-	// 		Amount(AssetType::EthAndWeth((0, 42))),
-	// 	)
-	// 	.await;
-	//println!("{res:?}",);
 	loop {
 		let event =
 			tokio::time::timeout(std::time::Duration::from_secs(30), eth_monitoring.next()).await?;
@@ -551,10 +526,6 @@ async fn test_eth_client_lock_then_complete_transfer() -> Result<(), anyhow::Err
 	let mut reader = std::io::BufReader::new(stdout).lines();
 	while let Some(Ok(line)) = reader.next() {
 		println!(">:{:?}", line);
-		// writer.write_all(line.as_bytes()).await?;
-		// writer.write_all(b"\n").await?;
-		// output.push_str(&line);
-		// output.push('\n');
 	}
 
 	Ok(())

--- a/protocol-units/bridge/service/src/chains/movement/event_monitoring.rs
+++ b/protocol-units/bridge/service/src/chains/movement/event_monitoring.rs
@@ -27,10 +27,10 @@ use hex::FromHex;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
-use tracing::info;
 use std::{pin::Pin, task::Poll};
 use tokio::fs::{self, File};
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
+use tracing::info;
 
 const PULL_STATE_FILE_NAME: &str = "pullstate.store";
 
@@ -244,8 +244,10 @@ async fn pool_initiator_contract(
 	rest_url: &str,
 	pull_state: &MvtPullingState,
 ) -> BridgeContractResult<Vec<(BridgeContractEvent<MovementAddress>, u64)>> {
-	let struct_tag =
-	format!("{}::atomic_bridge_initiator::BridgeInitiatorEvents", framework_address.to_string());
+	let struct_tag = format!(
+		"{}::atomic_bridge_initiator::BridgeInitiatorEvents",
+		framework_address.to_string()
+	);
 	// Get initiated events
 	let initiated_events = get_account_events(
 		rest_url,
@@ -343,8 +345,10 @@ async fn pool_counterparty_contract(
 	rest_url: &str,
 	pull_state: &MvtPullingState,
 ) -> BridgeContractResult<Vec<(BridgeContractEvent<MovementAddress>, u64)>> {
-	let struct_tag =
-		format!("{}::atomic_bridge_counterparty::BridgeCounterpartyEvents", FRAMEWORK_ADDRESS.to_string());
+	let struct_tag = format!(
+		"{}::atomic_bridge_counterparty::BridgeCounterpartyEvents",
+		FRAMEWORK_ADDRESS.to_string()
+	);
 
 	// Get locked events
 	let locked_events = get_account_events(
@@ -515,7 +519,7 @@ impl TryFrom<BridgeInitEventData> for BridgeTransferDetails<MovementAddress> {
 			})?),
 			time_lock: TimeLock(data.time_lock),
 			amount: Amount(AssetType::Moveth(data.amount)),
-			state: 0
+			state: 0,
 		})
 	}
 }

--- a/protocol-units/bridge/service/src/chains/movement/utils.rs
+++ b/protocol-units/bridge/service/src/chains/movement/utils.rs
@@ -3,7 +3,6 @@ use crate::chains::bridge_contracts::BridgeContractError;
 use crate::types::{BridgeAddress, HashLockPreImage};
 use anyhow::{Context, Result};
 use aptos_sdk::crypto::ed25519::Ed25519PrivateKey;
-use aptos_sdk::crypto::ed25519::Ed25519PublicKey;
 use aptos_sdk::types::AccountKey;
 use aptos_sdk::{
 	crypto::ed25519::Ed25519Signature,
@@ -35,7 +34,7 @@ use serde_json::Value;
 use std::str::FromStr;
 use thiserror::Error;
 use tiny_keccak::{Hasher, Keccak};
-use tracing::log::{debug, error, info};
+use tracing::log::{error, info};
 pub type TestRng = StdRng;
 
 pub trait RngSeededClone: Rng + SeedableRng {
@@ -186,7 +185,7 @@ pub async fn send_and_confirm_aptos_transaction(
 
 	let signed_tx = signer.sign_transaction(raw_tx);
 
-	info!("Signed TX: {:?}", signed_tx);
+	//info!("Signed TX: {:?}", signed_tx);
 
 	let response = rest_client.submit_and_wait(&signed_tx).await.map_err(|e| {
 		let err_msg = format!("Transaction submission error: {}", e.to_string());
@@ -195,7 +194,7 @@ pub async fn send_and_confirm_aptos_transaction(
 	})?;
 
 	let txn = response.into_inner();
-	info!("Response: {:?}", txn);
+	//info!("Response: {:?}", txn);
 
 	match &txn {
 		Transaction::UserTransaction(user_txn) => {
@@ -385,35 +384,35 @@ pub async fn create_local_account(
 	Ok(local_account)
 }
 fn keccak256(input: &str) -> Vec<u8> {
-        let mut hasher = Keccak::v256();
-        let mut output = [0u8; 32];
-        hasher.update(input.as_bytes());
-        hasher.finalize(&mut output);
-        output.to_vec()
+	let mut hasher = Keccak::v256();
+	let mut output = [0u8; 32];
+	hasher.update(input.as_bytes());
+	hasher.finalize(&mut output);
+	output.to_vec()
 }
 
 pub fn to_eip55(address: &str) -> String {
-        let lowercased_address = address.trim_start_matches("0x").to_lowercase();
-        let hash = keccak256(&lowercased_address);
+	let lowercased_address = address.trim_start_matches("0x").to_lowercase();
+	let hash = keccak256(&lowercased_address);
 
-        lowercased_address
-                .chars()
-                .enumerate()
-                .map(|(i, c)| {
-                        if c.is_digit(10) {
-                                c
-                        } else {
-                                let byte_index = i / 2;
-                                let nibble_index = i % 2;
-                                let hash_byte = hash[byte_index];
-                                let should_uppercase = (hash_byte >> (4 * (1 - nibble_index))) & 0xF >= 8;
+	lowercased_address
+		.chars()
+		.enumerate()
+		.map(|(i, c)| {
+			if c.is_digit(10) {
+				c
+			} else {
+				let byte_index = i / 2;
+				let nibble_index = i % 2;
+				let hash_byte = hash[byte_index];
+				let should_uppercase = (hash_byte >> (4 * (1 - nibble_index))) & 0xF >= 8;
 
-                                if should_uppercase {
-                                        c.to_ascii_uppercase()
-                                } else {
-                                        c.to_ascii_lowercase()
-                                }
-                        }
-                })
-                .collect()
+				if should_uppercase {
+					c.to_ascii_uppercase()
+				} else {
+					c.to_ascii_lowercase()
+				}
+			}
+		})
+		.collect()
 }


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

<!--
Add your summary text here. 
 -->
Change the Eth pulling to pull manual using RPC.
# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->