### PR TITLE
Rate Limiter Parameterization

### DIFF
--- a/protocol-units/bridge/contracts/src/RateLimiter.sol
+++ b/protocol-units/bridge/contracts/src/RateLimiter.sol
@@ -49,7 +49,7 @@ contract RateLimiter is AccessControlUpgradeable {
 
     function setRateLimiterCoefficients(uint256 numerator, uint256 denominator) external onlyRole(RATE_LIMITER_ADMIN) {
 
-        require(denominator/numerator >= 4, "INSURANCE_FUND_MUST_BE_4X_RATE_LIMITER");
+        require(numerator == 0 || denominator/numerator >= 4, "INSURANCE_FUND_MUST_BE_4X_RATE_LIMITER");
 
         rateLimiterNumerator = numerator;
         rateLimiterDenominator = denominator;

--- a/protocol-units/bridge/contracts/src/RateLimiter.sol
+++ b/protocol-units/bridge/contracts/src/RateLimiter.sol
@@ -21,6 +21,7 @@ contract RateLimiter is AccessControlUpgradeable {
 
     error OutboundRateLimitExceeded();
     error InboundRateLimitExceeded();
+    error RateLimitCoefficientTooLow();
 
     constructor() {
         _disableInitializers();
@@ -49,7 +50,7 @@ contract RateLimiter is AccessControlUpgradeable {
 
     function setRateLimiterCoefficients(uint256 numerator, uint256 denominator) external onlyRole(RATE_LIMITER_ADMIN) {
 
-        require(numerator == 0 || denominator/numerator >= 4, "INSURANCE_FUND_MUST_BE_4X_RATE_LIMITER");
+        require(numerator == 0 || denominator/numerator >= 4, RateLimitCoefficientTooLow());
 
         rateLimiterNumerator = numerator;
         rateLimiterDenominator = denominator;

--- a/protocol-units/bridge/contracts/src/RateLimiter.sol
+++ b/protocol-units/bridge/contracts/src/RateLimiter.sol
@@ -6,11 +6,18 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract RateLimiter is AccessControlUpgradeable {
     bytes32 public constant ATOMIC_BRIDGE = keccak256("ATOMIC_BRIDGE");
+    bytes32 public constant RATE_LIMITER_ADMIN = keccak256("RATE_LIMITER_ADMIN");
 
     mapping(uint256 day => uint256 amount) public outboundRateLimitBudget;
     mapping(uint256 day => uint256 amount) public inboundRateLimitBudget;
     address public insuranceFund;
     IERC20 public moveToken;
+
+    uint256 public rateLimiterNumerator;
+    uint256 public rateLimiterDenominator;
+
+    // the period over which the rate limit is enforced
+    uint256 public periodDuration;
 
     error OutboundRateLimitExceeded();
     error InboundRateLimitExceeded();
@@ -27,21 +34,38 @@ contract RateLimiter is AccessControlUpgradeable {
         address _insuranceFund
     ) public initializer {
         _grantRole(DEFAULT_ADMIN_ROLE, _owner);
+        _grantRole(ATOMIC_BRIDGE, _owner);
         _grantRole(ATOMIC_BRIDGE, _initiatorAddress);
         _grantRole(ATOMIC_BRIDGE, _counterpartyAddress);
+        _grantRole(RATE_LIMITER_ADMIN, _owner);
+        _grantRole(RATE_LIMITER_ADMIN, _initiatorAddress);
+        _grantRole(RATE_LIMITER_ADMIN, _counterpartyAddress);
         moveToken = IERC20(_moveToken);
         insuranceFund = _insuranceFund;
+        periodDuration = 1 days;
+        rateLimiterNumerator = 1;
+        rateLimiterDenominator = 4;
+    }
+
+    function setRateLimiterCoefficients(uint256 numerator, uint256 denominator) external onlyRole(RATE_LIMITER_ADMIN) {
+
+        require(denominator/numerator >= 4, "INSURANCE_FUND_MUST_BE_4X_RATE_LIMITER");
+
+        rateLimiterNumerator = numerator;
+        rateLimiterDenominator = denominator;
     }
 
     function rateLimitOutbound(uint256 amount) external onlyRole(ATOMIC_BRIDGE) {
-        uint256 day = block.timestamp / 1 days;
-        outboundRateLimitBudget[day] += amount;
-        require(outboundRateLimitBudget[day] < moveToken.balanceOf(insuranceFund) / 4, OutboundRateLimitExceeded());
+        uint256 period = block.timestamp / periodDuration;
+        outboundRateLimitBudget[period] += amount;
+        uint256 periodMax = moveToken.balanceOf(insuranceFund) * rateLimiterNumerator / rateLimiterDenominator;
+        require(outboundRateLimitBudget[period] < periodMax, OutboundRateLimitExceeded());
     }
 
     function rateLimitInbound(uint256 amount) external onlyRole(ATOMIC_BRIDGE) {
-        uint256 day = block.timestamp / 1 days;
-        inboundRateLimitBudget[day] += amount;
-        require(inboundRateLimitBudget[day] < moveToken.balanceOf(insuranceFund) / 4, InboundRateLimitExceeded());
+        uint256 period = block.timestamp / periodDuration;
+        inboundRateLimitBudget[period] += amount;
+        uint256 periodMax = moveToken.balanceOf(insuranceFund) * rateLimiterNumerator / rateLimiterDenominator;
+        require(inboundRateLimitBudget[period] < periodMax, InboundRateLimitExceeded());
     }
 }

--- a/protocol-units/bridge/contracts/test/RateLimiter.t.sol
+++ b/protocol-units/bridge/contracts/test/RateLimiter.t.sol
@@ -89,7 +89,7 @@ contract RateLimiterTest is Test {
             }
 
         } else {
-            vm.expectRevert("INSURANCE_FUND_MUST_BE_4X_RATE_LIMITER");
+            vm.expectRevert(RateLimiter.RateLimitCoefficientTooLow.selector);
             rateLimiter.setRateLimiterCoefficients(_numerator, _denominator);
         }
 

--- a/protocol-units/bridge/contracts/test/RateLimiter.t.sol
+++ b/protocol-units/bridge/contracts/test/RateLimiter.t.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.22;
+pragma abicoder v2;
+
+import {Test, console} from "forge-std/Test.sol";
+import {AtomicBridgeInitiatorMOVE, IAtomicBridgeInitiatorMOVE, OwnableUpgradeable} from "../src/AtomicBridgeInitiatorMOVE.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {MockMOVEToken} from "../src/MockMOVEToken.sol";  
+import {RateLimiter} from "../src/RateLimiter.sol";
+
+contract RateLimiterTest is Test {
+    MockMOVEToken public moveToken;   
+    RateLimiter public rateLimiterImplementation;
+    RateLimiter public rateLimiter;
+    ProxyAdmin public proxyAdmin;
+    TransparentUpgradeableProxy public proxy;
+    AtomicBridgeInitiatorMOVE public atomicBridgeInitiatorMOVE;
+
+    address public originator = address(1);
+    address public insuranceFund = address(4);
+    address public rateLimiterOperator = address(5);
+    bytes32 public recipient = keccak256(abi.encodePacked(address(2)));
+    bytes32 public hashLock = keccak256(abi.encodePacked("secret"));
+    uint256 public amount = 1 ether;
+    uint256 public constant timeLockDuration = 48 * 60 * 60; // 48 hours in seconds
+
+    function setUp() public {
+        // Deploy the MOVEToken contract and mint some tokens to the deployer
+        moveToken = new MockMOVEToken();
+        moveToken.initialize(address(this)); // Contract will hold initial MOVE tokens
+        moveToken.transfer(insuranceFund, moveToken.balanceOf(address(this)) / 10); // 10% of the total supply
+
+        originator = vm.addr(uint256(keccak256(abi.encodePacked(block.timestamp, block.prevrandao))));
+
+        rateLimiterImplementation = new RateLimiter();
+        proxy = new TransparentUpgradeableProxy(
+            address(rateLimiterImplementation),
+            address(this),
+            abi.encodeWithSignature(
+                "initialize(address,address,address,address,address)",
+                address(moveToken),
+                address(this),
+                address(rateLimiterOperator),
+                address(0x1337), // just a mock address
+                insuranceFund
+            )
+        );
+
+        rateLimiter = RateLimiter(address(proxy));
+    }
+
+   function testSetRateLimitFuzz(uint256 _numerator, uint256 _denominator, uint256 _perTransfer) public {
+
+        _numerator = _numerator % 1000;
+        _denominator = _denominator % 1000;
+        uint256 _perTransfer = 1 ether * (_perTransfer % 1000);
+
+        vm.prank(rateLimiterOperator);
+        if (_numerator == 0) {
+            // should fail on division error
+        } else if ((_denominator/_numerator) >= 4) {
+            rateLimiter.setRateLimiterCoefficients(_numerator, _denominator);
+
+            if (_perTransfer > 0) {
+                // rate limit on both inbound and outbound until we exceed the limit for the period
+                uint256 totalTransferred = 0;
+                // number of iterations should be the total balance of the insurance fund divided by the _perTransfer divided by 2 to check reverts are applied consistently on higher values
+                uint256 numberOfIterations = moveToken.balanceOf(insuranceFund) / (_perTransfer / 2);
+                uint256 periodMax = moveToken.balanceOf(insuranceFund) * _numerator / _denominator;
+                for (uint256 i = 0; i < numberOfIterations; i++) {
+
+                    if (totalTransferred + _perTransfer > periodMax) {
+                        vm.expectRevert();
+                        rateLimiter.rateLimitOutbound(_perTransfer);
+                    } else {
+                        rateLimiter.rateLimitOutbound(_perTransfer);
+                    }
+
+                    if (totalTransferred + _perTransfer > periodMax) {
+                        vm.expectRevert();
+                        rateLimiter.rateLimitInbound(_perTransfer);
+                    } else {
+                        rateLimiter.rateLimitInbound(_perTransfer);
+                    }
+
+                    totalTransferred += _perTransfer;
+                }
+            }
+
+        } else {
+            vm.expectRevert("INSURANCE_FUND_MUST_BE_4X_RATE_LIMITER");
+            rateLimiter.setRateLimiterCoefficients(_numerator, _denominator);
+        }
+
+    }
+}
+


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**: `protocol-units`

Adds parameterization to rate limit contracts and tests. 
- Parameterization allows setting rate limits less than $\frac{1}{4}$
- Parameterization allows shutting down the bridge without having to transfer away from the insurance fund. 

# Testing
1. Unite tests added demonstrating usage. 

# Outstanding issues
None