### PR TITLE
fix(mempool): pre-allocate capacity for the db key

### DIFF
--- a/protocol-units/mempool/move-rocks/src/lib.rs
+++ b/protocol-units/mempool/move-rocks/src/lib.rs
@@ -22,7 +22,7 @@ pub struct RocksdbMempool {
 
 fn construct_mempool_transaction_key(transaction: &MempoolTransaction) -> Result<String, Error> {
 	// Pre-allocate a string with the required capacity
-	let mut key = String::with_capacity(32 + 1 + 32 + 1 + 32 + 1 + 32);
+	let mut key = String::with_capacity(32 + 1 + 32 + 1 + 32 + 1 + 64);
 	// Write key components. The numbers are zero-padded to 32 characters.
 	key.write_fmt(format_args!(
 		"{:032}:{:032}:{:032}:{}",


### PR DESCRIPTION
# Summary
- **Categories**: `protocol-units`.

The amount allocated was not enough, wasting a re-allocation.

# Testing

Existing tests should pass.
