### PR TITLE
Fix up ansible/follower-node documentation and recipes

### DIFF
--- a/docs/movement-node-experimental/l-monninger/open-network/README.md
+++ b/docs/movement-node-experimental/l-monninger/open-network/README.md
@@ -38,9 +38,9 @@ ansible-playbook --inventory <your-inventory> \
 
 This will set up the Movement Node to connect to sync with the `l-monninger/open-network` environment.
 
-For a basic check on syncing, assert that there is a `0.tgz` file in the `~/.movement` directory. This file is unarchived into the same directory when syncing. If you see it, that indicates that the syncing resource was fetched. It is not rearchived itself.
+For a basic check on syncing, assert that there is a `0.tar.gz` file in the `~/.movement` directory. This file is unarchived into the same directory when syncing. If you see it, that indicates that the syncing resource was fetched. It is not rearchived itself.
 
-If you do not see the `0.tgz` that could indicate an issue with sync. See the troubleshooting steps below.
+If you do not see the `0.tar.gz` that could indicate an issue with sync. See the troubleshooting steps below.
 
 ## Troubleshooting 
 

--- a/docs/movement-node/run/ansible/follower-node/README.md
+++ b/docs/movement-node/run/ansible/follower-node/README.md
@@ -49,9 +49,9 @@ The username (`ubuntu` in this example) is the remote user to connect to instanc
 
 This will set up the Movement Node to connect to sync with the Follower Node environment.
 
-For a basic check on syncing, assert that there is a `0.tgz` file in the `~/.movement` directory. This file is unarchived into the same directory when syncing. If you see it, that indicates that the syncing resource was fetched. It is not rearchived itself.
+For a basic check on syncing, assert that there is a `0.tar.gz` file in the `~/.movement` directory. This file is unarchived into the same directory when syncing. If you see it, that indicates that the syncing resource was fetched. It is not rearchived itself.
 
-If you do not see the `0.tgz` that could indicate an issue with sync. See the troubleshooting steps below.
+If you do not see the `0.tar.gz` that could indicate an issue with sync. See the troubleshooting steps below.
 
 ## Troubleshooting 
 

--- a/docs/movement-node/run/ansible/follower-node/suzuka-full-follower.service.j2
+++ b/docs/movement-node/run/ansible/follower-node/suzuka-full-follower.service.j2
@@ -8,16 +8,14 @@ User={{ user }}
 WorkingDirectory=/home/{{ user }}/movement
 Environment="DOT_MOVEMENT_PATH=/home/{{ user }}/.movement"
 Environment="CONTAINER_REV={{ rev }}"
+Environment="MAPTOS_CHAIN_ID={{ chain_id }}"
 Environment="MOVEMENT_SYNC={{ movement_sync }}"
 
 Environment="M1_DA_LIGHT_NODE_CONNECTION_PROTOCOL={{ m1_da_light_node_connection_protocol }}"
 Environment="M1_DA_LIGHT_NODE_CONNECTION_HOSTNAME={{ m1_da_light_node_connection_hostname }}"
 Environment="M1_DA_LIGHT_NODE_CONNECTION_PORT={{ m1_da_light_node_connection_port }}"
 
-Environment="AWS_ACCESS_KEY_ID={{ aws_access_key_id }}"
-Environment="AWS_SECRET_ACCESS_KEY={{ aws_secret_access_key }}"
-Environment="AWS_DEFAULT_REGION={{ aws_default_region }}"
-Environment="AWS_REGION={{ aws_default_region }}"
+Environment="AWS_REGION={{ aws_region }}"
 ExecStart=/usr/bin/docker compose --env-file .env -f /home/{{ user }}/movement/docker/compose/suzuka-full-node/docker-compose.yml -f /home/{{ user }}/movement/docker/compose/suzuka-full-node/docker-compose.follower.yml up --force-recreate --remove-orphans
 Restart=on-failure
 

--- a/docs/movement-node/run/ansible/follower-node/suzuka-full-follower.service.j2
+++ b/docs/movement-node/run/ansible/follower-node/suzuka-full-follower.service.j2
@@ -18,7 +18,7 @@ Environment="AWS_ACCESS_KEY_ID={{ aws_access_key_id }}"
 Environment="AWS_SECRET_ACCESS_KEY={{ aws_secret_access_key }}"
 Environment="AWS_DEFAULT_REGION={{ aws_default_region }}"
 Environment="AWS_REGION={{ aws_default_region }}"
-ExecStart=/usr/bin/docker compose --env-file .env -f /home/{{ user }}/movement/docker/compose/suzuka-full-node/docker-compose.yml -f /home/{{ user }}/movement/docker/compose/suzuka-full-node/docker-compose.local.yml up --force-recreate --remove-orphans
+ExecStart=/usr/bin/docker compose --env-file .env -f /home/{{ user }}/movement/docker/compose/suzuka-full-node/docker-compose.yml -f /home/{{ user }}/movement/docker/compose/suzuka-full-node/docker-compose.follower.yml up --force-recreate --remove-orphans
 Restart=on-failure
 
 [Install]

--- a/docs/movement-node/run/ansible/follower-node/suzuka-full-follower.yml
+++ b/docs/movement-node/run/ansible/follower-node/suzuka-full-follower.yml
@@ -8,6 +8,7 @@
     repo_url: "https://github.com/movementlabsxyz/movement"
     destination_path: "/home/{{ user }}/movement"
     movement_sync: "follower::mtnet-l-sync-bucket-sync<=>{maptos,maptos-storage,suzuka-da-db}/**"
+    chain_id: "250"
 
     m1_da_light_node_connection_protocol: "https"
     m1_da_light_node_connection_hostname: "m1-da-light-node.testnet.bardock.movementlabs.xyz"


### PR DESCRIPTION
# Summary
- **Categories**: `scripts`.

The follower node setup provisioned with Ansible is supposed to use the follower overlay, like in the README.