### PR TITLE
Reimplement GC in move-rocks by added CF index

### DIFF
--- a/protocol-units/mempool/move-rocks/src/lib.rs
+++ b/protocol-units/mempool/move-rocks/src/lib.rs
@@ -32,7 +32,7 @@ fn construct_mempool_transaction_key(transaction: &MempoolTransaction) -> String
 		transaction.transaction.sequence_number(),
 		transaction.transaction.id(),
 	))
-	.unwrap();
+	.unwrap(); // write to String never fails
 	key
 }
 
@@ -41,7 +41,7 @@ fn construct_transaction_timeline_key(transaction: &MempoolTransaction) -> Strin
 	let mut key = String::with_capacity(32 + 1 + 64);
 	// Write key components. The numbers are zero-padded to 32 characters.
 	key.write_fmt(format_args!("{:032}:{}", transaction.timestamp, transaction.transaction.id()))
-		.unwrap();
+		.unwrap(); // write to String never fails
 	key
 }
 


### PR DESCRIPTION
Fixes: #879 #880 #881

# Summary
- **Categories**: `protocol-units`.

Resolve the problem of GC not being implemented for the key format that ended up being merged, by introducing a time-sorted index CF named "transaction_timeline". The entries are added with each transaction, but are only collected by GC passes when their time window passes.

# Changelog

* move-rocks: Fix garbage collection so that it actually works.

# Testing

`test_rocksdb_gc` passes in the move-rocks crate.
