### PR TITLE
deps: bump diesel to 2.2, update aptos-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -812,7 +812,7 @@ checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -835,7 +835,7 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-logger",
  "aptos-types",
@@ -849,7 +849,7 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -921,7 +921,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "hex",
@@ -930,7 +930,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -974,7 +974,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -995,7 +995,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "futures",
  "rustversion",
@@ -1005,7 +1005,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "shadow-rs",
 ]
@@ -1013,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1027,7 +1027,7 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -1038,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -1050,7 +1050,7 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1081,7 +1081,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1108,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1161,7 +1161,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1171,7 +1171,7 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
@@ -1219,7 +1219,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1239,7 +1239,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer-schemas"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-schemadb",
@@ -1253,7 +1253,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1284,7 +1284,7 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-infallible",
  "aptos-metrics-core",
@@ -1295,7 +1295,7 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -1311,7 +1311,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-consensus-types",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-block-partitioner",
  "aptos-config",
@@ -1373,7 +1373,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -1395,7 +1395,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1415,7 +1415,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-runtimes",
  "core_affinity",
@@ -1428,7 +1428,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1462,7 +1462,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -1476,7 +1476,7 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -1544,7 +1544,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "either",
  "move-core-types",
@@ -1553,7 +1553,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -1568,7 +1568,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -1588,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
@@ -1601,17 +1601,17 @@ dependencies = [
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 
 [[package]]
 name = "aptos-indexer"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1643,7 +1643,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1655,7 +1655,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-metrics-core",
  "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors)",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490)",
  "aptos-runtimes",
  "aptos-storage-interface",
  "aptos-types",
@@ -1681,7 +1681,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-table-info"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1712,11 +1712,11 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-utils"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490)",
  "async-trait",
  "backoff",
  "base64 0.13.1",
@@ -1744,12 +1744,12 @@ dependencies = [
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1777,7 +1777,7 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1787,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
@@ -1831,7 +1831,7 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1844,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1854,7 +1854,7 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-infallible",
  "aptos-log-derive",
@@ -1878,7 +1878,7 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
@@ -1891,7 +1891,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -1931,7 +1931,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-types",
  "async-trait",
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-infallible",
  "bytes 1.8.0",
@@ -1955,7 +1955,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -1964,7 +1964,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -1979,7 +1979,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=65185e5998c1a6892aee20045b09fcf17718c866#65185e5998c1a6892aee20045b09fcf17718c866"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=7658338eb9224abd9698c1e02dbc6ca526c268ce#7658338eb9224abd9698c1e02dbc6ca526c268ce"
 dependencies = [
  "chrono",
 ]
@@ -1995,7 +1995,7 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2016,7 +2016,7 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2033,7 +2033,7 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
@@ -2050,7 +2050,7 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2095,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2106,7 +2106,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-build-info",
  "aptos-infallible",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -2145,7 +2145,7 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -2158,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-config",
  "aptos-types",
@@ -2183,11 +2183,23 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "crossbeam",
  "proptest",
  "proptest-derive",
+]
+
+[[package]]
+name = "aptos-protos"
+version = "1.3.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
+dependencies = [
+ "futures-core",
+ "pbjson",
+ "prost 0.12.6",
+ "serde",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -2203,21 +2215,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "aptos-protos"
-version = "1.3.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
-dependencies = [
- "futures-core",
- "pbjson",
- "prost 0.12.6",
- "serde",
- "tonic 0.11.0",
-]
-
-[[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "ipnet",
 ]
@@ -2225,7 +2225,7 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -2236,7 +2236,7 @@ dependencies = [
 [[package]]
 name = "aptos-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2250,7 +2250,7 @@ dependencies = [
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-config",
  "rocksdb",
@@ -2282,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "rayon",
  "tokio",
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2308,7 +2308,7 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-crypto",
  "aptos-drop-helper",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -2349,7 +2349,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2367,11 +2367,11 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490)",
  "bcs 0.1.4",
  "crossbeam-channel",
  "once_cell",
@@ -2385,7 +2385,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-crypto",
  "aptos-infallible",
@@ -2406,7 +2406,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -2417,7 +2417,7 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2428,7 +2428,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2476,7 +2476,7 @@ dependencies = [
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -2494,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -2503,7 +2503,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -2516,7 +2516,7 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2573,12 +2573,12 @@ dependencies = [
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
@@ -2594,7 +2594,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2644,7 +2644,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-cached-packages",
  "aptos-crypto",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -2680,7 +2680,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2702,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -5752,9 +5752,9 @@ checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
 
 [[package]]
 name = "diesel"
-version = "2.1.1"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98235fdc2f355d330a8244184ab6b4b33c28679c0b4158f63138e51d6cf7e88"
+checksum = "158fe8e2e68695bd615d7e4f3227c0727b151330d3e253b525086c348d055d5e"
 dependencies = [
  "bigdecimal",
  "bitflags 2.6.0",
@@ -5772,8 +5772,9 @@ dependencies = [
 
 [[package]]
 name = "diesel-async"
-version = "0.4.1"
-source = "git+https://github.com/weiznich/diesel_async.git?rev=d02798c67065d763154d7272dd0c09b39757d0f2#d02798c67065d763154d7272dd0c09b39757d0f2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c5c6ec8d5c7b8444d19a47161797cbe361e0fb1ee40c6a8124ec915b64a4125"
 dependencies = [
  "async-trait",
  "bb8",
@@ -5786,11 +5787,12 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.1.4"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14701062d6bed917b5c7103bdffaee1e4609279e240488ad24e7bd979ca6866c"
+checksum = "e7f2c3de51e2ba6bf2a648285696137aaf0f5f487bcbea93972fe8a364e131a4"
 dependencies = [
  "diesel_table_macro_syntax",
+ "dsl_auto_type",
  "proc-macro2",
  "quote",
  "syn 2.0.82",
@@ -5798,9 +5800,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_migrations"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6036b3f0120c5961381b570ee20a02432d7e2d27ea60de9578799cf9156914ac"
+checksum = "8a73ce704bad4231f001bff3314d91dce4aba0770cee8b233991859abc15c1f6"
 dependencies = [
  "diesel",
  "migrations_internals",
@@ -5809,9 +5811,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_table_macro_syntax"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
 dependencies = [
  "syn 2.0.82",
 ]
@@ -5913,6 +5915,20 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "dsl_auto_type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d9abe6314103864cc2d8901b7ae224e0ab1a103a0a416661b4097b0779b607"
+dependencies = [
+ "darling 0.20.10",
+ "either",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.82",
+]
 
 [[package]]
 name = "dunce"
@@ -8731,7 +8747,7 @@ dependencies = [
  "aptos-language-e2e-tests",
  "aptos-logger",
  "aptos-mempool",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490)",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
@@ -8993,19 +9009,19 @@ dependencies = [
 
 [[package]]
 name = "migrations_internals"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f23f71580015254b020e856feac3df5878c2c7a8812297edd6c0a485ac9dada"
+checksum = "fd01039851e82f8799046eabbb354056283fb265c8ec0996af940f4e85a380ff"
 dependencies = [
  "serde",
- "toml 0.7.8",
+ "toml 0.8.19",
 ]
 
 [[package]]
 name = "migrations_macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce3325ac70e67bbab5bd837a31cae01f1a6db64e0e744a33cb03a543469ef08"
+checksum = "ffb161cc72176cb37aa47f1fc520d3ef02263d67d661f44f05d05a079e1237fd"
 dependencies = [
  "migrations_internals",
  "proc-macro2",
@@ -9098,7 +9114,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -9115,7 +9131,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -9130,12 +9146,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -9150,7 +9166,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-spec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "once_cell",
  "quote",
@@ -9160,7 +9176,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -9172,7 +9188,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "fail",
  "move-binary-format",
@@ -9186,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -9201,7 +9217,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -9231,7 +9247,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "difference",
@@ -9248,7 +9264,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -9274,7 +9290,7 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -9305,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -9330,7 +9346,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -9349,7 +9365,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -9366,7 +9382,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -9385,7 +9401,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -9397,7 +9413,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -9413,7 +9429,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -9431,7 +9447,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "hex",
@@ -9444,7 +9460,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -9457,7 +9473,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "codespan",
@@ -9483,7 +9499,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -9509,7 +9525,7 @@ dependencies = [
  "sha2 0.9.9",
  "tempfile",
  "termcolor",
- "toml 0.7.8",
+ "toml 0.8.19",
  "walkdir",
  "whoami",
 ]
@@ -9517,7 +9533,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "atty",
@@ -9538,13 +9554,13 @@ dependencies = [
  "once_cell",
  "serde",
  "simplelog",
- "toml 0.7.8",
+ "toml 0.8.19",
 ]
 
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9573,7 +9589,7 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -9590,7 +9606,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "hex",
@@ -9617,7 +9633,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "abstract-domain-derive",
  "codespan-reporting",
@@ -9636,7 +9652,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "hex",
@@ -9659,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "once_cell",
  "serde",
@@ -9668,7 +9684,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "better_any",
  "bytes 1.8.0",
@@ -9683,7 +9699,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "better_any",
@@ -9711,7 +9727,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "better_any",
  "bytes 1.8.0",
@@ -9735,7 +9751,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "anyhow",
  "bytes 1.8.0",
@@ -9750,7 +9766,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f#d9859a6ac139e70d37e1cb73f29e4a15f55f946f"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490#2be8941bd1c7d0d77dc741f43782898dfb099490"
 dependencies = [
  "bcs 0.1.4",
  "derivative",
@@ -11253,13 +11269,13 @@ dependencies = [
 [[package]]
 name = "processor"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=65185e5998c1a6892aee20045b09fcf17718c866#65185e5998c1a6892aee20045b09fcf17718c866"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=7658338eb9224abd9698c1e02dbc6ca526c268ce#7658338eb9224abd9698c1e02dbc6ca526c268ce"
 dependencies = [
  "ahash 0.8.11",
  "allocative",
  "allocative_derive",
  "anyhow",
- "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=65185e5998c1a6892aee20045b09fcf17718c866)",
+ "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=7658338eb9224abd9698c1e02dbc6ca526c268ce)",
  "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=338f9a1bcc06f62ce4a4994f1642b9a61b631ee0)",
  "async-trait",
  "bcs 0.1.4",
@@ -11299,7 +11315,7 @@ dependencies = [
  "server-framework",
  "sha2 0.9.9",
  "sha3",
- "strum 0.24.1",
+ "strum 0.26.3",
  "tiny-keccak",
  "tokio",
  "tokio-postgres",
@@ -12843,7 +12859,7 @@ dependencies = [
 [[package]]
 name = "server-framework"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=65185e5998c1a6892aee20045b09fcf17718c866#65185e5998c1a6892aee20045b09fcf17718c866"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=7658338eb9224abd9698c1e02dbc6ca526c268ce#7658338eb9224abd9698c1e02dbc6ca526c268ce"
 dependencies = [
  "anyhow",
  "aptos-system-utils",
@@ -12855,7 +12871,7 @@ dependencies = [
  "serde_yaml 0.8.26",
  "tempfile",
  "tokio",
- "toml 0.7.8",
+ "toml 0.8.19",
  "tracing",
  "tracing-subscriber 0.3.18",
  "warp",
@@ -13339,9 +13355,6 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros 0.24.3",
-]
 
 [[package]]
 name = "strum"
@@ -13426,7 +13439,7 @@ name = "suzuka-client"
 version = "0.0.2"
 dependencies = [
  "anyhow",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=d9859a6ac139e70d37e1cb73f29e4a15f55f946f)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=2be8941bd1c7d0d77dc741f43782898dfb099490)",
  "aptos-sdk",
  "aptos-types",
  "async-trait",
@@ -14171,18 +14184,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
@@ -14209,8 +14210,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.6.0",
- "serde",
- "serde_spanned",
  "toml_datetime",
  "winnow 0.5.40",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,44 +120,44 @@ serde_yaml = "0.9.34"
 ## Aptos dependencies
 ### We use a forked version so that we can override dependency versions. This is required
 ### to be avoid dependency conflicts with other Sovereign Labs crates.
-aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f", features = [
+aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490", features = [
     "cloneable-private-keys",
 ] }
-aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
-aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "d9859a6ac139e70d37e1cb73f29e4a15f55f946f" }
+aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
+aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "2be8941bd1c7d0d77dc741f43782898dfb099490" }
 
 # Indexer
-processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "65185e5998c1a6892aee20045b09fcf17718c866" }
-server-framework = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "65185e5998c1a6892aee20045b09fcf17718c866" }
+processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "7658338eb9224abd9698c1e02dbc6ca526c268ce" }
+server-framework = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "7658338eb9224abd9698c1e02dbc6ca526c268ce" }
 
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
 ethereum-types = "0.14.1"
@@ -315,8 +315,8 @@ globset = "0.4.15"
 glob = "0.3.1"
 
 # trying to pin diesel
-diesel = { version = "=2.1.1", features = ["postgres", "numeric", "r2d2"]}
-diesel_migrations = { version = "=2.1.0"}
+diesel = { version = "2.2.4", features = ["postgres", "numeric", "r2d2"] }
+diesel_migrations = { version = "2.2.0" }
 bigdecimal = "0.4.0"
 num_cpus = "=1.16.0"
 ahash = "=0.8.11"

--- a/protocol-units/bridge/indexer-db/src/models.rs
+++ b/protocol-units/bridge/indexer-db/src/models.rs
@@ -4,7 +4,7 @@ use diesel::prelude::*;
 
 // LockBridgeTransfer mapping
 #[derive(Debug, Insertable)]
-#[table_name = "lock_bridge_transfers"]
+#[diesel(table_name = lock_bridge_transfers)]
 pub struct NewLockBridgeTransfer {
 	pub bridge_transfer_id: String,
 	pub hash_lock: String,
@@ -14,7 +14,7 @@ pub struct NewLockBridgeTransfer {
 }
 
 #[derive(Debug, Queryable, Insertable)]
-#[table_name = "lock_bridge_transfers"]
+#[diesel(table_name = lock_bridge_transfers)]
 pub struct LockBridgeTransfer {
 	pub id: i32,
 	pub bridge_transfer_id: String,
@@ -26,14 +26,14 @@ pub struct LockBridgeTransfer {
 
 // WaitAndCompleteInitiator mapping
 #[derive(Debug, Insertable)]
-#[table_name = "wait_and_complete_initiators"]
+#[diesel(table_name = wait_and_complete_initiators)]
 pub struct NewWaitAndCompleteInitiator {
 	pub wait_time_secs: i64,
 	pub pre_image: String,
 }
 
 #[derive(Debug, Queryable, Insertable)]
-#[table_name = "wait_and_complete_initiators"]
+#[diesel(table_name = wait_and_complete_initiators)]
 pub struct WaitAndCompleteInitiator {
 	pub id: i32,
 	pub wait_time_secs: i64,
@@ -42,7 +42,7 @@ pub struct WaitAndCompleteInitiator {
 
 // InitiatedEvent mapping
 #[derive(Debug, Insertable)]
-#[table_name = "initiated_events"]
+#[diesel(table_name = initiated_events)]
 pub struct NewInitiatedEvent {
 	pub bridge_transfer_id: String,
 	pub initiator_address: String,
@@ -54,7 +54,7 @@ pub struct NewInitiatedEvent {
 }
 
 #[derive(Debug, Queryable, Insertable)]
-#[table_name = "initiated_events"]
+#[diesel(table_name = initiated_events)]
 pub struct InitiatedEvent {
 	pub id: i32,
 	pub bridge_transfer_id: String,
@@ -68,7 +68,7 @@ pub struct InitiatedEvent {
 
 // LockedEvent mapping
 #[derive(Debug, Insertable)]
-#[table_name = "locked_events"]
+#[diesel(table_name = locked_events)]
 pub struct NewLockedEvent {
 	pub bridge_transfer_id: String,
 	pub initiator: String,
@@ -79,7 +79,7 @@ pub struct NewLockedEvent {
 }
 
 #[derive(Debug, Queryable, Insertable)]
-#[table_name = "locked_events"]
+#[diesel(table_name = locked_events)]
 pub struct LockedEvent {
 	pub id: i32,
 	pub bridge_transfer_id: String,
@@ -92,13 +92,13 @@ pub struct LockedEvent {
 
 // InitiatorCompletedEvent mapping
 #[derive(Debug, Insertable)]
-#[table_name = "initiator_completed_events"]
+#[diesel(table_name = initiator_completed_events)]
 pub struct NewInitiatorCompletedEvent {
 	pub bridge_transfer_id: String,
 }
 
 #[derive(Debug, Queryable, Insertable)]
-#[table_name = "initiator_completed_events"]
+#[diesel(table_name = initiator_completed_events)]
 pub struct InitiatorCompletedEvent {
 	pub id: i32,
 	pub bridge_transfer_id: String,
@@ -106,14 +106,14 @@ pub struct InitiatorCompletedEvent {
 
 // CounterPartCompletedEvent mapping
 #[derive(Debug, Insertable)]
-#[table_name = "counter_part_completed_events"]
+#[diesel(table_name = counter_part_completed_events)]
 pub struct NewCounterPartCompletedEvent {
 	pub bridge_transfer_id: String,
 	pub pre_image: String,
 }
 
 #[derive(Debug, Queryable, Insertable)]
-#[table_name = "counter_part_completed_events"]
+#[diesel(table_name = counter_part_completed_events)]
 pub struct CounterPartCompletedEvent {
 	pub id: i32,
 	pub bridge_transfer_id: String,
@@ -122,13 +122,13 @@ pub struct CounterPartCompletedEvent {
 
 // CancelledEvent mapping
 #[derive(Debug, Insertable)]
-#[table_name = "cancelled_events"]
+#[diesel(table_name = cancelled_events)]
 pub struct NewCancelledEvent {
 	pub bridge_transfer_id: String,
 }
 
 #[derive(Debug, Queryable, Insertable)]
-#[table_name = "cancelled_events"]
+#[diesel(table_name = cancelled_events)]
 pub struct CancelledEvent {
 	pub id: i32,
 	pub bridge_transfer_id: String,
@@ -136,13 +136,13 @@ pub struct CancelledEvent {
 
 // RefundedEvent mapping
 #[derive(Debug, Insertable)]
-#[table_name = "refunded_events"]
+#[diesel(table_name = refunded_events)]
 pub struct NewRefundedEvent {
 	pub bridge_transfer_id: String,
 }
 
 #[derive(Debug, Queryable, Insertable)]
-#[table_name = "refunded_events"]
+#[diesel(table_name = refunded_events)]
 pub struct RefundedEvent {
 	pub id: i32,
 	pub bridge_transfer_id: String,


### PR DESCRIPTION
# Summary
- **Categories**: `protocol-units`.
- **Associated PR**: https://github.com/movementlabsxyz/aptos-core/pull/97

Resolves https://github.com/movementlabsxyz/movement/security/dependabot/12
by updating dependencies to use diesel >= 2.2.3

# Changelog

* Updated dependencies to fix GHSA-wq9x-qwcq-mmgf

# Testing

CI tests should pass.