### PR TITLE
Feat: Fund Movement recipient

### DIFF
--- a/protocol-units/bridge/integration-tests/tests/client_eth_movement.rs
+++ b/protocol-units/bridge/integration-tests/tests/client_eth_movement.rs
@@ -168,7 +168,7 @@ async fn test_movement_client_should_successfully_call_lock_and_complete(
 
 	test_result
 }
-
+ 
 #[tokio::test]
 async fn test_movement_client_should_successfully_call_lock_and_abort() -> Result<(), anyhow::Error>
 {

--- a/protocol-units/bridge/service/src/actions.rs
+++ b/protocol-units/bridge/service/src/actions.rs
@@ -82,7 +82,6 @@ where
 
 				if recipient.0.len() == 32 {
 					if let Err(e) = movement_utils::fund_recipient(&recipient).await {
-					tracing::error!("Funding failed: {:?}", e);
 					return Err(ActionExecError(action.clone(), e));
 					}
 				}

--- a/protocol-units/bridge/service/src/actions.rs
+++ b/protocol-units/bridge/service/src/actions.rs
@@ -1,20 +1,11 @@
-use anyhow::anyhow;
-use aptos_sdk::rest_client::{Client as RestClient, FaucetClient};
-use aptos_sdk::types::account_address::AccountAddress;
-use crate::chains::bridge_contracts::BridgeContract;
-use crate::chains::bridge_contracts::BridgeContractError;
-use crate::types::Amount;
-use crate::types::BridgeAddress;
-use crate::types::BridgeTransferId;
-use crate::types::HashLock;
-use crate::types::HashLockPreImage;
+use crate::chains::bridge_contracts::{BridgeContract, BridgeContractError};
+use crate::chains::movement::utils as movement_utils;
+use crate::types::{Amount, BridgeAddress, BridgeTransferId, HashLock,HashLockPreImage};
 use crate::ChainId;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use thiserror::Error;
-
-use url::Url;
 
 #[derive(Error, Debug, Clone)]
 pub struct ActionExecError(TransferAction, BridgeContractError);
@@ -89,50 +80,11 @@ where
 		} => {
 			let future = async move {
 
-				// Check whether recipient is a Movement address (32 bytes)
 				if recipient.0.len() == 32 {
-					tracing::info!("Recipient is a Movement address. Creating faucet client...");
-					let faucet_url = Url::parse("https://faucet.testnet.bardock.movementnetwork.xyz")
-					.expect("Invalid faucet URL");
-					let rest_url = Url::parse("https://testnet.bardock.movementnetwork.xyz")
-					.expect("Invalid REST URL");
-		
-					// Create FaucetClient and RestClient
-					let rest_client = RestClient::new(rest_url.clone());
-					let faucet_client = FaucetClient::new(faucet_url, rest_url);
-		
-					let recipient_address: [u8; 32] = recipient.0.clone().try_into()
-					.map_err(|_| ActionExecError(action.clone(), BridgeContractError::SerializationError))?;
-
-					let account_address = AccountAddress::new(recipient_address);
-
-					/// Fetch and log balance before funding
-					/// This should return an error for a new address because funding creates the account
-					match rest_client.get_account_balance(account_address).await {
-						Ok(balance) => tracing::info!("Balance before funding: {:?}", balance),
-						Err(e) => tracing::error!("Failed to retrieve balance before funding: {:?}", e),
+					if let Err(e) = movement_utils::fund_recipient(&recipient).await {
+					tracing::error!("Funding failed: {:?}", e);
+					return Err(ActionExecError(action.clone(), e));
 					}
-					
-					// Execute the funding transaction and capture the result
-					match faucet_client
-						.fund(account_address, 100_000_000)
-						.await
-					{
-						Ok(tx_result) => {
-						tracing::info!("Successfully funded Movement address. Transaction result: {:?}", tx_result);
-						}
-						Err(e) => {
-						tracing::error!("Failed to fund Movement address: {:?}", e);
-						return Err(ActionExecError(action.clone(), BridgeContractError::SerializationError));
-						}
-					};
-
-					// Fetch and log balance before funding
-					match rest_client.get_account_balance(account_address).await {
-						Ok(balance) => tracing::info!("Balance after funding: {:?}", balance),
-						Err(e) => tracing::error!("Failed to retrieve balance before funding: {:?}", e),
-					}
-
 				}
 
 				client

--- a/protocol-units/bridge/service/src/chains/bridge_contracts.rs
+++ b/protocol-units/bridge/service/src/chains/bridge_contracts.rs
@@ -9,6 +9,8 @@ use crate::types::{
 
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum BridgeContractError {
+	#[error("Invalid Url")]
+	InvalidUrl,
 	#[error("Failed to extract transfer Id")]
 	TransferIdExtractionError,
 	#[error("Failed to mint")]

--- a/protocol-units/bridge/service/src/chains/bridge_contracts.rs
+++ b/protocol-units/bridge/service/src/chains/bridge_contracts.rs
@@ -9,6 +9,10 @@ use crate::types::{
 
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum BridgeContractError {
+	#[error("Account balance error")]
+	AccountBalanceError,
+	#[error("Funding error")]
+	FundingError,
 	#[error("Invalid Url")]
 	InvalidUrl,
 	#[error("Failed to extract transfer Id")]


### PR DESCRIPTION
# Summary
- Adds a call to fund the Movement recipient when locking, so they have some funds to cover transaction fees when they call `complete_bridge_transfer`.

# Changelog

In `process_action` add a funding step before `lock_bridge_transfer` if the `recipient` field contains a 32-byte Movement address. This guarantees the recipient will have funds to to subsequently call `complete_bridge_transfer`.

# Testing

Run bridge:

```
CELESTIA_LOG_LEVEL=FATAL CARGO_PROFILE=release CARGO_PROFILE_FLAGS=--release  nix develop --extra-experimental-features nix-command --extra-experimental-features flakes --command bash  -c "just bridge native build.setup.eth-local.celestia-local.bridge --keep-tui"
```

Then run the test:

```
DOT_MOVEMENT_PATH="$(pwd)/.movement" cargo test --test bridge_e2e_test_framework test_bridge_transfer_eth_movement_happy_path -- --nocapture --test-threads=1
```

Before funding you'll see an error logged due to the recipient Movement account not exisiting yet. After funding, the balance is 1 MOVE.


# Outstanding issues
Intended to be temporary, for testnet only.