### PR TITLE
Update aptos core rev and correct bridge setup build issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -812,7 +812,7 @@ checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -835,7 +835,7 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-logger",
  "aptos-types",
@@ -849,7 +849,7 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -921,7 +921,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "hex",
@@ -930,7 +930,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -974,7 +974,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -995,7 +995,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "futures",
  "rustversion",
@@ -1005,7 +1005,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "shadow-rs",
 ]
@@ -1013,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1027,7 +1027,7 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -1038,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -1050,7 +1050,7 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1081,7 +1081,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1108,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1161,7 +1161,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1171,7 +1171,7 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
@@ -1219,7 +1219,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1239,7 +1239,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer-schemas"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-schemadb",
@@ -1253,7 +1253,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1284,7 +1284,7 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-infallible",
  "aptos-metrics-core",
@@ -1295,7 +1295,7 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -1311,7 +1311,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-consensus-types",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-block-partitioner",
  "aptos-config",
@@ -1373,7 +1373,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -1395,7 +1395,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1415,7 +1415,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-runtimes",
  "core_affinity",
@@ -1428,7 +1428,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1462,7 +1462,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -1476,7 +1476,7 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -1544,7 +1544,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "either",
  "move-core-types",
@@ -1553,7 +1553,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -1568,7 +1568,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -1588,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
@@ -1601,17 +1601,17 @@ dependencies = [
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 
 [[package]]
 name = "aptos-indexer"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1643,7 +1643,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1655,7 +1655,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-metrics-core",
  "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors)",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8)",
  "aptos-runtimes",
  "aptos-storage-interface",
  "aptos-types",
@@ -1681,7 +1681,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-table-info"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1712,11 +1712,11 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-utils"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8)",
  "async-trait",
  "backoff",
  "base64 0.13.1",
@@ -1744,12 +1744,12 @@ dependencies = [
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1777,7 +1777,7 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1787,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
@@ -1831,7 +1831,7 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1844,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1854,7 +1854,7 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-infallible",
  "aptos-log-derive",
@@ -1878,7 +1878,7 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
@@ -1891,7 +1891,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -1931,7 +1931,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-types",
  "async-trait",
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-infallible",
  "bytes 1.8.0",
@@ -1955,7 +1955,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -1964,7 +1964,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -1995,7 +1995,7 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2016,7 +2016,7 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2033,7 +2033,7 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
@@ -2050,7 +2050,7 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2095,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2106,7 +2106,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-build-info",
  "aptos-infallible",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -2145,7 +2145,7 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -2158,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-config",
  "aptos-types",
@@ -2183,23 +2183,11 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "crossbeam",
  "proptest",
  "proptest-derive",
-]
-
-[[package]]
-name = "aptos-protos"
-version = "1.3.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
-dependencies = [
- "futures-core",
- "pbjson",
- "prost 0.12.6",
- "serde",
- "tonic 0.11.0",
 ]
 
 [[package]]
@@ -2215,9 +2203,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-protos"
+version = "1.3.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
+dependencies = [
+ "futures-core",
+ "pbjson",
+ "prost 0.12.6",
+ "serde",
+ "tonic 0.11.0",
+]
+
+[[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "ipnet",
 ]
@@ -2225,7 +2225,7 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -2236,7 +2236,7 @@ dependencies = [
 [[package]]
 name = "aptos-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2250,7 +2250,7 @@ dependencies = [
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-config",
  "rocksdb",
@@ -2282,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "rayon",
  "tokio",
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2308,7 +2308,7 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-crypto",
  "aptos-drop-helper",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -2349,7 +2349,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2367,11 +2367,11 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8)",
  "bcs 0.1.4",
  "crossbeam-channel",
  "once_cell",
@@ -2385,7 +2385,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-crypto",
  "aptos-infallible",
@@ -2406,7 +2406,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -2417,7 +2417,7 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2428,7 +2428,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2476,7 +2476,7 @@ dependencies = [
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -2494,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -2503,7 +2503,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -2516,7 +2516,7 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2573,12 +2573,12 @@ dependencies = [
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
@@ -2594,7 +2594,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2644,7 +2644,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-cached-packages",
  "aptos-crypto",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -2680,7 +2680,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2702,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -9017,7 +9017,7 @@ dependencies = [
  "aptos-language-e2e-tests",
  "aptos-logger",
  "aptos-mempool",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8)",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
@@ -9386,7 +9386,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -9403,7 +9403,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -9418,12 +9418,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -9438,7 +9438,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-spec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "once_cell",
  "quote",
@@ -9448,7 +9448,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -9460,7 +9460,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "fail",
  "move-binary-format",
@@ -9474,7 +9474,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "clap 4.5.21",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "clap 4.5.21",
@@ -9519,7 +9519,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "difference",
@@ -9536,7 +9536,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -9562,7 +9562,7 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -9593,7 +9593,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -9618,7 +9618,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "clap 4.5.21",
@@ -9654,7 +9654,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "clap 4.5.21",
@@ -9673,7 +9673,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -9685,7 +9685,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -9701,7 +9701,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -9719,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "hex",
@@ -9732,7 +9732,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "codespan",
@@ -9771,7 +9771,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "clap 4.5.21",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "atty",
@@ -9832,7 +9832,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9861,7 +9861,7 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -9878,7 +9878,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "hex",
@@ -9905,7 +9905,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "abstract-domain-derive",
  "codespan-reporting",
@@ -9924,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "hex",
@@ -9947,7 +9947,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "once_cell",
  "serde",
@@ -9956,7 +9956,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "better_any",
  "bytes 1.8.0",
@@ -9971,7 +9971,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "better_any",
@@ -9999,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "better_any",
  "bytes 1.8.0",
@@ -10023,7 +10023,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "anyhow",
  "bytes 1.8.0",
@@ -10038,7 +10038,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef#111a5540e5def0b17851cc4a9e2f46955efcf1ef"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8#903d4b3267024785063fd17d1fb90639e7d55ca8"
 dependencies = [
  "bcs 0.1.4",
  "derivative",
@@ -13784,7 +13784,7 @@ name = "suzuka-client"
 version = "0.0.2"
 dependencies = [
  "anyhow",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=111a5540e5def0b17851cc4a9e2f46955efcf1ef)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=903d4b3267024785063fd17d1fb90639e7d55ca8)",
  "aptos-sdk",
  "aptos-types",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,40 +122,40 @@ serde_yaml = "0.9.34"
 ## Aptos dependencies
 ### We use a forked version so that we can override dependency versions. This is required
 ### to be avoid dependency conflicts with other Sovereign Labs crates.
-aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef", features = [
+aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8", features = [
     "cloneable-private-keys",
 ] }
-aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
-aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "111a5540e5def0b17851cc4a9e2f46955efcf1ef" }
+aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
+aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "903d4b3267024785063fd17d1fb90639e7d55ca8" }
 
 # Indexer
 processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "7658338eb9224abd9698c1e02dbc6ca526c268ce" }

--- a/protocol-units/bridge/setup/src/deploy.rs
+++ b/protocol-units/bridge/setup/src/deploy.rs
@@ -146,7 +146,9 @@ async fn initialize_eth_contracts(
 
 	// Load the ABI from a JSON file or inline JSON
 	//	let contract_abi = include_bytes!("../../service/abis/AtomicBridgeInitiator.json");
-	let path = "/home/pdelrieu/dev/blockchain/movement/github/PR/state_logic/both_framework/movement/protocol-units/bridge/service/abis/NativeBridge.json";
+	let path = std::env::current_dir()
+		.unwrap() // unwrap ok current dir set during setup start.
+		.join("protocol-units/bridge/service/abis/NativeBridge.json");
 	let data = std::fs::read_to_string(path).expect("Unable to read ABI file");
 
 	// Parse the JSON data


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.
<!--
Add your summary text here. 
 -->

# Changelog
Update the Aptos core framework rev to the one that include the @andygolay transfer_id serialization PR 105.
Correct a build issue in the bridge setup.
The bridge process compose starts now.

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->
`CELESTIA_LOG_LEVEL=FATAL CARGO_PROFILE=release CARGO_PROFILE_FLAGS=--release nix develop --extra-experimental-features nix-command --extra-experimental-features flakes --command bash -c "just bridge native build.setup.eth-local.celestia-local.bridge --keep-tui`

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->