### PR TITLE
feat: auto-remove .movement if exists in justfile

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -153,6 +153,9 @@
               export DOT_MOVEMENT_PATH=$(pwd)/.movement
               mkdir -p $DOT_MOVEMENT_PATH
 
+              # by default set to remove the .movement directory
+              export REMOVE_DOT_MOVEMENT=true
+
               # export PKG_CONFIG_PATH=$PKG_CONFIG_PATH_FOR_TARGET
 
               # Export linker flags if on Darwin (macOS)

--- a/justfile
+++ b/justfile
@@ -1,18 +1,43 @@
+# Function to check and remove the .movement/ directory if it exists
+remove-dot-movement:
+    @if [ -d .movement ]; then \
+        echo "Removing .movement directory..."; \
+        rm -rf .movement; \
+    fi
+
+# Commands with a dependency on `remove-dot-movement`
 movement-celestia-da-light-node RUNTIME FEATURES *ARGS:
+    just remove-dot-movement
     ./scripts/movement/run movement-celestia-da-light-node {{ RUNTIME }} {{ FEATURES }} {{ ARGS }}
+
 monza-full-node RUNTIME FEATURES *ARGS:
+    just remove-dot-movement
     ./scripts/movement/run monza-full-node {{ RUNTIME }} {{ FEATURES }} {{ ARGS }}
+
 movement-full-node RUNTIME FEATURES *ARGS:
+    just remove-dot-movement
     ./scripts/movement/run movement-full-node {{ RUNTIME }} {{ FEATURES }} {{ ARGS }}
+
 mcr-contract-tests: 
+    just remove-dot-movement
     cd ./protocol-units/settlement/mcr/contracts && forge test
+
 mcr-client RUNTIME FEATURES *ARGS:
+    just remove-dot-movement
     ./scripts/movement/run mcr-client {{ RUNTIME }} {{ FEATURES }} {{ ARGS }}
+
 bridge RUNTIME FEATURES *ARGS:
+    just remove-dot-movement
     ./scripts/movement/run bridge {{ RUNTIME }} {{ FEATURES }} {{ ARGS }}
+
 bridge-solo RUNTIME FEATURES *ARGS:
+    just remove-dot-movement
     ./scripts/movement/run bridge-solo {{ RUNTIME }} {{ FEATURES }} {{ ARGS }}
+
 build-push-container IMAGE:
+    just remove-dot-movement
     ./scripts/movement/build-push-image {{ IMAGE }}
+
 container-tests:
+    just remove-dot-movement
     ./scripts/tests/container-tests

--- a/justfile
+++ b/justfile
@@ -1,8 +1,8 @@
 # Function to check and remove the .movement/ directory if it exists
 remove-dot-movement:
-    @if [ -d .movement ]; then \
-        echo "Removing .movement directory..."; \
-        rm -rf .movement; \
+    @if [ "${REMOVE_DOT_MOVEMENT}" = "true" ] && [ -d "${DOT_MOVEMENT_PATH}" ]; then \
+        echo "Removing ${DOT_MOVEMENT_PATH} directory..."; \
+        rm -rf "${DOT_MOVEMENT_PATH}"; \
     fi
 
 # Commands with a dependency on `remove-dot-movement`


### PR DESCRIPTION
# Summary
Several times I run the just command to start the node or run tests and realise I have forgotten to remove `.movement`, this updates the justfile so that it will always remove that if it exists.

# Changelog
- Updates the justfile to include a function, runs that on every just command

# Testing
Ran 
```
CELESTIA_LOG_LEVEL=FATAL CARGO_PROFILE=release CARGO_PROFILE_FLAGS=--release nix develop --extra-experimental-features nix-command --extra-experimental-features flakes --command bash -c "just bridge native build.setup.eth-local.celestia-local.bridge.bridge-indexer --keep-tui"
```
It worked as expected, it removed my already existing `.movement/` dir.
