### PR TITLE
Add missing parameter to spin function

### DIFF
--- a/networks/movement/movement-tests/src/tests/complex-alice/sources/resource_roulette.move
+++ b/networks/movement/movement-tests/src/tests/complex-alice/sources/resource_roulette.move
@@ -172,7 +172,7 @@ module resource_roulette::resource_roulette {
     
     init_module(account);
     bid(bidder_one, 10);
-    spin();
+    spin(account);
 
     // spin empties the bids
     let i = 0;
@@ -222,7 +222,7 @@ module resource_roulette::resource_roulette {
     let i : u64 = 0;
     while (i < 1_000) {
       bid(bidder_one, 7);
-      spin();
+      spin(account);
 
       let winnings = borrow_global<RouletteWinnings>(signer::address_of(bidder_one));
       if (winnings.amount > 0) {
@@ -247,7 +247,7 @@ module resource_roulette::resource_roulette {
       bid(bidder_one, 2);
       bid(bidder_two, 2);
       bid(bidder_three, 4);
-      spin();
+      spin(account);
 
       let winnings_one = borrow_global<RouletteWinnings>(signer::address_of(bidder_one));
       let winnings_two = borrow_global<RouletteWinnings>(signer::address_of(bidder_two));


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$
- **Categories**: `misc`

This PR addresses the issue with missing account parameters in the `spin()` function calls in the `resource_roulette.move` (`networks/movement/movement-tests/src/tests/complex-alice/sources/resource_roulette.move`) file. The function was originally called without parameters. This change ensures the function calls are correctly passed the `account` parameter.

# Changelog
- Replaced all instances of `spin();` with `spin(account);` to pass the `account` parameter correctly.

# Testing
- The modified `spin()` function now accepts and correctly processes the `account` parameter.
- All tests within the module are now passing.

# Outstanding issues
- No outstanding issues. All necessary changes are included in this PR.
