### PR TITLE
Bridge: set from before gas_estimation

### DIFF
--- a/protocol-units/bridge/integration-tests/tests/bridge_e2e_test.rs
+++ b/protocol-units/bridge/integration-tests/tests/bridge_e2e_test.rs
@@ -62,7 +62,7 @@ async fn initiate_eth_bridge_transfer(
 		.from(*initiator_address.0);
 	let _ = send_transaction(
 		call,
-		initiator_address,
+		**initiator_address,
 		&send_transaction_rules(),
 		config.eth.transaction_send_retries,
 		config.eth.gas_limit as u128,

--- a/protocol-units/bridge/integration-tests/tests/bridge_e2e_test.rs
+++ b/protocol-units/bridge/integration-tests/tests/bridge_e2e_test.rs
@@ -62,6 +62,7 @@ async fn initiate_eth_bridge_transfer(
 		.from(*initiator_address.0);
 	let _ = send_transaction(
 		call,
+		initiator_address,
 		&send_transaction_rules(),
 		config.eth.transaction_send_retries,
 		config.eth.gas_limit as u128,

--- a/protocol-units/bridge/integration-tests/tests/bridge_e2e_test_framework.rs
+++ b/protocol-units/bridge/integration-tests/tests/bridge_e2e_test_framework.rs
@@ -58,7 +58,7 @@ async fn initiate_eth_bridge_transfer(
 		.from(*initiator_address.0);
 	let _ = send_transaction(
 		call,
-		initiator_address,
+		**initiator_address,
 		&send_transaction_rules(),
 		config.eth.transaction_send_retries,
 		config.eth.gas_limit as u128,

--- a/protocol-units/bridge/integration-tests/tests/bridge_e2e_test_framework.rs
+++ b/protocol-units/bridge/integration-tests/tests/bridge_e2e_test_framework.rs
@@ -12,16 +12,15 @@ use bridge_service::{
 		bridge_contracts::{BridgeContractError, BridgeContractEvent},
 		ethereum::{
 			event_monitoring::EthMonitoring,
-			types::{EthAddress, AtomicBridgeInitiator},
+			types::{AtomicBridgeInitiator, EthAddress},
 			utils::{send_transaction, send_transaction_rules},
 		},
 		movement::{
-			client_framework::MovementClientFramework, 
-			event_monitoring::MovementMonitoring, 
+			client_framework::MovementClientFramework, event_monitoring::MovementMonitoring,
 			utils::MovementAddress,
 		},
 	},
-	types::{Amount, AssetType, BridgeAddress, HashLock, HashLockPreImage}
+	types::{Amount, AssetType, BridgeAddress, HashLock, HashLockPreImage},
 };
 use futures::StreamExt;
 use tracing_subscriber::EnvFilter;
@@ -59,6 +58,7 @@ async fn initiate_eth_bridge_transfer(
 		.from(*initiator_address.0);
 	let _ = send_transaction(
 		call,
+		initiator_address,
 		&send_transaction_rules(),
 		config.eth.transaction_send_retries,
 		config.eth.gas_limit as u128,
@@ -70,9 +70,7 @@ async fn initiate_eth_bridge_transfer(
 
 #[tokio::test]
 async fn test_bridge_transfer_eth_movement_happy_path() -> Result<(), anyhow::Error> {
-	tracing_subscriber::fmt()
-	.with_env_filter(EnvFilter::new("info"))
-	.init();
+	tracing_subscriber::fmt().with_env_filter(EnvFilter::new("info")).init();
 
 	let (_eth_client_harness, mut mvt_client_harness, config) =
 		TestHarness::new_with_eth_and_movement().await?;
@@ -170,7 +168,7 @@ async fn test_movement_event() -> Result<(), anyhow::Error> {
 		args.initiator.0,
 		args.recipient.clone(),
 		args.hash_lock.0,
-		args.amount
+		args.amount,
 	)
 	.await
 	.expect("Failed to initiate bridge transfer");

--- a/protocol-units/bridge/service/src/chains/ethereum/utils.rs
+++ b/protocol-units/bridge/service/src/chains/ethereum/utils.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::Address;
 use std::str::FromStr;
 
 use crate::chains::ethereum::types::EthAddress;
@@ -73,12 +74,17 @@ pub async fn send_transaction<
 	D: CallDecoder + Clone,
 >(
 	base_call_builder: CallBuilder<T, &P, D, Ethereum>,
+	signer_address: Address,
 	send_transaction_error_rules: &[Box<dyn VerifyRule>],
 	number_retry: u32,
 	gas_limit: u128,
 ) -> Result<TransactionReceipt, anyhow::Error> {
 	println!("base_call_builder: {:?}", base_call_builder);
 	println!("Sending transaction with gas limit: {}", gas_limit);
+
+	// set signer address as from for gas_estimation.
+	// The gas estimate need to set teh from before calling.
+	let base_call_builder = base_call_builder.from(signer_address);
 	//validate gas price.
 	let mut estimate_gas = base_call_builder.estimate_gas().await?;
 	// Add 20% because initial gas estimate are too low.

--- a/protocol-units/bridge/setup/src/deploy.rs
+++ b/protocol-units/bridge/setup/src/deploy.rs
@@ -117,6 +117,7 @@ async fn initialize_initiator_contract(
 	transaction_send_retries: u32,
 ) -> Result<(), anyhow::Error> {
 	tracing::info!("Setup Eth initialize_initiator_contract with timelock:{timelock});");
+	let signer_address = signer_private_key.address();
 
 	let rpc_provider = ProviderBuilder::new()
 		.with_recommended_fillers()
@@ -129,9 +130,15 @@ async fn initialize_initiator_contract(
 
 	let call =
 		initiator_contract.initialize(weth.0, owner.0, U256::from(timelock), U256::from(100));
-	send_transaction(call, &send_transaction_rules(), transaction_send_retries, gas_limit.into())
-		.await
-		.expect("Failed to send transaction");
+	send_transaction(
+		call,
+		signer_address,
+		&send_transaction_rules(),
+		transaction_send_retries,
+		gas_limit.into(),
+	)
+	.await
+	.expect("Failed to send transaction");
 	Ok(())
 }
 


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

<!--
Add your summary text here. 
 -->
Update eth send_transaction to set the from(signer_address) before gas_estimation.
Correct an issue where gas_estimation doesn't set correctly the sender and revert onlyOwner contract call.
# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->