### PR TITLE
remove pool balance

### DIFF
--- a/protocol-units/bridge/contracts/script/DeployAtomicBridgeInitiatorMOVE.s.sol
+++ b/protocol-units/bridge/contracts/script/DeployAtomicBridgeInitiatorMOVE.s.sol
@@ -19,7 +19,6 @@ contract AtomicBridgeInitiatorMOVEDeployer is Script {
     address public moveTokenAddress = address(0xC36ba8B8fD9EcbF36288b9B9B0ae9FC3E0645227); 
     address public ownerAddress = address(0x5b97cdf756f6363A88706c376464180E008Bd88b); 
     uint256 public timeLockDuration = 2 days; // 48 hours in seconds
-    uint256 public initialPoolBalance = 1 ether; // Initial pool balance
     uint256 public minDelay = 2 days; // 2-day delay for governance timelock
 
     // Safe addresses (replace these with actual safe addresses)
@@ -62,8 +61,7 @@ contract AtomicBridgeInitiatorMOVEDeployer is Script {
                 atomicBridgeSignature,
                 moveTokenAddress,  // MOVE token address
                 ownerAddress,      // Owner of the contract
-                timeLockDuration,  // Timelock duration (48 hours)
-                initialPoolBalance // Initial pool balance
+                timeLockDuration  // Timelock duration (48 hours)
             )
         );
 
@@ -86,8 +84,7 @@ contract AtomicBridgeInitiatorMOVEDeployer is Script {
                     atomicBridgeSignature,
                     moveTokenAddress, 
                     ownerAddress, 
-                    timeLockDuration, 
-                    initialPoolBalance
+                    timeLockDuration
                 )
             ),
             bytes32(0),

--- a/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeCounterparty.sol
@@ -53,12 +53,7 @@ contract AtomicBridgeCounterparty is IAtomicBridgeCounterparty, OwnableUpgradeab
         address recipient,
         uint256 amount
     ) external onlyOwner returns (bool) {
-        if (amount == 0) revert ZeroAmount();
-
-        if (atomicBridgeInitiator.poolBalance() < amount) revert InsufficientWethBalance();
-        
-        // potentially mint some gas here for the recipient here. The recipient could be an account with gas already.
-
+        if (amount == 0) revert ZeroAmount();        
         // The time lock is now based on the configurable duration
         uint256 timeLock = block.timestamp + counterpartyTimeLockDuration;
 

--- a/protocol-units/bridge/contracts/src/AtomicBridgeCounterpartyMOVE.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeCounterpartyMOVE.sol
@@ -57,8 +57,6 @@ contract AtomicBridgeCounterpartyMOVE is IAtomicBridgeCounterpartyMOVE, OwnableU
         uint256 amount
     ) external onlyOwner returns (bool) {
         if (amount == 0) revert ZeroAmount();
-        if (atomicBridgeInitiatorMOVE.poolBalance() < amount) revert InsufficientMOVEBalance();
-
         // The time lock is now based on the configurable duration
         uint256 timeLock = block.timestamp + counterpartyTimeLockDuration;
 

--- a/protocol-units/bridge/contracts/src/AtomicBridgeCounterpartyMOVE.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeCounterpartyMOVE.sol
@@ -55,7 +55,7 @@ contract AtomicBridgeCounterpartyMOVE is IAtomicBridgeCounterpartyMOVE, OwnableU
         bytes32 hashLock,
         address recipient,
         uint256 amount
-    ) external onlyOwner returns (bool) {
+    ) external onlyOwner {
         if (amount == 0) revert ZeroAmount();
         // The time lock is now based on the configurable duration
         uint256 timeLock = block.timestamp + counterpartyTimeLockDuration;
@@ -70,7 +70,6 @@ contract AtomicBridgeCounterpartyMOVE is IAtomicBridgeCounterpartyMOVE, OwnableU
         });
 
         emit BridgeTransferLocked(bridgeTransferId, recipient, amount, hashLock, counterpartyTimeLockDuration);
-        return true;
     }
 
     function completeBridgeTransfer(bytes32 bridgeTransferId, bytes32 preImage) external {

--- a/protocol-units/bridge/contracts/src/IAtomicBridgeCounterpartyMOVE.sol
+++ b/protocol-units/bridge/contracts/src/IAtomicBridgeCounterpartyMOVE.sol
@@ -33,7 +33,6 @@ interface IAtomicBridgeCounterpartyMOVE {
      * @param hashLock The hash of the secret (HASH) that will unlock the funds
      * @param recipient The address to which to transfer the funds
      * @param amount The amount of WETH to lock
-     * @return bool indicating successful lock
      *
      */
     function lockBridgeTransfer(
@@ -42,7 +41,7 @@ interface IAtomicBridgeCounterpartyMOVE {
         bytes32 hashLock,
         address recipient,
         uint256 amount
-    ) external returns (bool);
+    ) external;
 
     /**
      * @dev Completes the bridge transfer and withdraws WETH to the recipient

--- a/protocol-units/bridge/contracts/test/AtomicBridgeCounterparty.t.sol
+++ b/protocol-units/bridge/contracts/test/AtomicBridgeCounterparty.t.sol
@@ -45,11 +45,10 @@ contract AtomicBridgeCounterpartyTest is Test {
             address(atomicBridgeInitiatorImplementation),
             address(proxyAdmin),
             abi.encodeWithSignature(
-                "initialize(address,address,uint256,uint256)", 
+                "initialize(address,address,uint256)", 
                 wethAddress, 
                 deployer, 
-                initiatorTimeLockDuration, // Set 48-hour time lock for the initiator
-                0 ether // Initial pool balance 
+                initiatorTimeLockDuration // Set 48-hour time lock for the initiator
             )
         );
 

--- a/protocol-units/bridge/contracts/test/AtomicBridgeCounterpartyMOVE.t.sol
+++ b/protocol-units/bridge/contracts/test/AtomicBridgeCounterpartyMOVE.t.sol
@@ -58,11 +58,10 @@ contract AtomicBridgeCounterpartyMOVETest is Test {
             address(atomicBridgeInitiatorMOVEImplementation),
             address(proxyAdmin),
             abi.encodeWithSignature(
-                "initialize(address,address,uint256,uint256)",
+                "initialize(address,address,uint256)",
                 address(moveToken),
                 deployer, 
-                initiatorTimeLockDuration,
-                0 ether // Initial pool balance
+                initiatorTimeLockDuration
             )
         );
         atomicBridgeInitiatorMOVE = AtomicBridgeInitiatorMOVE(address(proxy));

--- a/protocol-units/bridge/contracts/test/AtomicBridgeCounterpartyMOVE.t.sol
+++ b/protocol-units/bridge/contracts/test/AtomicBridgeCounterpartyMOVE.t.sol
@@ -106,7 +106,7 @@ contract AtomicBridgeCounterpartyMOVETest is Test {
         vm.stopPrank();
 
         vm.startPrank(deployer);  // Only the owner (deployer) can call lockBridgeTransfer
-        bool result = atomicBridgeCounterpartyMOVE.lockBridgeTransfer(
+        atomicBridgeCounterpartyMOVE.lockBridgeTransfer(
             initiator,
             bridgeTransferId,
             hashLock,
@@ -124,7 +124,6 @@ contract AtomicBridgeCounterpartyMOVETest is Test {
             AtomicBridgeCounterpartyMOVE.MessageState pendingState
         ) = atomicBridgeCounterpartyMOVE.bridgeTransfers(bridgeTransferId);
 
-        assert(result);
         assertEq(pendingInitiator, initiator);
         assertEq(pendingRecipient, recipient);
         assertEq(pendingAmount, amount);

--- a/protocol-units/bridge/contracts/test/AtomicBridgeInitiator.t.sol
+++ b/protocol-units/bridge/contracts/test/AtomicBridgeInitiator.t.sol
@@ -21,7 +21,6 @@ contract AtomicBridgeInitiatorWethTest is Test {
     bytes32 public hashLock = keccak256(abi.encodePacked("secret"));
     uint256 public amount = 1 ether;
     uint256 public constant timeLockDuration = 48 * 60 * 60; // 48 hours in seconds
-    uint256 public initialPoolBalance = 0 ether;
 
     function setUp() public {
         // Sepolia WETH9 address
@@ -38,11 +37,10 @@ contract AtomicBridgeInitiatorWethTest is Test {
             address(atomicBridgeInitiatorImplementation),
             address(proxyAdmin),
             abi.encodeWithSignature(
-                "initialize(address,address,uint256,uint256)",
+                "initialize(address,address,uint256)",
                 wethAddress,
                 address(this),
-                timeLockDuration,
-                initialPoolBalance
+                timeLockDuration
             )
         );
 

--- a/protocol-units/bridge/contracts/test/AtomicBridgeInitiatorMOVE.t.sol
+++ b/protocol-units/bridge/contracts/test/AtomicBridgeInitiatorMOVE.t.sol
@@ -40,11 +40,10 @@ contract AtomicBridgeInitiatorMOVETest is Test {
             address(atomicBridgeInitiatorImplementation),
             address(proxyAdmin),
             abi.encodeWithSignature(
-                "initialize(address,address,uint256,uint256)",
+                "initialize(address,address,uint256)",
                 address(moveToken),
                 address(this),
-                timeLockDuration,
-                0 ether
+                timeLockDuration
             )
         );
 


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

Removes Pool Balance from eth contracts.

# Changelog


# Testing

> cd /Users/user/movement/protocol-units/bridge/contracts

> forge test

# Outstanding issues

There are tests that are failing in main branch. Disregard them