### PR TITLE
Avoid races in CD container builds over symbolic references in checkouts

### DIFF
--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -28,7 +28,6 @@ jobs:
       uses: actions/checkout@v4
       with: 
         submodules: true
-        ref: ${{ github.event.pull_request.head.ref || github.ref }}
     
     - name: Login to Docker Hub
       uses: docker/login-action@v3
@@ -58,7 +57,6 @@ jobs:
         uses: actions/checkout@v4
         with: 
           submodules: true
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -93,7 +91,6 @@ jobs:
       uses: actions/checkout@v4
       with: 
         submodules: true
-        ref: ${{ github.event.pull_request.head.ref || github.ref }}
     
     - name: Login to Docker Hub
       uses: docker/login-action@v3
@@ -123,7 +120,6 @@ jobs:
         uses: actions/checkout@v4
         with: 
           submodules: true
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -158,7 +154,6 @@ jobs:
       uses: actions/checkout@v4
       with: 
         submodules: true
-        ref: ${{ github.event.pull_request.head.ref || github.ref }}
     
     - name: Login to Docker Hub
       uses: docker/login-action@v3
@@ -188,7 +183,6 @@ jobs:
         uses: actions/checkout@v4
         with: 
           submodules: true
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -223,7 +217,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-        ref: ${{ github.event.pull_request.head.ref || github.ref }}
     
     - name: Login to Docker Hub
       uses: docker/login-action@v3
@@ -253,7 +246,6 @@ jobs:
         uses: actions/checkout@v4
         with: 
           submodules: true
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -288,7 +280,6 @@ jobs:
       uses: actions/checkout@v4
       with: 
         submodules: true
-        ref: ${{ github.event.pull_request.head.ref || github.ref }}
     
     - name: Login to Docker Hub
       uses: docker/login-action@v3
@@ -318,7 +309,6 @@ jobs:
         uses: actions/checkout@v4
         with: 
           submodules: true
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -353,7 +343,6 @@ jobs:
       uses: actions/checkout@v4
       with: 
         submodules: true
-        ref: ${{ github.event.pull_request.head.ref || github.ref }}
     
     - name: Login to Docker Hub
       uses: docker/login-action@v3
@@ -383,7 +372,6 @@ jobs:
         uses: actions/checkout@v4
         with: 
           submodules: true
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -418,7 +406,6 @@ jobs:
       uses: actions/checkout@v4
       with: 
         submodules: true
-        ref: ${{ github.event.pull_request.head.ref || github.ref }}
     
     - name: Login to Docker Hub
       uses: docker/login-action@v3
@@ -448,7 +435,6 @@ jobs:
         uses: actions/checkout@v4
         with: 
           submodules: true
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -483,7 +469,6 @@ jobs:
       uses: actions/checkout@v4
       with: 
         submodules: true
-        ref: ${{ github.event.pull_request.head.ref || github.ref }}
     
     - name: Login to Docker Hub
       uses: docker/login-action@v3
@@ -513,7 +498,6 @@ jobs:
         uses: actions/checkout@v4
         with: 
           submodules: true
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -548,7 +532,6 @@ jobs:
       uses: actions/checkout@v4
       with: 
         submodules: true
-        ref: ${{ github.event.pull_request.head.ref || github.ref }}
     
     - name: Login to Docker Hub
       uses: docker/login-action@v3
@@ -578,7 +561,6 @@ jobs:
         uses: actions/checkout@v4
         with: 
           submodules: true
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -613,7 +595,6 @@ jobs:
       uses: actions/checkout@v4
       with: 
         submodules: true
-        ref: ${{ github.event.pull_request.head.ref || github.ref }}
     
     - name: Login to Docker Hub
       uses: docker/login-action@v3
@@ -643,7 +624,6 @@ jobs:
         uses: actions/checkout@v4
         with: 
           submodules: true
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -682,7 +662,6 @@ jobs:
         uses: actions/checkout@v4
         with: 
           submodules: true
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
   
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
@@ -793,7 +772,6 @@ jobs:
       uses: actions/checkout@v4
       with: 
         submodules: true
-        ref: ${{ github.event.pull_request.head.ref || github.ref }}
     
     - name: Login to Docker Hub
       uses: docker/login-action@v3
@@ -823,7 +801,6 @@ jobs:
         uses: actions/checkout@v4
         with: 
           submodules: true
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -859,7 +836,6 @@ jobs:
       uses: actions/checkout@v4
       with: 
         submodules: true
-        ref: ${{ github.event.pull_request.head.ref || github.ref }}
     
     - name: Login to Docker Hub
       uses: docker/login-action@v3
@@ -889,7 +865,6 @@ jobs:
         uses: actions/checkout@v4
         with: 
           submodules: true
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
# Summary
- **Categories**: `cicd`.

Don't supply the symbolic GitHub reference name to the `ref` parameter of the checkout action in the build-push-container-all workflow jobs.
The default behavior of actions/checkout would do the right thing, checking out the SHA of the triggering event, thereby avoiding races with concurrent pushes to the repository modifying the symbolic references.
