### PR TITLE
Bridge: Add the address convertion trait to the relayer type.

### DIFF
--- a/protocol-units/bridge/service/src/actions.rs
+++ b/protocol-units/bridge/service/src/actions.rs
@@ -31,7 +31,7 @@ where
 					.complete_bridge_transfer(
 						bridge_transfer_id,
 						initiator,
-						BridgeAddress(A::try_decode(recipient.0).map_err(|err| {
+						BridgeAddress(A::try_decode_recipient(recipient.0).map_err(|err| {
 							ActionExecError(
 								action.clone(),
 								BridgeContractError::BadAddressEncoding(format!("Complete bridge transfer fail to convert recipient address to vec<u8> : {err}")),

--- a/protocol-units/bridge/service/src/actions.rs
+++ b/protocol-units/bridge/service/src/actions.rs
@@ -1,4 +1,3 @@
-//use crate::chains::movement::utils as movement_utils;
 use bridge_util::chains::bridge_contracts::BridgeContractError;
 use bridge_util::chains::bridge_contracts::BridgeRelayerContract;
 use bridge_util::chains::AddressVecCodec;
@@ -61,7 +60,7 @@ where
 					.complete_bridge_transfer(
 						bridge_transfer_id,
 						initiator,
-						BridgeAddress(A::try_decode(recipient.0).map_err(|err| {
+						BridgeAddress(A::try_decode_recipient(recipient.0).map_err(|err| {
 							ActionExecError(
 								action.clone(),
 								BridgeContractError::BadAddressEncoding(format!("Complete bridge transfer fail to convert recipient address to vec<u8> : {err}")),

--- a/protocol-units/bridge/service/src/chains/ethereum/event_monitoring.rs
+++ b/protocol-units/bridge/service/src/chains/ethereum/event_monitoring.rs
@@ -125,7 +125,6 @@ impl EthMonitoring {
 							Ok(Ok(events)) => {
 								for (initiated, _log) in events {
 									let event = {
-										// BridgeTransferInitiated(bridgeTransferId, originator, recipient, totalAmount, hashLock, initiatorTimeLockDuration);
 										let details: BridgeTransferInitiatedDetails<EthAddress> =
 											BridgeTransferInitiatedDetails {
 												bridge_transfer_id: BridgeTransferId(

--- a/protocol-units/bridge/service/src/chains/ethereum/types.rs
+++ b/protocol-units/bridge/service/src/chains/ethereum/types.rs
@@ -7,6 +7,7 @@ use alloy::providers::fillers::{
 use alloy::providers::RootProvider;
 use alloy::rlp::{RlpDecodable, RlpEncodable};
 use alloy::transports::BoxTransport;
+use bridge_util::chains::AddressVecCodec;
 use bridge_util::types::BridgeAddress;
 use rand::Rng;
 use std::hash::{DefaultHasher, Hash, Hasher};
@@ -147,5 +148,14 @@ impl From<[u8; 32]> for EthAddress {
 impl From<[u8; 20]> for EthAddress {
 	fn from(bytes: [u8; 20]) -> Self {
 		EthAddress(Address(bytes.into()))
+	}
+}
+
+impl AddressVecCodec for EthAddress {
+	fn try_decode(value: Vec<u8>) -> Result<Self, AddressError> {
+		EthAddress::try_from(value)
+	}
+	fn encode(self) -> Vec<u8> {
+		self.into()
 	}
 }

--- a/protocol-units/bridge/service/src/chains/ethereum/types.rs
+++ b/protocol-units/bridge/service/src/chains/ethereum/types.rs
@@ -152,10 +152,10 @@ impl From<[u8; 20]> for EthAddress {
 }
 
 impl AddressVecCodec for EthAddress {
-	fn try_decode(value: Vec<u8>) -> Result<Self, AddressError> {
+	fn try_decode_recipient(value: Vec<u8>) -> Result<Self, AddressError> {
 		EthAddress::try_from(value)
 	}
-	fn encode(self) -> Vec<u8> {
+	fn encode_initiator(self) -> Vec<u8> {
 		self.into()
 	}
 }

--- a/protocol-units/bridge/service/src/chains/movement/utils.rs
+++ b/protocol-units/bridge/service/src/chains/movement/utils.rs
@@ -137,11 +137,7 @@ impl AddressVecCodec for MovementAddress {
 		MovementAddress::try_from(value)
 	}
 	fn encode_initiator(self) -> Vec<u8> {
-		let bytes: Vec<u8> = self.into();
-		// convert initiator address to hex because Transfer id verification
-		// use hex encoded address for initiator on Mvt.
-		// Encode initiator so that counterpart chain use the same encoding.
-		hex::encode(bytes).into_bytes()
+		self.into()
 	}
 }
 

--- a/protocol-units/bridge/service/src/chains/movement/utils.rs
+++ b/protocol-units/bridge/service/src/chains/movement/utils.rs
@@ -132,18 +132,11 @@ impl TryFrom<&str> for MovementAddress {
 }
 
 impl AddressVecCodec for MovementAddress {
-	fn try_decode(value: Vec<u8>) -> Result<Self, AddressError> {
-		// let addr_str = String::from_utf8(value).map_err(|err| {
-		// 	AddressError::AddressConvertionlError(format!("MovementAddress vecdecode error:{err}",))
-		// })?;
-		// let bytes = hex::decode(addr_str).map_err(|err| {
-		// 	AddressError::AddressConvertionlError(
-		// 		format!("MovementAddress hex decode error:{err}",),
-		// 	)
-		// })?;
+	fn try_decode_recipient(value: Vec<u8>) -> Result<Self, AddressError> {
+		// Get binary address from movement chain.
 		MovementAddress::try_from(value)
 	}
-	fn encode(self) -> Vec<u8> {
+	fn encode_initiator(self) -> Vec<u8> {
 		let bytes: Vec<u8> = self.into();
 		// convert initiator address to hex because Transfer id verification
 		// use hex encoded address for initiator on Mvt.

--- a/protocol-units/bridge/service/src/chains/movement/utils.rs
+++ b/protocol-units/bridge/service/src/chains/movement/utils.rs
@@ -21,6 +21,7 @@ use aptos_sdk::{
 		AccountKey, LocalAccount,
 	},
 };
+use bridge_util::chains::AddressVecCodec;
 use bridge_util::{
 	chains::bridge_contracts::BridgeContractError,
 	types::{AddressError, BridgeAddress},
@@ -127,6 +128,27 @@ impl TryFrom<&str> for MovementAddress {
 		let s = s.trim_start_matches("0x");
 		let bytes = hex::decode(s).map_err(|_| AddressError::InvalidHexString)?;
 		bytes.try_into()
+	}
+}
+
+impl AddressVecCodec for MovementAddress {
+	fn try_decode(value: Vec<u8>) -> Result<Self, AddressError> {
+		// let addr_str = String::from_utf8(value).map_err(|err| {
+		// 	AddressError::AddressConvertionlError(format!("MovementAddress vecdecode error:{err}",))
+		// })?;
+		// let bytes = hex::decode(addr_str).map_err(|err| {
+		// 	AddressError::AddressConvertionlError(
+		// 		format!("MovementAddress hex decode error:{err}",),
+		// 	)
+		// })?;
+		MovementAddress::try_from(value)
+	}
+	fn encode(self) -> Vec<u8> {
+		let bytes: Vec<u8> = self.into();
+		// convert initiator address to hex because Transfer id verification
+		// use hex encoded address for initiator on Mvt.
+		// Encode initiator so that counterpart chain use the same encoding.
+		hex::encode(bytes).into_bytes()
 	}
 }
 

--- a/protocol-units/bridge/service/src/lib.rs
+++ b/protocol-units/bridge/service/src/lib.rs
@@ -1,4 +1,5 @@
 use crate::actions::process_action;
+use bridge_util::chains::AddressVecCodec;
 //use bridge_indexer_db::client::Client as IndexerClient;
 use bridge_util::{
 	actions::{ActionExecError, TransferAction, TransferActionType},
@@ -46,8 +47,8 @@ impl HeathCheckStatus {
 }
 
 pub async fn run_bridge<
-	A1: Send + TryFrom<Vec<u8>> + std::clone::Clone + 'static + std::fmt::Debug,
-	A2: Send + TryFrom<Vec<u8>> + std::clone::Clone + 'static + std::fmt::Debug,
+	A1: Send + std::clone::Clone + 'static + std::fmt::Debug + AddressVecCodec,
+	A2: Send + std::clone::Clone + 'static + std::fmt::Debug + AddressVecCodec,
 >(
 	client_one: impl BridgeRelayerContract<A1> + 'static,
 	mut stream_one: impl BridgeContractMonitoring<Address = A1>,
@@ -57,11 +58,7 @@ pub async fn run_bridge<
 	//	indexer_db_client: Option<IndexerClient>,
 	healthcheck_tx_one: mpsc::Sender<oneshot::Sender<bool>>,
 	healthcheck_tx_two: mpsc::Sender<oneshot::Sender<bool>>,
-) -> Result<(), anyhow::Error>
-where
-	Vec<u8>: From<A1>,
-	Vec<u8>: From<A2>,
-{
+) -> Result<(), anyhow::Error> {
 	let mut state_runtime = Runtime::new(); //indexer_db_client
 
 	let mut client_exec_result_futures_one = FuturesUnordered::new();
@@ -337,7 +334,7 @@ impl Runtime {
 		event: TransferEvent<A>,
 	) -> Result<TransferAction, InvalidEventError>
 	where
-		A: Into<Vec<u8>> + std::clone::Clone + std::fmt::Debug,
+		A: AddressVecCodec + std::clone::Clone + std::fmt::Debug,
 	{
 		tracing::info!("Event received: {:?}", event);
 		self.validate_state(&event)?;

--- a/protocol-units/bridge/util/src/chains/mod.rs
+++ b/protocol-units/bridge/util/src/chains/mod.rs
@@ -1,1 +1,8 @@
+use crate::types::AddressError;
+
 pub mod bridge_contracts;
+
+pub trait AddressVecCodec: TryFrom<Vec<u8>, Error = AddressError> + Into<Vec<u8>> {
+	fn try_decode(value: Vec<u8>) -> Result<Self, AddressError>;
+	fn encode(self) -> Vec<u8>;
+}

--- a/protocol-units/bridge/util/src/chains/mod.rs
+++ b/protocol-units/bridge/util/src/chains/mod.rs
@@ -2,7 +2,10 @@ use crate::types::AddressError;
 
 pub mod bridge_contracts;
 
+// Address are converted from one chain to another.
+// Source chain Initiator address are converted in a Vec<u8> for target Chain.
+// Source chain Recipient address is a Vec<u8> that is converted to target address.
 pub trait AddressVecCodec: TryFrom<Vec<u8>, Error = AddressError> + Into<Vec<u8>> {
-	fn try_decode(value: Vec<u8>) -> Result<Self, AddressError>;
-	fn encode(self) -> Vec<u8>;
+	fn try_decode_recipient(value: Vec<u8>) -> Result<Self, AddressError>;
+	fn encode_initiator(self) -> Vec<u8>;
 }

--- a/protocol-units/bridge/util/src/states.rs
+++ b/protocol-units/bridge/util/src/states.rs
@@ -95,7 +95,7 @@ impl TransferState {
 	) -> (Self, TransferAction) {
 		println!("State transition_from_initiated amount {:?}", detail.amount);
 
-		let initiator = detail.initiator.0.encode();
+		let initiator = detail.initiator.0.encode_initiator();
 
 		let state = TransferState {
 			state: TransferStateType::Initialized,


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

<!--
Add your summary text here. 
 -->
Initially it was done to remove the hex encoding of the initiator address from the relayer logic since the PR #916.
@andygolay is working on the serialization to remove the encoding, but I think it's a good thing to have this convert trait in the relayer logic in case we need to add specific processing (like the hex encoding) during the relayer address conversion without putting it in its logic.
I put in draft until the hex encoding is fixed.
# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->