### PR TITLE
Feat: E2E Eth -> Movement happy path passes

### DIFF
--- a/protocol-units/bridge/integration-tests/tests/bridge_e2e_test_framework.rs
+++ b/protocol-units/bridge/integration-tests/tests/bridge_e2e_test_framework.rs
@@ -78,7 +78,8 @@ async fn test_bridge_transfer_eth_movement_happy_path() -> Result<(), anyhow::Er
 		if let Some(Ok(BridgeContractEvent::Completed(detail))) = event {
 			assert_eq!(detail.bridge_transfer_id, bridge_transfer_id);
 			let addr_vec: Vec<u8> = EthAddress(HarnessEthClient::get_initiator(&config)).into();
-			assert_eq!(detail.initiator.0, addr_vec);
+			let addr_ascii_hex: Vec<u8> = hex::encode(addr_vec).into_bytes();
+			assert_eq!(detail.initiator.0, addr_ascii_hex);
 			assert_eq!(detail.recipient, BridgeAddress(recipient));
 			assert_eq!(detail.amount, amount);
 			assert_eq!(detail.nonce, nonce);

--- a/protocol-units/bridge/service/src/actions.rs
+++ b/protocol-units/bridge/service/src/actions.rs
@@ -19,13 +19,15 @@ where
 	match action.kind.clone() {
 		TransferActionType::CompleteBridgeTransfer {
 			bridge_transfer_id,
-			initiator,
+			mut initiator,
 			recipient,
 			amount,
 			nonce,
 		} => {
+			initiator.0 = hex::encode(initiator.0).into_bytes();
+
 			let future = async move {
-				tracing::info!("Before client.lock_bridge_transfer");
+				tracing::info!("Before client.complete_bridge_transfer");
 				client
 					.complete_bridge_transfer(
 						bridge_transfer_id,
@@ -33,7 +35,7 @@ where
 						BridgeAddress(recipient.0.try_into().map_err(|_| {
 							ActionExecError(
 								action.clone(),
-								BridgeContractError::BadAddressEncoding("lock bridge transfer fail to convert recipient address to vec<u8>".to_string()),
+								BridgeContractError::BadAddressEncoding("Complete bridge transfer fail to convert recipient address to vec<u8>".to_string()),
 							)
 						})?),
 						amount,


### PR DESCRIPTION
# Summary
- **Issue** #914 
- **Categories**: `bridge`, `E2E tests`

# Changelog

- Add `initiator.0 = hex::encode(initiator.0).into_bytes()` into `process_action` under `TransferActionType::CompleteBridgeTransfer` to convert Eth address into hex before feeding into `complete_bridge_transfer` due to hex encoding issue.
- Convert initiator data type to ASCII-encoded hex to compare initiator data after receiving Completed event

# Testing

1. Run bridge with `CELESTIA_LOG_LEVEL=FATAL CARGO_PROFILE=release CARGO_PROFILE_FLAGS=--release nix develop --extra-experimental-features nix-command --extra-experimental-features flakes --command bash -c "just bridge native build.setup.eth-local.celestia-local.bridge.bridge-indexer --keep-tui"`
2. Run test with `RUST_BACKTRACE=1 DOT_MOVEMENT_PATH="$(pwd)/.movement" cargo test --test bridge_e2e_test_framework test_bridge_transfer_eth_movement_happy_path -- --nocapture --test-threads=1`


# Outstanding issues
The error code 2 in `aptos-core` was incorrectly logged as `ENONCE_NOT_FOUND` which also has error code 2. I'll open an issue on `aptos-core` so it can be fixed. We should at least use named error codes to avoid such ambiguity and incorrect error logging.