### PR TITLE
Make Inflight Limit Optional

### DIFF
--- a/protocol-units/execution/opt-executor/src/background/task.rs
+++ b/protocol-units/execution/opt-executor/src/background/task.rs
@@ -33,7 +33,7 @@ impl BackgroundTask {
 		node_config: &NodeConfig,
 		mempool_config: &MempoolConfig,
 		transactions_in_flight: Arc<AtomicU64>,
-		transactions_in_flight_limit: u64,
+		transactions_in_flight_limit: Option<u64>,
 	) -> Self {
 		Self {
 			inner: BackgroundInner::Full(TransactionPipe::new(

--- a/protocol-units/execution/util/src/config/common.rs
+++ b/protocol-units/execution/util/src/config/common.rs
@@ -162,7 +162,7 @@ env_default!(
 	"auth_token".to_string()
 );
 
-env_default!(default_max_transactions_in_flight, "MAPTOS_MAX_TRANSACTIONS_IN_FLIGHT", u64, 12000);
+env_default!(default_max_transactions_in_flight, "MAPTOS_MAX_TRANSACTIONS_IN_FLIGHT", u64);
 
 env_default!(default_sequence_number_ttl_ms, "MAPTOS_SEQUENCE_NUMBER_TTL_MS", u64, 1000 * 60 * 3);
 

--- a/protocol-units/execution/util/src/config/load_shedding.rs
+++ b/protocol-units/execution/util/src/config/load_shedding.rs
@@ -1,4 +1,4 @@
-//! Configuration for load-sheding limits.
+//! Configuration for load-shedding limits.
 
 use super::common::default_max_transactions_in_flight;
 
@@ -9,7 +9,7 @@ pub struct Config {
 	/// The maximum number of transactions permitted to be in flight
 	/// before new transactions are rejected.
 	#[serde(default = "default_max_transactions_in_flight")]
-	pub max_transactions_in_flight: u64,
+	pub max_transactions_in_flight: Option<u64>,
 }
 
 impl Default for Config {


### PR DESCRIPTION
# Summary
- **RFCs**:$\emptyset$.
- **Categories**: `protocol-units`

Makes inflight transaction limit optional in a manner which should be compatible with #839 . 

- Simply allows inflight transaction limit to be an option. If none, new transactions are always accepted. 
- This effectively pushes load-shedding down to the mempool garbage collection, which is undesirable because said subsystem will not be able to cleanly report `MempoolFull` to the client. So, #839 is preferred.

# Testing

1. e2e testing.

# Outstanding issues

1. Add automated e2e test covering restricted and non-restricted cases. 