### PR TITLE
Fix `test_movement_client_complete_transfer` so it passes, uses random nonce for test hardness

### DIFF
--- a/protocol-units/bridge/util/src/types.rs
+++ b/protocol-units/bridge/util/src/types.rs
@@ -47,7 +47,7 @@ impl fmt::Display for ChainId {
 	}
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, Deserialize, serde::Serialize)]
 pub struct Nonce(pub u128);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize)]
@@ -129,7 +129,7 @@ where
 	}
 }
 
-#[derive(Deref, DerefMut, Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Deref, DerefMut, Debug, Clone, Copy, PartialEq, Eq, Deserialize, serde::Serialize)]
 pub struct Amount(pub u64);
 
 impl From<Uint<256, 4>> for Amount {


### PR DESCRIPTION
# Summary
- Addresses one point of https://github.com/movementlabsxyz/movement/issues/914, `client_mvt_tests test_movement_complete_transfer` (fixes `EINVALID_BRIDGE_TRANFER_ID` error in `test_movement_client_complete_transfer`)
- **Categories**: `bridge`

# Changelog

- Add helper function `normalize_to_32_bytes` to serialize `u64` the same way that's done on the Solidity side
- Update `test_movement_client_complete_transfer` to use the correct serialization

# Testing

1. Run `CELESTIA_LOG_LEVEL=FATAL CARGO_PROFILE=release CARGO_PROFILE_FLAGS=--release nix develop --extra-experimental-features nix-command --extra-experimental-features flakes --command bash -c "just bridge native build.setup.eth-local.celestia-local.bridge.bridge-indexer --keep-tui"` to start the local Movement network

2. Run the integration test with `RUST_BACKTRACE=1 DOT_MOVEMENT_PATH="$(pwd)/.movement" cargo test --test client_mvt_tests test_movement_client_complete_transfer -- --nocapture --test-threads=1`