### PR TITLE
Indexer: update aptos-indexer version to correct chain_id issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,7 +1979,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=8e83cde3cb75fabdade9485e0af680cc4b73ca8e#8e83cde3cb75fabdade9485e0af680cc4b73ca8e"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=65185e5998c1a6892aee20045b09fcf17718c866#65185e5998c1a6892aee20045b09fcf17718c866"
 dependencies = [
  "chrono",
 ]
@@ -11220,13 +11220,13 @@ dependencies = [
 [[package]]
 name = "processor"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=8e83cde3cb75fabdade9485e0af680cc4b73ca8e#8e83cde3cb75fabdade9485e0af680cc4b73ca8e"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=65185e5998c1a6892aee20045b09fcf17718c866#65185e5998c1a6892aee20045b09fcf17718c866"
 dependencies = [
  "ahash 0.8.11",
  "allocative",
  "allocative_derive",
  "anyhow",
- "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=8e83cde3cb75fabdade9485e0af680cc4b73ca8e)",
+ "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=65185e5998c1a6892aee20045b09fcf17718c866)",
  "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=338f9a1bcc06f62ce4a4994f1642b9a61b631ee0)",
  "async-trait",
  "bcs 0.1.4",
@@ -12809,7 +12809,7 @@ dependencies = [
 [[package]]
 name = "server-framework"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=8e83cde3cb75fabdade9485e0af680cc4b73ca8e#8e83cde3cb75fabdade9485e0af680cc4b73ca8e"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=65185e5998c1a6892aee20045b09fcf17718c866#65185e5998c1a6892aee20045b09fcf17718c866"
 dependencies = [
  "anyhow",
  "aptos-system-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,8 +152,8 @@ aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/apto
 aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
 
 # Indexer
-processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "8e83cde3cb75fabdade9485e0af680cc4b73ca8e" }
-server-framework = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "8e83cde3cb75fabdade9485e0af680cc4b73ca8e" }
+processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "65185e5998c1a6892aee20045b09fcf17718c866" }
+server-framework = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "65185e5998c1a6892aee20045b09fcf17718c866" }
 
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
 ethereum-types = "0.14.1"


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

<!--
Add your summary text here. 
 -->
Update the Aptos indexer version to the one that correct the chain_id issue.
# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->