### PR TITLE
Make completeBridgeTransfer onlyOwner in AtomicBridgeInitiatorMOVE.sol

### DIFF
--- a/protocol-units/bridge/contracts/src/AtomicBridgeInitiatorMOVE.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeInitiatorMOVE.sol
@@ -95,7 +95,7 @@ contract AtomicBridgeInitiatorMOVE is IAtomicBridgeInitiatorMOVE, OwnableUpgrade
         return bridgeTransferId;
     }
 
-    function completeBridgeTransfer(bytes32 bridgeTransferId, bytes32 preImage) external {
+    function completeBridgeTransfer(bytes32 bridgeTransferId, bytes32 preImage) external onlyOwner {
         BridgeTransfer storage bridgeTransfer = bridgeTransfers[bridgeTransferId];
         if (bridgeTransfer.state != MessageState.INITIALIZED) revert BridgeTransferHasBeenCompleted();
         if (keccak256(abi.encodePacked(preImage)) != bridgeTransfer.hashLock) revert InvalidSecret();


### PR DESCRIPTION
# Summary
- The protocol specifies that the initiator-side completeBridgeTransfer function should be onlyOwner. The initiator-side Move contract already has this in place. 

# Changelog

- Make completeBridgeTransfer onlyOwner in AtomicBridgeInitiatorMOVE.sol

# Testing

 CI should pass. 
 
# Outstanding issues
