### PR TITLE
Update for celestia 0.17 / celestia-appd 2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4457,9 +4457,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6eb26c852e42015f85f3aed5c3d1472c751b143e2199d0401ebac2f4500b20d"
+checksum = "0ab6f922c6488623dc5f78e602e0cea658d41c40825033ecbd810a83b73636e1"
 dependencies = [
  "celestia-tendermint-proto",
  "prost 0.12.6",
@@ -4471,12 +4471,13 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688345250891163ec0747e429fbbb172f053f8cae40ec99875a2ee2c997d03c6"
+checksum = "677fc8e51b4f53987fcd18bb0f3234ebe938155539cb272d5c771e22ce2ed6d1"
 dependencies = [
  "async-trait",
  "celestia-types",
+ "futures",
  "http 1.1.0",
  "jsonrpsee 0.24.7",
  "serde",
@@ -4533,9 +4534,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf52cc4b4cdf73fc07d9eeaea6d27bb39eed81f4bf8c89f01df86ace4e6da10"
+checksum = "ab143eba97ed0c957769fa16baecac8e88e479b8d7eae9a71bd084bb2ca80eca"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -4552,6 +4553,7 @@ dependencies = [
  "multiaddr",
  "multihash",
  "nmt-rs",
+ "prost 0.12.6",
  "ruint",
  "serde",
  "serde_repr",
@@ -8370,7 +8372,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.8.5",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -8953,7 +8955,7 @@ checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3970,9 +3970,9 @@ dependencies = [
 
 [[package]]
 name = "blockstore"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc99329facbb960effbe7ed707c753a718877c1878eb8ca08704fa391c494020"
+checksum = "7679095248a6dc7555fae81154ed1baef264383c16621ef881a219576c72a9be"
 dependencies = [
  "cid",
  "dashmap 6.1.0",
@@ -4457,23 +4457,23 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cde2c574760f88d5a6da8dfc55dbb79d91f4da15aa87b9e0d57d4d3a8fa5687"
+checksum = "c6eb26c852e42015f85f3aed5c3d1472c751b143e2199d0401ebac2f4500b20d"
 dependencies = [
- "anyhow",
  "celestia-tendermint-proto",
  "prost 0.12.6",
  "prost-build",
  "prost-types 0.12.6",
+ "protox",
  "serde",
 ]
 
 [[package]]
 name = "celestia-rpc"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5110ce517363b075f3880f4bc88fd1f5c0b3f711a11daa3c34c66da7ae94b9a7"
+checksum = "688345250891163ec0747e429fbbb172f053f8cae40ec99875a2ee2c997d03c6"
 dependencies = [
  "async-trait",
  "celestia-types",
@@ -4533,9 +4533,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.3.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e6a207db787043faf6b630e2caa365d5be1b72553d541a75cfd4e17086191c"
+checksum = "caf52cc4b4cdf73fc07d9eeaea6d27bb39eed81f4bf8c89f01df86ace4e6da10"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -8350,6 +8350,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6b6e02facda28ca5fb8dbe4b152496ba3b1bd5a4b40bb2b1b2d8ad74e0f39b"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32eb6b5f26efacd015b000bfc562186472cd9b34bdba3f6b264e2a052676d10"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.8.5",
+ "syn 2.0.82",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5d0c5463c911ef55624739fc353238b4e310f0144be1f875dc42fec6bfd5ec"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "lru"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8898,6 +8931,29 @@ dependencies = [
  "keccak",
  "rand_core 0.6.4",
  "zeroize",
+]
+
+[[package]]
+name = "miette"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -11346,6 +11402,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-reflect"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5eec97d5d34bdd17ad2db2219aabf46b054c6c41bd5529767c9ce55be5898f"
+dependencies = [
+ "logos",
+ "miette",
+ "once_cell",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11386,6 +11455,33 @@ checksum = "95a29399fc94bcd3eeaa951c715f7bea69409b2445356b00519740bcd6ddd865"
 dependencies = [
  "protobuf",
  "protobuf-codegen",
+]
+
+[[package]]
+name = "protox"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac532509cee918d40f38c3e12f8ef9230f215f017d54de7dd975015538a42ce7"
+dependencies = [
+ "bytes 1.8.0",
+ "miette",
+ "prost 0.12.6",
+ "prost-reflect",
+ "prost-types 0.12.6",
+ "protox-parse",
+ "thiserror",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6c33f43516fe397e2f930779d720ca12cd057f7da4cd6326a0ef78d69dee96"
+dependencies = [
+ "logos",
+ "miette",
+ "prost-types 0.12.6",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,8 +183,8 @@ secp256k1 = { version = "0.27", default-features = false, features = [
 ] }
 
 ## Celestia Dependencies
-celestia-rpc = { version = "0.6.0" }
-celestia-types = { version = "0.6.1" }
+celestia-rpc = { version = "0.7.0" }
+celestia-types = { version = "0.7.0" }
 
 alloy = { git = "https://github.com/alloy-rs/alloy.git", package = "alloy", rev = "83343b172585fe4e040fb104b4d1421f58cbf9a2", features = [
     "node-bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,8 +183,8 @@ secp256k1 = { version = "0.27", default-features = false, features = [
 ] }
 
 ## Celestia Dependencies
-celestia-rpc = { version = "0.3.0" }
-celestia-types = { version = "0.3.0" }
+celestia-rpc = { version = "0.6.0" }
+celestia-types = { version = "0.6.1" }
 
 alloy = { git = "https://github.com/alloy-rs/alloy.git", package = "alloy", rev = "83343b172585fe4e040fb104b4d1421f58cbf9a2", features = [
     "node-bindings",

--- a/flake.lock
+++ b/flake.lock
@@ -84,17 +84,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1726671079,
-        "narHash": "sha256-7iV7wI5qNmKoWBf3F6xT5aeZmwHcUO2Q+627wPnhqoA=",
+        "lastModified": 1730459414,
+        "narHash": "sha256-PL7GnJNjw2XsnUfaJTW4tYe3LqV1TJqs+ljl2EeTTh4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2ac40064487f7dfae54f188705e8ed9173993e79",
+        "rev": "8dedccea6cea1e65bf74fc6c7f35e0aadf832a14",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2ac40064487f7dfae54f188705e8ed9173993e79",
+        "rev": "8dedccea6cea1e65bf74fc6c7f35e0aadf832a14",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/2ac40064487f7dfae54f188705e8ed9173993e79";
+    nixpkgs.url = "github:NixOS/nixpkgs/8dedccea6cea1e65bf74fc6c7f35e0aadf832a14";
     rust-overlay.url = "github:oxalica/rust-overlay/db12d0c6ef002f16998723b5dd619fa7b8997086";
     flake-utils.url = "github:numtide/flake-utils";
     foundry.url = "github:shazow/foundry.nix/f533e2c70e520adb695c9917be21d514c15b1c4d"; 
@@ -87,29 +87,29 @@
 
         celestia-app = pkgs.buildGoModule {
           pname = "celestia-app";
-          version = "1.8.0";
+          version = "2.3.1";
 
           src = pkgs.fetchgit {
             url = "https://github.com/celestiaorg/celestia-app";
-            rev = "e75a1fdc8f2386d9f389cb596c88ca7cc19563af";
-            hash = "sha256-EE9r1sybbm4Hyh57/nC8utMx/uFdMsIdPecxBtDqAbk=";
+            rev = "v2.3.1";
+            hash = "sha256-ui67KRaabQyZiV5QD4Qyaqobky++rAe9ppJ2yveoXOs=";
           };
 
-          vendorHash = "sha256-2vU1liAm0us7Nk1eawgMvarhq77+IUS0VE61FuvQbuQ=";
+          vendorHash = "sha256-zL3G+ml2bIcQlthHY6rovr2ykCGHqV51rQBkS3J9tGo=";
           subPackages = [ "cmd/celestia-appd" ];
         };
 
         celestia-node = pkgs.buildGoModule {
           pname = "celestia-node";
-          version = "0.13.3";
+          version = "0.17.2";
 
           src = pkgs.fetchgit {
             url = "https://github.com/celestiaorg/celestia-node";
-            rev = "05238b3e087eb9ecd3b9684cd0125f2400f6f0c7";
-            hash = "sha256-bmFcJrC4ocbCw1pew2HKEdLj6+1D/0VuWtdoTs1S2sU=";
+            rev = "v0.17.2";
+            hash = "sha256-7Ame5xxLbLgD8LGNNWWqI0uUFO5K6MXvCo9TK9V5Sls=";
           };
 
-          vendorHash = "sha256-8RC/9KiFOsEJDpt7d8WtzRLn0HzYrZ1LIHo6lOKSQxU=";
+          vendorHash = "sha256-RoydbcJ4A2KTW20ihybnUkROwKlrT69qhl8E+NRgOpk=";
           subPackages = [ "cmd/celestia" "cmd/cel-key" ];
         };
     

--- a/protocol-units/da/m1/light-node/src/v1/passthrough.rs
+++ b/protocol-units/da/m1/light-node/src/v1/passthrough.rs
@@ -127,11 +127,14 @@ where
 
 	/// Submits a CelestiaBlob to the Celestia node.
 	pub async fn submit_celestia_blob(&self, blob: CelestiaBlob) -> Result<u64, anyhow::Error> {
-		let height = self
-			.default_client
-			.blob_submit(&[blob], GasPrice::default())
-			.await
-			.map_err(|e| anyhow::anyhow!("Failed submitting the blob: {}", e))?;
+		let height =
+			self.default_client
+				.blob_submit(&[blob], GasPrice::default())
+				.await
+				.map_err(|e| {
+					error!(error = %e, "failed to submit the blob");
+					anyhow::anyhow!("Failed submitting the blob: {}", e)
+				})?;
 
 		Ok(height)
 	}
@@ -141,11 +144,11 @@ where
 		&self,
 		blobs: &[CelestiaBlob],
 	) -> Result<u64, anyhow::Error> {
-		let height = self
-			.default_client
-			.blob_submit(blobs, GasPrice::default())
-			.await
-			.map_err(|e| anyhow::anyhow!("Failed submitting the blob: {}", e))?;
+		let height =
+			self.default_client.blob_submit(blobs, GasPrice::default()).await.map_err(|e| {
+				error!(error = %e, "failed to submit the blobs");
+				anyhow::anyhow!("Failed submitting the blob: {}", e)
+			})?;
 
 		Ok(height)
 	}
@@ -187,7 +190,7 @@ where
 		Ok(verified_blobs)
 	}
 
-	#[tracing::instrument(target = "movement_timing", level = "debug")]
+	#[tracing::instrument(target = "movement_timing", level = "info", skip(self))]
 	async fn get_blobs_at_height(&self, height: u64) -> Result<Vec<Blob>, anyhow::Error> {
 		let ir_blobs = self.get_ir_blobs_at_height(height).await?;
 		let mut blobs = Vec::new();

--- a/protocol-units/da/m1/light-node/src/v1/sequencer.rs
+++ b/protocol-units/da/m1/light-node/src/v1/sequencer.rs
@@ -479,7 +479,7 @@ where
 
 pub mod block {
 
-	use celestia_types::{nmt::Namespace, Blob};
+	use celestia_types::{consts::appconsts::AppVersion, nmt::Namespace, Blob};
 	use movement_algs::grouping_heuristic::{binpacking::BinpackingWeighted, splitting::Splitable};
 	use movement_types::block::Block;
 
@@ -505,7 +505,7 @@ pub mod block {
 			let compressed_block_bytes = zstd::encode_all(block_bytes.as_slice(), 0)?;
 
 			// then create a blob from the compressed block bytes
-			let blob = Blob::new(namespace, compressed_block_bytes)?;
+			let blob = Blob::new(namespace, compressed_block_bytes, AppVersion::V2)?;
 
 			Ok(Self { block, blob })
 		}

--- a/protocol-units/da/m1/runners/src/celestia_bridge/local.rs
+++ b/protocol-units/da/m1/runners/src/celestia_bridge/local.rs
@@ -108,7 +108,7 @@ impl Local {
 				"--gateway",
 				"--core.ip",
 				&config.bridge.celestia_rpc_connection_hostname,
-				"--keyring.accname",
+				"--keyring.keyname",
 				"validator",
 				"--gateway.addr",
 				&config.bridge.celestia_websocket_listen_hostname,

--- a/protocol-units/da/m1/setup/src/local.rs
+++ b/protocol-units/da/m1/setup/src/local.rs
@@ -97,6 +97,8 @@ impl Local {
 				"gentx",
 				"validator",
 				"5000000000utia",
+				"--fees",
+				"1utia",
 				"--keyring-backend=test",
 				"--chain-id",
 				&celestia_chain_id,

--- a/protocol-units/da/m1/util/src/ir_blob.rs
+++ b/protocol-units/da/m1/util/src/ir_blob.rs
@@ -158,7 +158,7 @@ pub mod celestia {
 
 	use super::IntermediateBlobRepresentation;
 	use anyhow::Context;
-	use celestia_types::{nmt::Namespace, Blob as CelestiaBlob};
+	use celestia_types::{consts::appconsts::AppVersion, nmt::Namespace, Blob as CelestiaBlob};
 	use tracing::info;
 
 	impl TryFrom<CelestiaBlob> for IntermediateBlobRepresentation {
@@ -202,7 +202,8 @@ pub mod celestia {
 
 			// Construct the final CelestiaBlob by assigning the compressed data
 			// and associating it with the provided namespace
-			Ok(CelestiaBlob::new(namespace, compressed_blob).map_err(|e| anyhow::anyhow!(e))?)
+			Ok(CelestiaBlob::new(namespace, compressed_blob, AppVersion::V2)
+				.map_err(|e| anyhow::anyhow!(e))?)
 		}
 	}
 }

--- a/scripts/services/suzuka-full-node/build
+++ b/scripts/services/suzuka-full-node/build
@@ -6,9 +6,7 @@ cargo build $CARGO_PROFILE_FLAGS -p m1-da-light-node --features "sequencer"
 echo "Built m1-da-light-node!"
 
 echo "Building m1-da-light-node-celestia-* runners..."
-cargo build $CARGO_PROFILE_FLAGS -p m1-da-light-node-runners \
-    --bin m1-da-light-node-celestia-appd \
-    --bin m1-da-light-node-celestia-bridge
+cargo build $CARGO_PROFILE_FLAGS -p m1-da-light-node-runners
 echo "Built m1-da-light-node-celestia-* runners!"
 
 echo "Building suzuka-full-node..."


### PR DESCRIPTION
# Summary
- **Categories**: `util`.

Update crate dependencies and local Celestia setup for latest stable (testnet) releases.

# Changelog

* Updated celestia crate dependency versions to 0.7.0.

# Testing

`just suzuka-full-node native build.setup.eth-local.celestia-local.test`

# Outstanding issues

* Can't fully verify yet because of a failure of the faucet readiness test.
* Bump crates to 0.7.0.