### PR TITLE
Atomic Bridge Rate Limiter

### DIFF
--- a/protocol-units/bridge/contracts/foundry.toml
+++ b/protocol-units/bridge/contracts/foundry.toml
@@ -3,7 +3,7 @@ src = "src"
 out = "out"
 libs = ["lib"]
 
-solc = "0.8.26"
+solc = "0.8.27"
 evm_version = "cancun"
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/protocol-units/bridge/contracts/src/AtomicBridgeCounterpartyMOVE.sol
+++ b/protocol-units/bridge/contracts/src/AtomicBridgeCounterpartyMOVE.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.22;
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {IAtomicBridgeCounterpartyMOVE} from "./IAtomicBridgeCounterpartyMOVE.sol";
 import {AtomicBridgeInitiatorMOVE} from "./AtomicBridgeInitiatorMOVE.sol";
+import {RateLimiter} from "./RateLimiter.sol";
 
 contract AtomicBridgeCounterpartyMOVE is IAtomicBridgeCounterpartyMOVE, OwnableUpgradeable {
     enum MessageState {
@@ -22,6 +23,7 @@ contract AtomicBridgeCounterpartyMOVE is IAtomicBridgeCounterpartyMOVE, OwnableU
     }
 
     AtomicBridgeInitiatorMOVE public atomicBridgeInitiatorMOVE;
+    RateLimiter public rateLimiter;
     mapping(bytes32 => BridgeTransferDetails) public bridgeTransfers;
 
     // Configurable time lock duration
@@ -43,6 +45,11 @@ contract AtomicBridgeCounterpartyMOVE is IAtomicBridgeCounterpartyMOVE, OwnableU
 
     function setTimeLockDuration(uint256 _timeLockDuration) external onlyOwner {
         counterpartyTimeLockDuration = _timeLockDuration;
+    }
+
+    function setRateLimiter(address _rateLimiter) external onlyOwner {
+        if (_rateLimiter == address(0)) revert ZeroAddress();
+        rateLimiter = RateLimiter(_rateLimiter);
     }
 
     function lockBridgeTransfer(

--- a/protocol-units/bridge/contracts/src/RateLimiter.sol
+++ b/protocol-units/bridge/contracts/src/RateLimiter.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.22;
+
+import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract RateLimiter is AccessControlUpgradeable {
+    bytes32 public constant ATOMIC_BRIDGE = keccak256("ATOMIC_BRIDGE");
+
+    mapping(uint256 day => uint256 amount) public outboundRateLimitBudget;
+    mapping(uint256 day => uint256 amount) public inboundRateLimitBudget;
+    address public insuranceFund;
+    IERC20 public moveToken;
+
+    error OutboundRateLimitExceeded();
+    error InboundRateLimitExceeded();
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
+        address _moveToken,
+        address _owner,
+        address _initiatorAddress,
+        address _counterpartyAddress,
+        address _insuranceFund
+    ) public initializer {
+        _grantRole(DEFAULT_ADMIN_ROLE, _owner);
+        _grantRole(ATOMIC_BRIDGE, _initiatorAddress);
+        _grantRole(ATOMIC_BRIDGE, _counterpartyAddress);
+        moveToken = IERC20(_moveToken);
+        insuranceFund = _insuranceFund;
+    }
+
+    function rateLimitOutbound(uint256 amount) external onlyRole(ATOMIC_BRIDGE) {
+        uint256 day = block.timestamp / 1 days;
+        outboundRateLimitBudget[day] += amount;
+        require(outboundRateLimitBudget[day] < moveToken.balanceOf(insuranceFund) / 4, OutboundRateLimitExceeded());
+    }
+
+    function rateLimitInbound(uint256 amount) external onlyRole(ATOMIC_BRIDGE) {
+        uint256 day = block.timestamp / 1 days;
+        inboundRateLimitBudget[day] += amount;
+        require(inboundRateLimitBudget[day] < moveToken.balanceOf(insuranceFund) / 4, InboundRateLimitExceeded());
+    }
+}

--- a/protocol-units/bridge/contracts/test/AtomicBridgeCounterpartyMOVE.t.sol
+++ b/protocol-units/bridge/contracts/test/AtomicBridgeCounterpartyMOVE.t.sol
@@ -5,45 +5,41 @@ pragma abicoder v2;
 import {Test, console} from "forge-std/Test.sol";
 import {AtomicBridgeCounterpartyMOVE} from "../src/AtomicBridgeCounterpartyMOVE.sol";
 import {AtomicBridgeInitiatorMOVE} from "../src/AtomicBridgeInitiatorMOVE.sol";
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {MockMOVEToken} from "../src/MockMOVEToken.sol";
+import {RateLimiter} from "../src/RateLimiter.sol";
 
 contract AtomicBridgeCounterpartyMOVETest is Test {
     AtomicBridgeCounterpartyMOVE public atomicBridgeCounterpartyMOVEImplementation;
     AtomicBridgeCounterpartyMOVE public atomicBridgeCounterpartyMOVE;
     AtomicBridgeInitiatorMOVE public atomicBridgeInitiatorMOVEImplementation;
     AtomicBridgeInitiatorMOVE public atomicBridgeInitiatorMOVE;
+    RateLimiter public rateLimiterImplementation;
+    RateLimiter public rateLimiter;
     MockMOVEToken public moveToken;
-    ProxyAdmin public proxyAdmin;
     TransparentUpgradeableProxy public proxy;
 
     address public deployer = address(0x1);
     address public originator = address(1);
     address public recipient = address(0x2);
     address public otherUser = address(0x3);
+    address public insuranceFund = address(0x4);
     bytes32 public hashLock = keccak256(abi.encodePacked("secret"));
     uint256 public amount = 100 * 10 ** 8; // 100 MOVEToken (assuming 8 decimals)
     uint256 public timeLock = 100;
     bytes32 public initiator = keccak256(abi.encodePacked(deployer));
     bytes32 public bridgeTransferId =
-        keccak256(
-            abi.encodePacked(
-                block.timestamp,
-                initiator,
-                recipient,
-                amount,
-                hashLock,
-                timeLock
-            )
-        );
+        keccak256(abi.encodePacked(block.timestamp, initiator, recipient, amount, hashLock, timeLock));
 
     uint256 public constant COUNTERPARTY_TIME_LOCK_DURATION = 24 * 60 * 60; // 24 hours
 
     function setUp() public {
+        // Set the counterparty contract in the AtomicBridgeInitiator contract
         // Deploy the MOVEToken contract and mint some tokens to the deployer
         moveToken = new MockMOVEToken();
         moveToken.initialize(address(this)); // Contract will hold initial MOVE tokens
+
+        moveToken.transfer(insuranceFund, moveToken.balanceOf(address(this)) / 10); // 10% of the total supply
 
         // Time lock durations
         uint256 initiatorTimeLockDuration = 48 * 60 * 60; // 48 hours for the initiator
@@ -53,14 +49,13 @@ contract AtomicBridgeCounterpartyMOVETest is Test {
 
         // Deploy the AtomicBridgeInitiator contract with a 48-hour time lock
         atomicBridgeInitiatorMOVEImplementation = new AtomicBridgeInitiatorMOVE();
-        proxyAdmin = new ProxyAdmin(deployer);
         proxy = new TransparentUpgradeableProxy(
             address(atomicBridgeInitiatorMOVEImplementation),
-            address(proxyAdmin),
+            address(deployer),
             abi.encodeWithSignature(
                 "initialize(address,address,uint256,uint256)",
                 address(moveToken),
-                deployer, 
+                deployer,
                 initiatorTimeLockDuration,
                 0 ether // Initial pool balance
             )
@@ -71,7 +66,7 @@ contract AtomicBridgeCounterpartyMOVETest is Test {
         atomicBridgeCounterpartyMOVEImplementation = new AtomicBridgeCounterpartyMOVE();
         proxy = new TransparentUpgradeableProxy(
             address(atomicBridgeCounterpartyMOVEImplementation),
-            address(proxyAdmin),
+            address(deployer),
             abi.encodeWithSignature(
                 "initialize(address,address,uint256)",
                 address(atomicBridgeInitiatorMOVE),
@@ -81,39 +76,45 @@ contract AtomicBridgeCounterpartyMOVETest is Test {
         );
         atomicBridgeCounterpartyMOVE = AtomicBridgeCounterpartyMOVE(address(proxy));
 
-        // Set the counterparty contract in the AtomicBridgeInitiator contract
-        vm.startPrank(deployer);
-        atomicBridgeInitiatorMOVE.setCounterpartyAddress(
-            address(atomicBridgeCounterpartyMOVE)
+        rateLimiterImplementation = new RateLimiter();
+        proxy = new TransparentUpgradeableProxy(
+            address(rateLimiterImplementation),
+            address(deployer),
+            abi.encodeWithSignature(
+                "initialize(address,address,address,address,address)",
+                address(moveToken),
+                deployer,
+                address(atomicBridgeInitiatorMOVE),
+                address(atomicBridgeCounterpartyMOVE),
+                insuranceFund
+            )
         );
+
+        rateLimiter = RateLimiter(address(proxy));
+
+        vm.startPrank(deployer);
+        atomicBridgeInitiatorMOVE.setRateLimiter(address(rateLimiter));
+        atomicBridgeCounterpartyMOVE.setRateLimiter(address(rateLimiter));
+        
+        atomicBridgeInitiatorMOVE.setCounterpartyAddress(address(atomicBridgeCounterpartyMOVE));
         vm.stopPrank();
     }
 
     function testLockBridgeTransfer() public {
-        uint256 moveAmount = 100 * 10**8;
-        moveToken.transfer(originator, moveAmount); 
+        uint256 moveAmount = 100 * 10 ** 8;
+        moveToken.transfer(originator, moveAmount);
         vm.startPrank(originator);
 
         // Approve the AtomicBridgeInitiatorMOVE contract to spend MOVEToken
         moveToken.approve(address(atomicBridgeInitiatorMOVE), amount);
 
         // Initiate the bridge transfer
-        atomicBridgeInitiatorMOVE.initiateBridgeTransfer(
-            amount,
-            initiator,
-            hashLock
-        );
+        atomicBridgeInitiatorMOVE.initiateBridgeTransfer(amount, initiator, hashLock);
 
         vm.stopPrank();
 
-        vm.startPrank(deployer);  // Only the owner (deployer) can call lockBridgeTransfer
-        atomicBridgeCounterpartyMOVE.lockBridgeTransfer(
-            initiator,
-            bridgeTransferId,
-            hashLock,
-            recipient,
-            amount
-        );
+        vm.startPrank(deployer); // Only the owner (deployer) can call lockBridgeTransfer
+        atomicBridgeCounterpartyMOVE.lockBridgeTransfer(initiator, bridgeTransferId, hashLock, recipient, amount);
         vm.stopPrank();
 
         (
@@ -130,48 +131,32 @@ contract AtomicBridgeCounterpartyMOVETest is Test {
         assertEq(pendingAmount, amount);
         assertEq(pendingHashLock, hashLock);
         assertGt(pendingTimelock, block.timestamp);
-        assertEq(
-            uint8(pendingState),
-            uint8(AtomicBridgeCounterpartyMOVE.MessageState.PENDING)
-        );
+        assertEq(uint8(pendingState), uint8(AtomicBridgeCounterpartyMOVE.MessageState.PENDING));
     }
 
     function testCompleteBridgeTransfer() public {
         bytes32 preImage = "secret";
         bytes32 testHashLock = keccak256(abi.encodePacked(preImage));
 
-        uint256 moveAmount = 100 * 10**8;
-        moveToken.transfer(originator, moveAmount); 
+        uint256 moveAmount = 100 * 10 ** 8;
+        moveToken.transfer(originator, moveAmount);
         vm.startPrank(originator);
 
         // Approve the AtomicBridgeInitiatorMOVE contract to spend MOVEToken
         moveToken.approve(address(atomicBridgeInitiatorMOVE), amount);
 
         // Initiate the bridge transfer
-        atomicBridgeInitiatorMOVE.initiateBridgeTransfer(
-            amount,
-            initiator,
-            testHashLock
-        );
+        atomicBridgeInitiatorMOVE.initiateBridgeTransfer(amount, initiator, testHashLock);
 
         vm.stopPrank();
 
-        vm.startPrank(deployer);  // Only the owner (deployer) can call lockBridgeTransfer
-        atomicBridgeCounterpartyMOVE.lockBridgeTransfer(
-            initiator,
-            bridgeTransferId,
-            testHashLock,
-            recipient,
-            amount
-        );
+        vm.startPrank(deployer); // Only the owner (deployer) can call lockBridgeTransfer
+        atomicBridgeCounterpartyMOVE.lockBridgeTransfer(initiator, bridgeTransferId, testHashLock, recipient, amount);
         vm.stopPrank();
 
         vm.startPrank(otherUser);
 
-        atomicBridgeCounterpartyMOVE.completeBridgeTransfer(
-            bridgeTransferId,
-            preImage
-        );
+        atomicBridgeCounterpartyMOVE.completeBridgeTransfer(bridgeTransferId, preImage);
 
         (
             bytes32 completedInitiator,
@@ -187,81 +172,59 @@ contract AtomicBridgeCounterpartyMOVETest is Test {
         assertEq(completedAmount, amount);
         assertEq(completedHashLock, testHashLock);
         assertGt(completedTimeLock, block.timestamp);
-        assertEq(
-            uint8(completedState),
-            uint8(AtomicBridgeCounterpartyMOVE.MessageState.COMPLETED)
-        );
+        assertEq(uint8(completedState), uint8(AtomicBridgeCounterpartyMOVE.MessageState.COMPLETED));
 
         vm.stopPrank();
     }
 
-function testAbortBridgeTransfer() public {
-    uint256 moveAmount = 100 * 10**8;
-    moveToken.transfer(originator, moveAmount); 
-    vm.startPrank(originator);
+    function testAbortBridgeTransfer() public {
+        uint256 moveAmount = 100 * 10 ** 8;
+        moveToken.transfer(originator, moveAmount);
+        vm.startPrank(originator);
 
-    // Approve the AtomicBridgeInitiatorMOVE contract to spend MOVEToken
-    moveToken.approve(address(atomicBridgeInitiatorMOVE), amount);
+        // Approve the AtomicBridgeInitiatorMOVE contract to spend MOVEToken
+        moveToken.approve(address(atomicBridgeInitiatorMOVE), amount);
 
-    // Initiate the bridge transfer
-    atomicBridgeInitiatorMOVE.initiateBridgeTransfer(
-        amount,
-        initiator,
-        hashLock
-    );
+        // Initiate the bridge transfer
+        atomicBridgeInitiatorMOVE.initiateBridgeTransfer(amount, initiator, hashLock);
 
-    vm.stopPrank();
+        vm.stopPrank();
 
-    vm.startPrank(deployer);
+        vm.startPrank(deployer);
 
-    atomicBridgeCounterpartyMOVE.lockBridgeTransfer(
-        initiator,
-        bridgeTransferId,
-        hashLock,
-        recipient,
-        amount
-    );
+        atomicBridgeCounterpartyMOVE.lockBridgeTransfer(initiator, bridgeTransferId, hashLock, recipient, amount);
 
-    vm.stopPrank();
+        vm.stopPrank();
 
-    // Advance the block number to beyond the timelock period
-    vm.warp(block.timestamp + COUNTERPARTY_TIME_LOCK_DURATION + 1);
+        // Advance the block number to beyond the timelock period
+        vm.warp(block.timestamp + COUNTERPARTY_TIME_LOCK_DURATION + 1);
 
-    // Try to abort as a malicious user (this should fail)
-    //vm.startPrank(otherUser);
-    //vm.expectRevert("Ownable: caller is not the owner");
-    //atomicBridgeCounterpartyMOVE.abortBridgeTransfer(bridgeTransferId);
-    //vm.stopPrank();
+        // Try to abort as a malicious user (this should fail)
+        //vm.startPrank(otherUser);
+        //vm.expectRevert("Ownable: caller is not the owner");
+        //atomicBridgeCounterpartyMOVE.abortBridgeTransfer(bridgeTransferId);
+        //vm.stopPrank();
 
-    // Abort as the owner (this should pass)
-    vm.startPrank(deployer); // The deployer is the owner
-    atomicBridgeCounterpartyMOVE.abortBridgeTransfer(bridgeTransferId);
+        // Abort as the owner (this should pass)
+        vm.startPrank(deployer); // The deployer is the owner
+        atomicBridgeCounterpartyMOVE.abortBridgeTransfer(bridgeTransferId);
 
-    (
-        bytes32 abortedInitiator,
-        address abortedRecipient,
-        uint256 abortedAmount,
-        bytes32 abortedHashLock,
-        uint256 abortedTimeLock,
-        AtomicBridgeCounterpartyMOVE.MessageState abortedState
-    ) = atomicBridgeCounterpartyMOVE.bridgeTransfers(bridgeTransferId);
+        (
+            bytes32 abortedInitiator,
+            address abortedRecipient,
+            uint256 abortedAmount,
+            bytes32 abortedHashLock,
+            uint256 abortedTimeLock,
+            AtomicBridgeCounterpartyMOVE.MessageState abortedState
+        ) = atomicBridgeCounterpartyMOVE.bridgeTransfers(bridgeTransferId);
 
-    assertEq(abortedInitiator, initiator);
-    assertEq(abortedRecipient, recipient);
-    assertEq(abortedAmount, amount);
-    assertEq(abortedHashLock, hashLock);
-    assertLe(
-        abortedTimeLock,
-        block.timestamp,
-        "Timelock is not less than or equal to current timestamp"
-    );
-    assertEq(
-        uint8(abortedState),
-        uint8(AtomicBridgeCounterpartyMOVE.MessageState.REFUNDED)
-    );
+        assertEq(abortedInitiator, initiator);
+        assertEq(abortedRecipient, recipient);
+        assertEq(abortedAmount, amount);
+        assertEq(abortedHashLock, hashLock);
+        assertLe(abortedTimeLock, block.timestamp, "Timelock is not less than or equal to current timestamp");
+        assertEq(uint8(abortedState), uint8(AtomicBridgeCounterpartyMOVE.MessageState.REFUNDED));
 
-    vm.stopPrank();
-}
-
-
+        vm.stopPrank();
+    }
 }


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

Atomic Bridge Rate Limiter

# Changelog

Added Rate Limiter contract that stores states on rate limiting.
Calls are made from permissioned atomic bridge contracts

# Testing

cd bridge/contracts
forge test

# Outstanding issues

Demonstrating that the rate limiting is valid throught time, but that's done on the other rate limiter.