### PR TITLE
Add Bridge Counterparty Hash Verification

### DIFF
--- a/protocol-units/bridge/contracts/src/AtomicBridgeInitiatorMOVE.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeInitiatorMOVE.sol
@@ -18,7 +18,7 @@ contract AtomicBridgeInitiatorMOVE is IAtomicBridgeInitiatorMOVE, OwnableUpgrade
         address originator;
         bytes32 recipient;
         bytes32 hashLock;
-        uint256 timeLock; // in seconds (timestamp)
+        uint256 timeLock;
         MessageState state;
     }
 
@@ -80,7 +80,7 @@ contract AtomicBridgeInitiatorMOVE is IAtomicBridgeInitiatorMOVE, OwnableUpgrade
         poolBalance += moveAmount;
 
         // Generate a unique nonce to prevent replay attacks, and generate a transfer ID
-        bridgeTransferId = keccak256(abi.encodePacked(originator, recipient, hashLock, initiatorTimeLockDuration, block.timestamp, nonce++));
+        bridgeTransferId = keccak256(abi.encodePacked(originator, recipient, amount, hashLock, block.timestamp, ++nonce));
 
         bridgeTransfers[bridgeTransferId] = BridgeTransfer({
             amount: moveAmount,
@@ -91,7 +91,7 @@ contract AtomicBridgeInitiatorMOVE is IAtomicBridgeInitiatorMOVE, OwnableUpgrade
             state: MessageState.INITIALIZED
         });
 
-        emit BridgeTransferInitiated(bridgeTransferId, originator, recipient, moveAmount, hashLock, initiatorTimeLockDuration);
+        emit BridgeTransferInitiated(bridgeTransferId, originator, recipient, moveAmount, hashLock, block.timestamp, nonce);
         return bridgeTransferId;
     }
 

--- a/protocol-units/bridge/contracts/src/IAtomicBridgeInitiatorMOVE.sol
+++ b/protocol-units/bridge/contracts/src/IAtomicBridgeInitiatorMOVE.sol
@@ -9,7 +9,8 @@ interface IAtomicBridgeInitiatorMOVE {
         bytes32 indexed _recipient,
         uint256 amount,
         bytes32 _hashLock,
-        uint256 _timeLock
+        uint256 _initiateTimestamp,
+        uint256 _nonce
     );
     // Event emitted when a BridgeTransfer is completed (withdrawn)
     event BridgeTransferCompleted(bytes32 indexed _bridgeTransferId, bytes32 pre_image);


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

counterparty has to hash the bridgeTransferId components to check if its produced by the correct parameters
For that to happen two things have to be added. One is the nonce on initiator has to be emitted and used as a parameter in lock call
Two the initiate block.timestamp has to be emitted and used as a parameter in lock call
With that we can produce the same hash on both sides 

# Changelog

Added the requirements above.

# Testing

Not tested

# Outstanding issues
Testing