### PR TITLE
feat: keep relayer alive

### DIFF
--- a/protocol-units/bridge/config/src/common/movement.rs
+++ b/protocol-units/bridge/config/src/common/movement.rs
@@ -7,10 +7,10 @@ const DEFAULT_MVT_RPC_CONNECTION_HOSTNAME: &str = "127.0.0.1";
 const DEFAULT_MVT_RPC_CONNECTION_PORT: u16 = 8080;
 const DEFAULT_MVT_FAUCET_CONNECTION_HOSTNAME: &str = "127.0.0.1";
 const DEFAULT_MVT_FAUCET_CONNECTION_PORT: u16 = 8081;
-const DEFAULT_REST_CONNECTION_HOSTNAME: &str = "0.0.0.0";
-const DEFAULT_GRPC_CONNECTION_HOSTNAME: &str = "0.0.0.0";
-const DEFAULT_GRPC_CONNECTION_PORT: u16 = 50051;
-const DEFAULT_REST_CONNECTION_PORT: u16 = 30883;
+const DEFAULT_REST_LISTENER_HOSTNAME: &str = "0.0.0.0";
+const DEFAULT_GRPC_LISTENER_HOSTNAME: &str = "0.0.0.0";
+const DEFAULT_GRPC_LISTENER_PORT: u16 = 50051;
+const DEFAULT_REST_LISTENER_PORT: u16 = 30883;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MovementConfig {
@@ -37,17 +37,17 @@ pub struct MovementConfig {
 	pub mvt_init_network: String,
 
 	/// Endpoint for the REST service
-	#[serde(default = "default_rest_connection_hostname")]
-	pub rest_hostname: String,
-	#[serde(default = "default_rest_connection_port")]
+	#[serde(default = "default_rest_listener_hostname")]
+	pub rest_listener_hostname: String,
+	#[serde(default = "default_rest_listener_port")]
 	pub rest_port: u16,
 
 	// gRPC service connection details
 	#[serde(default = "default_grpc_connection_protocol")]
 	pub grpc_protocol: String,
-	#[serde(default = "default_grpc_connection_hostname")]
-	pub grpc_hostname: String,
-	#[serde(default = "default_grpc_connection_port")]
+	#[serde(default = "default_grpc_listener_hostname")]
+	pub grpc_listener_hostname: String,
+	#[serde(default = "default_grpc_listener_port")]
 	pub grpc_port: u16,
 }
 
@@ -67,32 +67,22 @@ env_default!(
 );
 
 env_default!(
-	default_grpc_connection_hostname,
-	"GRPC_CONNECTION_HOSTNAME",
+	default_grpc_listener_hostname,
+	"GRPC_LISTENER_HOSTNAME",
 	String,
-	DEFAULT_GRPC_CONNECTION_HOSTNAME.to_string()
+	DEFAULT_GRPC_LISTENER_HOSTNAME.to_string()
 );
 
-env_default!(
-	default_grpc_connection_port,
-	"GRPC_CONNECTION_PORT",
-	u16,
-	DEFAULT_GRPC_CONNECTION_PORT
-);
+env_default!(default_grpc_listener_port, "GRPC_LISTENER_PORT", u16, DEFAULT_GRPC_LISTENER_PORT);
 
 env_default!(
-	default_rest_connection_hostname,
-	"REST_CONNECTION_HOSTNAME",
+	default_rest_listener_hostname,
+	"REST_LISTENER_HOSTNAME",
 	String,
-	DEFAULT_REST_CONNECTION_HOSTNAME.to_string()
+	DEFAULT_REST_LISTENER_HOSTNAME.to_string()
 );
 
-env_default!(
-	default_rest_connection_port,
-	"REST_CONNECTION_PORT",
-	u16,
-	DEFAULT_REST_CONNECTION_PORT
-);
+env_default!(default_rest_listener_port, "REST_LISTENER_PORT", u16, DEFAULT_REST_LISTENER_PORT);
 
 env_default!(
 	default_movement_native_address,
@@ -179,11 +169,11 @@ impl MovementConfig {
 			mvt_faucet_connection_hostname: default_mvt_rpc_connection_hostname(),
 			mvt_faucet_connection_port: 30732,
 			mvt_init_network: default_mvt_init_network(),
-			rest_hostname: default_rest_connection_hostname(),
-			rest_port: default_rest_connection_port(),
+			rest_listener_hostname: default_rest_listener_hostname(),
+			rest_port: default_rest_listener_port(),
 			grpc_protocol: default_grpc_connection_protocol(),
-			grpc_hostname: default_grpc_connection_hostname(),
-			grpc_port: default_grpc_connection_port(),
+			grpc_listener_hostname: default_grpc_listener_hostname(),
+			grpc_port: default_grpc_listener_port(),
 		}
 	}
 }
@@ -200,11 +190,11 @@ impl Default for MovementConfig {
 			mvt_faucet_connection_hostname: default_mvt_rpc_connection_hostname(),
 			mvt_faucet_connection_port: default_mvt_faucet_connection_port(),
 			mvt_init_network: default_mvt_init_network(),
-			rest_hostname: default_rest_connection_hostname(),
-			rest_port: default_rest_connection_port(),
+			rest_listener_hostname: default_rest_listener_hostname(),
+			rest_port: default_rest_listener_port(),
 			grpc_protocol: default_grpc_connection_protocol(),
-			grpc_hostname: default_grpc_connection_hostname(),
-			grpc_port: default_grpc_connection_port(),
+			grpc_listener_hostname: default_grpc_listener_hostname(),
+			grpc_port: default_grpc_listener_port(),
 		}
 	}
 }

--- a/protocol-units/bridge/config/src/common/movement.rs
+++ b/protocol-units/bridge/config/src/common/movement.rs
@@ -7,9 +7,10 @@ const DEFAULT_MVT_RPC_CONNECTION_HOSTNAME: &str = "127.0.0.1";
 const DEFAULT_MVT_RPC_CONNECTION_PORT: u16 = 8080;
 const DEFAULT_MVT_FAUCET_CONNECTION_HOSTNAME: &str = "127.0.0.1";
 const DEFAULT_MVT_FAUCET_CONNECTION_PORT: u16 = 8081;
-const DEFAULT_REST_CONNECTION_HOSTNAME: &str = "127.0.0.1";
-const DEFAULT_GRPC_CONNECTION_HOSTNAME: &str = "127.0.0.1";
+const DEFAULT_REST_CONNECTION_HOSTNAME: &str = "0.0.0.0";
+const DEFAULT_GRPC_CONNECTION_HOSTNAME: &str = "0.0.0.0";
 const DEFAULT_GRPC_CONNECTION_PORT: u16 = 50051;
+const DEFAULT_REST_CONNECTION_PORT: u16 = 30883;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MovementConfig {
@@ -39,7 +40,7 @@ pub struct MovementConfig {
 	#[serde(default = "default_rest_connection_hostname")]
 	pub rest_hostname: String,
 	#[serde(default = "default_rest_connection_port")]
-	pub rest_port: u32,
+	pub rest_port: u16,
 
 	// gRPC service connection details
 	#[serde(default = "default_grpc_connection_protocol")]
@@ -86,7 +87,12 @@ env_default!(
 	DEFAULT_REST_CONNECTION_HOSTNAME.to_string()
 );
 
-env_default!(default_rest_connection_port, "REST_CONNECTION_PORT", u32, 308833);
+env_default!(
+	default_rest_connection_port,
+	"REST_CONNECTION_PORT",
+	u16,
+	DEFAULT_REST_CONNECTION_PORT
+);
 
 env_default!(
 	default_movement_native_address,

--- a/protocol-units/bridge/integration-tests/tests/bridge_e2e_test.rs
+++ b/protocol-units/bridge/integration-tests/tests/bridge_e2e_test.rs
@@ -20,7 +20,6 @@ use bridge_service::chains::{
 		client::MovementClient, event_monitoring::MovementMonitoring, utils::MovementAddress,
 	},
 };
-use bridge_service::rest::BridgeRest;
 use bridge_service::types::Amount;
 use bridge_service::types::AssetType;
 use bridge_service::types::BridgeAddress;

--- a/protocol-units/bridge/integration-tests/tests/bridge_grpc.rs
+++ b/protocol-units/bridge/integration-tests/tests/bridge_grpc.rs
@@ -25,9 +25,11 @@ async fn test_grpc_health_check() -> Result<(), anyhow::Error> {
 	health_service.set_service_status("", ServingStatus::Serving);
 
 	// Set up the gRPC address based on the mock config
-	let grpc_addr: SocketAddr =
-		format!("{}:{}", mock_config.movement.grpc_hostname, mock_config.movement.grpc_port)
-			.parse()?;
+	let grpc_addr: SocketAddr = format!(
+		"{}:{}",
+		mock_config.movement.grpc_listener_hostname, mock_config.movement.grpc_port
+	)
+	.parse()?;
 	// Spawn the gRPC server
 	let grpc_server_handle = tokio::spawn(async move {
 		Server::builder()
@@ -39,8 +41,10 @@ async fn test_grpc_health_check() -> Result<(), anyhow::Error> {
 
 	tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
 
-	let grpc_address =
-		format!("http://{}:{}", mock_config.movement.grpc_hostname, mock_config.movement.grpc_port);
+	let grpc_address = format!(
+		"http://{}:{}",
+		mock_config.movement.grpc_listener_hostname, mock_config.movement.grpc_port
+	);
 
 	let mut client = HealthClient::connect(grpc_address).await?;
 	let request = Request::new(HealthCheckRequest { service: "".to_string() });

--- a/protocol-units/bridge/service/src/lib.rs
+++ b/protocol-units/bridge/service/src/lib.rs
@@ -48,10 +48,16 @@ where
 	let one_client_lock = Arc::new(Mutex::new(()));
 	let two_client_lock = Arc::new(Mutex::new(()));
 
-	// let mut action_to_exec_futures_one = FuturesUnordered::new();
-	// let mut action_to_exec_futures_two = FuturesUnordered::new();
-
 	let mut tranfer_log_interval = tokio::time::interval(tokio::time::Duration::from_secs(60));
+
+	// Keep-alive task for monitoring, every three minutes.
+	tokio::spawn(async {
+		let mut keep_alive_interval = tokio::time::interval(tokio::time::Duration::from_secs(180));
+		loop {
+			keep_alive_interval.tick().await;
+			tracing::debug!("Keep-alive: bridge loop is still active.");
+		}
+	});
 
 	loop {
 		select! {

--- a/protocol-units/bridge/service/src/lib.rs
+++ b/protocol-units/bridge/service/src/lib.rs
@@ -15,6 +15,8 @@ use futures::stream::FuturesUnordered;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::select;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use tokio::sync::Mutex;
 use tokio_stream::StreamExt;
 
@@ -34,6 +36,7 @@ pub async fn run_bridge<
 	mut one_stream: impl BridgeContractMonitoring<Address = A1>,
 	two_client: impl BridgeContract<A2> + 'static,
 	mut two_stream: impl BridgeContractMonitoring<Address = A2>,
+	mut healthcheck_request_rx: mpsc::Receiver<oneshot::Sender<String>>,
 ) -> Result<(), anyhow::Error>
 where
 	Vec<u8>: From<A1>,
@@ -50,17 +53,15 @@ where
 
 	let mut tranfer_log_interval = tokio::time::interval(tokio::time::Duration::from_secs(60));
 
-	// Keep-alive task for monitoring, every three minutes.
-	tokio::spawn(async {
-		let mut keep_alive_interval = tokio::time::interval(tokio::time::Duration::from_secs(180));
-		loop {
-			keep_alive_interval.tick().await;
-			tracing::debug!("Keep-alive: bridge loop is still active.");
-		}
-	});
-
 	loop {
 		select! {
+			//Manage HealthCheck request
+			Some(oneshot_tx) = healthcheck_request_rx.recv() => {
+				if let Err(err) = oneshot_tx.send("OK".to_string()){
+					tracing::warn!("Heal check oneshot channel closed abnormally :{err:?}");
+				}
+
+			}
 			// Log all current transfer
 			_ = tranfer_log_interval.tick() => {
 				//format logs

--- a/protocol-units/bridge/service/src/main.rs
+++ b/protocol-units/bridge/service/src/main.rs
@@ -54,10 +54,12 @@ async fn main() -> Result<()> {
 	health_service.set_service_status("", ServingStatus::Serving);
 	health_service.set_service_status("Bridge", ServingStatus::Serving);
 
-	let grpc_addr: SocketAddr =
-		format!("{}:{}", bridge_config.movement.grpc_hostname, bridge_config.movement.grpc_port)
-			.parse()
-			.unwrap();
+	let grpc_addr: SocketAddr = format!(
+		"{}:{}",
+		bridge_config.movement.grpc_listener_hostname, bridge_config.movement.grpc_port
+	)
+	.parse()
+	.unwrap();
 
 	let grpc_jh = tokio::spawn(async move {
 		Server::builder()

--- a/protocol-units/bridge/service/src/main.rs
+++ b/protocol-units/bridge/service/src/main.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
 
 	// Get a matching godfig object
 	let godfig: Godfig<Config, ConfigFile> = Godfig::new(ConfigFile::new(config_file), vec![]);
-	let mut bridge_config: Config = godfig.try_wait_for_ready().await?;
+	let bridge_config: Config = godfig.try_wait_for_ready().await?;
 
 	tracing::info!("Bridge config loaded: {bridge_config:?}");
 
@@ -49,6 +49,7 @@ async fn main() -> Result<()> {
 
 	let one_client_for_grpc = one_client.clone();
 
+	// Initialize the gRPC health check service
 	let health_service = HealthCheckService::default();
 	health_service.set_service_status("", ServingStatus::Serving);
 	health_service.set_service_status("Bridge", ServingStatus::Serving);
@@ -58,7 +59,7 @@ async fn main() -> Result<()> {
 			.parse()
 			.unwrap();
 
-	tokio::spawn(async move {
+	let grpc_jh = tokio::spawn(async move {
 		Server::builder()
 			.add_service(HealthServer::new(health_service))
 			.add_service(BridgeServer::new(one_client_for_grpc))
@@ -68,18 +69,29 @@ async fn main() -> Result<()> {
 	});
 
 	// Initialize the gRPC health check service
-	let health_service = HealthCheckService::default();
-	health_service.set_service_status("", ServingStatus::Serving);
-	health_service.set_service_status("Bridge", ServingStatus::Serving);
-
+	let (health_tx, health_rx) = tokio::sync::mpsc::channel(10);
 	// Start the gRPC server on a specific address (e.g., localhost:50051)
 	// Create and run the REST service
-	let rest_service = BridgeRest::new(&bridge_config.movement)?;
+	let rest_service = BridgeRest::new(&bridge_config.movement, health_tx)?;
 	let rest_service_future = rest_service.run_service();
-	tokio::spawn(rest_service_future);
+	let rest_jh = tokio::spawn(rest_service_future);
 
 	tracing::info!("Bridge Eth and Movement Inited. Starting bridge loop.");
-	bridge_service::run_bridge(one_client, one_stream, two_client, two_stream).await?;
+	let loop_jh = tokio::spawn(async move {
+		bridge_service::run_bridge(one_client, one_stream, two_client, two_stream, health_rx).await
+	});
+
+	tokio::select! {
+		res = rest_jh => {
+			tracing::error!("Heath check Rest server exit because :{res:?}");
+		}
+		res = loop_jh => {
+			tracing::error!("Main relayer loop exit because :{res:?}");
+		}
+		res = grpc_jh => {
+			tracing::error!("gRpc server exit because :{res:?}");
+		}
+	};
 
 	Ok(())
 }

--- a/protocol-units/bridge/service/src/rest.rs
+++ b/protocol-units/bridge/service/src/rest.rs
@@ -1,32 +1,36 @@
 use anyhow::Error;
-use aptos_api::Context;
 use bridge_config::common::movement::MovementConfig;
 use futures::prelude::*;
 use poem::{
-	get, handler, listener::TcpListener, middleware::Tracing, EndpointExt, IntoResponse, Response,
-	Route, Server,
+	get, handler, listener::TcpListener, middleware::Tracing, web::Data, EndpointExt, IntoResponse,
+	Response, Route, Server,
 };
 use std::future::Future;
 use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use tracing::info;
 
-#[derive(Debug)]
+struct RestContext {
+	request_tx: mpsc::Sender<oneshot::Sender<String>>,
+}
+
 pub struct BridgeRest {
 	pub url: String,
-	pub context: Option<Arc<Context>>,
+	context: Arc<RestContext>,
 }
 
 impl BridgeRest {
 	pub const BRIDGE_REST_ENV_VAR: &'static str = "BRIDGE_REST_URL";
 
-	pub fn new(conf: &MovementConfig) -> Result<Self, anyhow::Error> {
-		let url = format!("http://{}:{}", conf.rest_hostname, conf.rest_port);
+	pub fn new(
+		conf: &MovementConfig,
+		request_tx: mpsc::Sender<oneshot::Sender<String>>,
+	) -> Result<Self, anyhow::Error> {
+		let url = format!("{}:{}", conf.rest_hostname, conf.rest_port);
 
-		Ok(Self { url, context: None })
-	}
-
-	pub fn set_context(&mut self, context: Arc<Context>) {
-		self.context = Some(context);
+		let context = RestContext { request_tx };
+		Ok(Self { url, context: Arc::new(context) })
 	}
 
 	pub fn run_service(&self) -> impl Future<Output = Result<(), Error>> + Send {
@@ -38,11 +42,14 @@ impl BridgeRest {
 	}
 
 	pub fn create_routes(&self) -> impl EndpointExt {
-		Route::new().at("/health", get(health)).with(Tracing)
+		Route::new().at("/health", get(health)).with(Tracing).data(self.context.clone())
 	}
 }
 
 #[handler]
-async fn health() -> Response {
-	"OK".into_response()
+async fn health(context: Data<&Arc<RestContext>>) -> Result<Response, anyhow::Error> {
+	let (tx, rx) = oneshot::channel();
+	tokio::time::timeout(std::time::Duration::from_secs(2), context.request_tx.send(tx)).await??;
+	let resp = rx.await?;
+	Ok(resp.into_response())
 }

--- a/protocol-units/bridge/service/src/rest.rs
+++ b/protocol-units/bridge/service/src/rest.rs
@@ -27,7 +27,7 @@ impl BridgeRest {
 		conf: &MovementConfig,
 		request_tx: mpsc::Sender<oneshot::Sender<String>>,
 	) -> Result<Self, anyhow::Error> {
-		let url = format!("{}:{}", conf.rest_hostname, conf.rest_port);
+		let url = format!("{}:{}", conf.rest_listener_hostname, conf.rest_port);
 
 		let context = RestContext { request_tx };
 		Ok(Self { url, context: Arc::new(context) })


### PR DESCRIPTION
# Summary
Issue: #774 
Add a task that runs every three minutes to ensure relayer is alive. 

Note that when I noticed the relayer going idle no errors were emitted and the health endpoint still responded 200, this is why I have chosen this approach, rather than checking health within docker setup.

# Changelog
Adds periodic wakeup task

# Testing
This has to be observed over a 12 hour period in production, if the relayer continues to relay events after this time then the issue is resolved.
