### PR TITLE
fix path

### DIFF
--- a/docs/movement-node/run/ansible/follower-node/README.md
+++ b/docs/movement-node/run/ansible/follower-node/README.md
@@ -8,7 +8,7 @@ By running the a Follower Node locally, you will be able to gauge the performanc
 - 2 TB SSD w/ 60K IOPS and 200 MiB/s throughput
 
 ## Running a Movement Node on Follower Node
-You can join any sufficiently upgraded network as a Folloewr Node by running a Movement Node with container tags specified to latest commit hash on this branch, the [`follower`](../../../../docker/compose/suzuka-full-node/docker-compose.follower.yml) overlay. 
+You can join any sufficiently upgraded network as a Folloewr Node by running a Movement Node with container tags specified to latest commit hash on this branch, the [`follower`](../../../../../docker/compose/suzuka-full-node/docker-compose.follower.yml) overlay. 
 
 **Note**: the scripts provided herein have hardcoded constants for the Movement Testnet. You will need to change these to match the environment you are running on.
 


### PR DESCRIPTION
# Summary

- Fixes link in [docs/movement-node/run/ansible/follower-node/README.md ](https://github.com/movementlabsxyz/movement/blob/main/docs/movement-node/run/ansible/follower-node/README.md)

# Changelog

 - From: `../../../../docker/compose/suzuka-full-node/docker-compose.follower.yml`
 - To: `../../../../../docker/compose/suzuka-full-node/docker-compose.follower.yml`
  
# Testing

Tested the link.
