### PR TITLE
Read-only mode for Suzuka node

### DIFF
--- a/networks/suzuka/suzuka-full-node/src/partial.rs
+++ b/networks/suzuka/suzuka-full-node/src/partial.rs
@@ -31,9 +31,7 @@ where
 	/// Runs the executor until crash or shutdown.
 	pub async fn run(self) -> Result<(), anyhow::Error> {
 		let (transaction_sender, transaction_receiver) = mpsc::channel(16);
-		let (context, exec_background) = self
-			.executor
-			.background(transaction_sender, &self.config.execution_config.maptos_config)?;
+		let (context, exec_background) = self.executor.background(transaction_sender)?;
 		let services = context.services();
 		let mut movement_rest = self.movement_rest;
 		movement_rest.set_context(services.opt_api_context());
@@ -97,7 +95,7 @@ impl SuzukaPartialNode<Executor> {
 		.context("Failed to connect to light node")?;
 
 		debug!("Creating the executor");
-		let executor = Executor::try_from_config(&config.execution_config.maptos_config)
+		let executor = Executor::try_from_config(config.execution_config.maptos_config.clone())
 			.context("Failed to create the inner executor")?;
 
 		debug!("Creating the settlement client");

--- a/protocol-units/execution/dof/src/lib.rs
+++ b/protocol-units/execution/dof/src/lib.rs
@@ -27,7 +27,6 @@ pub trait DynOptFinExecutor {
 	fn background(
 		&self,
 		transaction_sender: Sender<SignedTransaction>,
-		config: &Config,
 	) -> Result<
 		(Self::Context, impl Future<Output = Result<(), anyhow::Error>> + Send + 'static),
 		anyhow::Error,

--- a/protocol-units/execution/fin-view/src/fin_view.rs
+++ b/protocol-units/execution/fin-view/src/fin_view.rs
@@ -77,7 +77,7 @@ mod tests {
 		// Create an Executor and a FinalityView instance from the environment configuration.
 		let config = Config::default();
 		let (tx_sender, _tx_receiver) = mpsc::channel(16);
-		let executor = Executor::try_from_config(&config)?;
+		let executor = Executor::try_from_config(config)?;
 		let (context, _transaction_pipe) = executor.background(tx_sender)?;
 		let finality_view = FinalityView::new(context.db_reader());
 		let service = finality_view.service(

--- a/protocol-units/execution/opt-executor/src/executor/execution.rs
+++ b/protocol-units/execution/opt-executor/src/executor/execution.rs
@@ -264,7 +264,7 @@ mod tests {
 	async fn test_execute_block() -> Result<(), anyhow::Error> {
 		let private_key = Ed25519PrivateKey::generate_for_testing();
 		let (tx_sender, _tx_receiver) = mpsc::channel(1);
-		let (executor, _config, _tempdir) = Executor::try_test_default(private_key)?;
+		let (executor, _tempdir) = Executor::try_test_default(private_key)?;
 		let (context, _transaction_pipe) = executor.background(tx_sender)?;
 		let block_id = HashValue::random();
 		let block_metadata = Transaction::BlockMetadata(BlockMetadata::new(
@@ -298,7 +298,7 @@ mod tests {
 		// Create an executor instance from the environment configuration.
 		let private_key = Ed25519PrivateKey::generate_for_testing();
 		let (tx_sender, _tx_receiver) = mpsc::channel(1);
-		let (executor, _config, _tempdir) = Executor::try_test_default(private_key)?;
+		let (executor, _tempdir) = Executor::try_test_default(private_key)?;
 		let (context, _transaction_pipe) = executor.background(tx_sender)?;
 		executor.rollover_genesis_now().await?;
 
@@ -400,7 +400,7 @@ mod tests {
 		// Create an executor instance from the environment configuration.
 		let private_key = Ed25519PrivateKey::generate_for_testing();
 		let (tx_sender, _tx_receiver) = mpsc::channel(16);
-		let (executor, _config, _tempdir) = Executor::try_test_default(private_key)?;
+		let (executor, _tempdir) = Executor::try_test_default(private_key)?;
 		let (context, _transaction_pipe) = executor.background(tx_sender)?;
 		let service = Service::new(&context);
 		executor.rollover_genesis_now().await?;

--- a/protocol-units/execution/opt-executor/src/executor/initialization.rs
+++ b/protocol-units/execution/opt-executor/src/executor/initialization.rs
@@ -25,7 +25,7 @@ use std::sync::{atomic::AtomicU64, Arc};
 const EXECUTOR_CHANNEL_SIZE: usize = 2_usize.pow(16);
 
 impl Executor {
-	pub fn bootstrap(maptos_config: &Config) -> Result<Self, anyhow::Error> {
+	pub fn bootstrap(maptos_config: Config) -> Result<Self, anyhow::Error> {
 		// set up the node config
 		let mut node_config = NodeConfig::default();
 
@@ -100,14 +100,14 @@ impl Executor {
 		})
 	}
 
-	pub fn try_from_config(maptos_config: &Config) -> Result<Self, anyhow::Error> {
+	pub fn try_from_config(maptos_config: Config) -> Result<Self, anyhow::Error> {
 		Self::bootstrap(maptos_config)
 	}
 
 	#[cfg(test)]
 	pub fn try_test_default(
 		private_key: Ed25519PrivateKey,
-	) -> Result<(Self, Config, TempDir), anyhow::Error> {
+	) -> Result<(Self, TempDir), anyhow::Error> {
 		let tempdir = tempfile::tempdir()?;
 
 		let mut maptos_config = Config::default();
@@ -115,8 +115,8 @@ impl Executor {
 
 		// replace the db path with the temporary directory
 		maptos_config.chain.maptos_db_path.replace(tempdir.path().to_path_buf());
-		let executor = Self::try_from_config(&maptos_config)?;
-		Ok((executor, maptos_config, tempdir))
+		let executor = Self::try_from_config(maptos_config)?;
+		Ok((executor, tempdir))
 	}
 
 	/// Creates an instance of [`Context`] and the background [`TransactionPipe`]

--- a/protocol-units/execution/opt-executor/src/service.rs
+++ b/protocol-units/execution/opt-executor/src/service.rs
@@ -115,7 +115,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_pipe_mempool_while_server_running() -> Result<(), anyhow::Error> {
 		let (tx_sender, mut tx_receiver) = mpsc::channel(16);
-		let (executor, config, _tempdir) = Executor::try_test_default(GENESIS_KEYPAIR.0.clone())?;
+		let (executor, _tempdir) = Executor::try_test_default(GENESIS_KEYPAIR.0.clone())?;
 		let (context, mut transaction_pipe) = executor.background(tx_sender)?;
 		let service = Service::new(&context);
 		let handle = tokio::spawn(async move { service.run().await });

--- a/protocol-units/execution/opt-executor/src/transaction_pipe.rs
+++ b/protocol-units/execution/opt-executor/src/transaction_pipe.rs
@@ -304,8 +304,7 @@ mod tests {
 
 	fn setup() -> (TransactionPipe, MempoolClientSender, mpsc::Receiver<SignedTransaction>) {
 		let (tx_sender, tx_receiver) = mpsc::channel(16);
-		let (executor, config, _tempdir) =
-			Executor::try_test_default(GENESIS_KEYPAIR.0.clone()).unwrap();
+		let (executor, _tempdir) = Executor::try_test_default(GENESIS_KEYPAIR.0.clone()).unwrap();
 		let (context, transaction_pipe) = executor.background(tx_sender).unwrap();
 		(transaction_pipe, context.mempool_client_sender(), tx_receiver)
 	}
@@ -415,7 +414,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_pipe_mempool_from_api() -> Result<(), anyhow::Error> {
 		let (tx_sender, mut tx_receiver) = mpsc::channel(16);
-		let (executor, config, _tempdir) = Executor::try_test_default(GENESIS_KEYPAIR.0.clone())?;
+		let (executor, _tempdir) = Executor::try_test_default(GENESIS_KEYPAIR.0.clone())?;
 		let (context, mut transaction_pipe) = executor.background(tx_sender)?;
 		let service = Service::new(&context);
 
@@ -444,7 +443,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_repeated_pipe_mempool_from_api() -> Result<(), anyhow::Error> {
 		let (tx_sender, mut tx_receiver) = mpsc::channel(16);
-		let (executor, _config, _tempdir) = Executor::try_test_default(GENESIS_KEYPAIR.0.clone())?;
+		let (executor, _tempdir) = Executor::try_test_default(GENESIS_KEYPAIR.0.clone())?;
 		let (context, mut transaction_pipe) = executor.background(tx_sender)?;
 		let service = Service::new(&context);
 
@@ -513,7 +512,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_sequence_number_too_old() -> Result<(), anyhow::Error> {
 		let (tx_sender, _tx_receiver) = mpsc::channel(16);
-		let (executor, _config, _tempdir) = Executor::try_test_default(GENESIS_KEYPAIR.0.clone())?;
+		let (executor, _tempdir) = Executor::try_test_default(GENESIS_KEYPAIR.0.clone())?;
 		let (context, mut transaction_pipe) = executor.background(tx_sender)?;
 
 		#[allow(unreachable_code)]

--- a/protocol-units/execution/util/src/config/chain.rs
+++ b/protocol-units/execution/util/src/config/chain.rs
@@ -2,7 +2,7 @@ use super::common::{
 	default_maptos_chain_id, default_maptos_epoch_snapshot_prune_window,
 	default_maptos_ledger_prune_window, default_maptos_private_key,
 	default_maptos_rest_listen_hostname, default_maptos_rest_listen_port,
-	default_maptos_state_merkle_prune_window,
+	default_maptos_state_merkle_prune_window, default_read_only,
 };
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_types::chain_id::ChainId;
@@ -27,6 +27,9 @@ pub struct Config {
 	#[serde(default = "default_maptos_private_key")]
 	pub maptos_private_key: Ed25519PrivateKey,
 
+	#[serde(default)]
+	pub read_only: bool,
+
 	/// Ledger prune window
 	#[serde(default = "default_maptos_ledger_prune_window")]
 	pub maptos_ledger_prune_window: u64,
@@ -50,6 +53,7 @@ impl Default for Config {
 			maptos_rest_listen_hostname: default_maptos_rest_listen_hostname(),
 			maptos_rest_listen_port: default_maptos_rest_listen_port(),
 			maptos_private_key: default_maptos_private_key(),
+			read_only: default_read_only(),
 			maptos_ledger_prune_window: default_maptos_ledger_prune_window(),
 			maptos_epoch_snapshot_prune_window: default_maptos_epoch_snapshot_prune_window(),
 			maptos_state_merkle_prune_window: default_maptos_state_merkle_prune_window(),

--- a/protocol-units/execution/util/src/config/common.rs
+++ b/protocol-units/execution/util/src/config/common.rs
@@ -70,6 +70,9 @@ env_default!(
 // The default chain id
 env_default!(default_maptos_chain_id, "MAPTOS_CHAIN_ID", ChainId, ChainId::from_str("27").unwrap());
 
+// The default read-only mode
+env_default!(default_read_only, "MAPTOS_READ_ONLY", bool, false);
+
 // The default private key
 pub fn default_maptos_private_key() -> Ed25519PrivateKey {
 	match std::env::var("MAPTOS_PRIVATE_KEY") {


### PR DESCRIPTION
# Summary
- **Categories**: `protocol-units`, `networks`.

Add a read-only flag to configuration.
If set, disable transaction submission and related requests
in the API.

# Changelog

* Read-only mode for executor, activated with the `MAPTOS_READ_ONLY` boolean environment variable.

# Testing

TODO: add tests to enable the mode and confirm the API behavior is as expected.