### PR TITLE
remove duplicate entries Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,14 +33,11 @@ members = [
     "util/syncador",
     "util/collections",
     "networks/movement/*",
-    "protocol-units/settlement/mcr/setup",
-    "protocol-units/settlement/mcr/runner",
     "protocol-units/bridge/service",
     "protocol-units/bridge/grpc",
     "protocol-units/bridge/integration-tests",
     "protocol-units/bridge/indexer-db",
     "protocol-units/bridge/util",
-    "protocol-units/settlement/mcr/runner",
     "benches/*",
 ]
 


### PR DESCRIPTION
# Summary

Cleaned up the workspace configuration by removing duplicate entries from the `members` array in `Cargo.toml`.
