### PR TITLE
Fix `test_movement_client_initiate_transfer` and E2E tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -812,7 +812,7 @@ checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -835,7 +835,7 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-logger",
  "aptos-types",
@@ -849,7 +849,7 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -921,7 +921,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "hex",
@@ -930,7 +930,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -974,7 +974,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -995,7 +995,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "futures",
  "rustversion",
@@ -1005,7 +1005,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "shadow-rs",
 ]
@@ -1013,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1027,7 +1027,7 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -1038,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -1050,7 +1050,7 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1081,7 +1081,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1108,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1161,7 +1161,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1171,7 +1171,7 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
@@ -1219,7 +1219,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1239,7 +1239,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer-schemas"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-schemadb",
@@ -1253,7 +1253,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1284,7 +1284,7 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-infallible",
  "aptos-metrics-core",
@@ -1295,7 +1295,7 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -1311,7 +1311,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-consensus-types",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-block-partitioner",
  "aptos-config",
@@ -1373,7 +1373,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -1395,7 +1395,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1415,7 +1415,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-runtimes",
  "core_affinity",
@@ -1428,7 +1428,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1462,7 +1462,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -1476,7 +1476,7 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -1544,7 +1544,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "either",
  "move-core-types",
@@ -1553,7 +1553,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -1568,7 +1568,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -1588,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
@@ -1601,17 +1601,17 @@ dependencies = [
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 
 [[package]]
 name = "aptos-indexer"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1643,7 +1643,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1655,7 +1655,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-metrics-core",
  "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors)",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730)",
  "aptos-runtimes",
  "aptos-storage-interface",
  "aptos-types",
@@ -1681,7 +1681,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-table-info"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -1712,11 +1712,11 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-utils"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730)",
  "async-trait",
  "backoff",
  "base64 0.13.1",
@@ -1744,12 +1744,12 @@ dependencies = [
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1777,7 +1777,7 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1787,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
@@ -1831,7 +1831,7 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -1844,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1854,7 +1854,7 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-infallible",
  "aptos-log-derive",
@@ -1878,7 +1878,7 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
@@ -1891,7 +1891,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -1931,7 +1931,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-types",
  "async-trait",
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-infallible",
  "bytes 1.8.0",
@@ -1955,7 +1955,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -1964,7 +1964,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -1995,7 +1995,7 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2016,7 +2016,7 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2033,7 +2033,7 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
@@ -2050,7 +2050,7 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2095,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2106,7 +2106,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-build-info",
  "aptos-infallible",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -2145,7 +2145,7 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -2158,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-config",
  "aptos-types",
@@ -2183,23 +2183,11 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "crossbeam",
  "proptest",
  "proptest-derive",
-]
-
-[[package]]
-name = "aptos-protos"
-version = "1.3.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
-dependencies = [
- "futures-core",
- "pbjson",
- "prost 0.12.6",
- "serde",
- "tonic 0.11.0",
 ]
 
 [[package]]
@@ -2215,9 +2203,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-protos"
+version = "1.3.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
+dependencies = [
+ "futures-core",
+ "pbjson",
+ "prost 0.12.6",
+ "serde",
+ "tonic 0.11.0",
+]
+
+[[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "ipnet",
 ]
@@ -2225,7 +2225,7 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -2236,7 +2236,7 @@ dependencies = [
 [[package]]
 name = "aptos-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2250,7 +2250,7 @@ dependencies = [
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-config",
  "rocksdb",
@@ -2282,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "rayon",
  "tokio",
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2308,7 +2308,7 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-crypto",
  "aptos-drop-helper",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -2349,7 +2349,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2367,11 +2367,11 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730)",
  "bcs 0.1.4",
  "crossbeam-channel",
  "once_cell",
@@ -2385,7 +2385,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-crypto",
  "aptos-infallible",
@@ -2406,7 +2406,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -2417,7 +2417,7 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2428,7 +2428,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2476,7 +2476,7 @@ dependencies = [
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -2494,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -2503,7 +2503,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -2516,7 +2516,7 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2573,12 +2573,12 @@ dependencies = [
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
@@ -2594,7 +2594,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2644,7 +2644,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-cached-packages",
  "aptos-crypto",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -2680,7 +2680,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2702,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -8839,7 +8839,7 @@ dependencies = [
  "aptos-language-e2e-tests",
  "aptos-logger",
  "aptos-mempool",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730)",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
@@ -9208,7 +9208,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -9225,7 +9225,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -9240,12 +9240,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -9260,7 +9260,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-spec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "once_cell",
  "quote",
@@ -9270,7 +9270,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -9282,7 +9282,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "fail",
  "move-binary-format",
@@ -9296,7 +9296,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "clap 4.5.21",
@@ -9311,7 +9311,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "clap 4.5.21",
@@ -9341,7 +9341,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "difference",
@@ -9358,7 +9358,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -9384,7 +9384,7 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -9415,7 +9415,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -9440,7 +9440,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -9459,7 +9459,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "clap 4.5.21",
@@ -9476,7 +9476,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "clap 4.5.21",
@@ -9495,7 +9495,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -9507,7 +9507,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -9523,7 +9523,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -9541,7 +9541,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "hex",
@@ -9554,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -9567,7 +9567,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "codespan",
@@ -9593,7 +9593,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "clap 4.5.21",
@@ -9627,7 +9627,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "atty",
@@ -9654,7 +9654,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9683,7 +9683,7 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -9700,7 +9700,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "hex",
@@ -9727,7 +9727,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "abstract-domain-derive",
  "codespan-reporting",
@@ -9746,7 +9746,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "hex",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "once_cell",
  "serde",
@@ -9778,7 +9778,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "better_any",
  "bytes 1.8.0",
@@ -9793,7 +9793,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "better_any",
@@ -9821,7 +9821,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "better_any",
  "bytes 1.8.0",
@@ -9845,7 +9845,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "anyhow",
  "bytes 1.8.0",
@@ -9860,7 +9860,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087#0cbe55e9d3d86c9213f35656c802e5f72f37d087"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730#53b1f0586b36a2659b84c65cea50b2946b8fa730"
 dependencies = [
  "bcs 0.1.4",
  "derivative",
@@ -10191,7 +10191,7 @@ name = "movement-tests"
 version = "0.0.2"
 dependencies = [
  "anyhow",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=0cbe55e9d3d86c9213f35656c802e5f72f37d087)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=53b1f0586b36a2659b84c65cea50b2946b8fa730)",
  "aptos-sdk",
  "aptos-types",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,40 +122,40 @@ serde_yaml = "0.9.34"
 ## Aptos dependencies
 ### We use a forked version so that we can override dependency versions. This is required
 ### to be avoid dependency conflicts with other Sovereign Labs crates.
-aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087", features = [
+aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730", features = [
     "cloneable-private-keys",
 ] }
-aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
-aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "0cbe55e9d3d86c9213f35656c802e5f72f37d087" }
+aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
+aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "53b1f0586b36a2659b84c65cea50b2946b8fa730" }
 
 # Indexer
 processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "7658338eb9224abd9698c1e02dbc6ca526c268ce" }

--- a/protocol-units/bridge/integration-tests/src/lib.rs
+++ b/protocol-units/bridge/integration-tests/src/lib.rs
@@ -22,7 +22,7 @@ use bridge_service::types::BridgeAddress;
 use bridge_service::types::BridgeTransferId;
 use bridge_service::types::Nonce;
 use bridge_util::chains::bridge_contracts::BridgeClientContract;
-use ethabi::ethereum_types;
+use ethabi;
 use godfig::{backend::config_file::ConfigFile, Godfig};
 use rand::{distributions::Alphanumeric, thread_rng, Rng, SeedableRng};
 use std::{

--- a/protocol-units/bridge/integration-tests/tests/bridge_e2e_test_framework.rs
+++ b/protocol-units/bridge/integration-tests/tests/bridge_e2e_test_framework.rs
@@ -87,12 +87,6 @@ async fn test_bridge_transfer_eth_movement_happy_path() -> Result<(), anyhow::Er
 		}
 	}
 
-	// Gracefully stop monitoring
-	tracing::info!("Stopping monitoring tasks.");
-	drop(mvt_monitoring);
-	drop(eth_monitoring);
-	tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-
 	Ok(())
 }
 
@@ -165,59 +159,5 @@ async fn test_bridge_transfer_movement_eth_happy_path() -> Result<(), anyhow::Er
 		}
 	}
 
-	// Gracefully stop monitoring
-	tracing::info!("Stopping monitoring tasks.");
-	drop(mvt_monitoring);
-	drop(eth_monitoring);
-	tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-
 	Ok(())
-}
-
-async fn test_get_events_by_account_event_handle(
-	rest_url: &str,
-	account_address: &str,
-	event_type: &str,
-) {
-	let url = format!(
-		"{}/v1/accounts/{}/events/{}/bridge_transfer_initiated_events",
-		rest_url, account_address, event_type
-	);
-
-	println!("url: {:?}", url);
-	let client = reqwest::Client::new();
-
-	// Send the GET request
-	let res = client
-		.get(&url)
-		.query(&[("start", "0"), ("limit", "10")])
-		.send()
-		.await
-		.unwrap()
-		.text()
-		.await;
-	println!("Account direct response: {res:?}",);
-}
-
-use aptos_sdk::rest_client::Client;
-use std::str::FromStr;
-
-async fn fetch_account_events(rest_url: &str, account_address: &str, event_type: &str) {
-	// Initialize the RestClient
-	let node_connection_url = url::Url::from_str(rest_url).unwrap();
-	let client = Client::new(node_connection_url); // Use the correct node URL
-	let native_address = AccountAddress::from_hex_literal(account_address).unwrap();
-
-	// Get the events for the specified account
-	let response = client
-		.get_account_events(
-			native_address,
-			event_type,
-			"bridge_transfer_initiated_events",
-			Some(1),
-			None,
-		)
-		.await;
-
-	println!("response{response:?}",);
 }

--- a/protocol-units/bridge/integration-tests/tests/bridge_e2e_test_framework.rs
+++ b/protocol-units/bridge/integration-tests/tests/bridge_e2e_test_framework.rs
@@ -20,7 +20,7 @@ use tracing_subscriber::EnvFilter;
 
 #[tokio::test]
 async fn test_bridge_transfer_eth_movement_happy_path() -> Result<(), anyhow::Error> {
-	tracing_subscriber::fmt().with_env_filter(EnvFilter::new("info")).init();
+	//tracing_subscriber::fmt().with_env_filter(EnvFilter::new("info")).init();
 
 	let (eth_client_harness, mvt_client_harness, config) =
 		TestHarness::new_with_eth_and_movement().await?;
@@ -87,16 +87,22 @@ async fn test_bridge_transfer_eth_movement_happy_path() -> Result<(), anyhow::Er
 		}
 	}
 
+	// Gracefully stop monitoring
+	tracing::info!("Stopping monitoring tasks.");
+	drop(mvt_monitoring);
+	drop(eth_monitoring);
+	tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
 	Ok(())
 }
 
 #[tokio::test]
 async fn test_bridge_transfer_movement_eth_happy_path() -> Result<(), anyhow::Error> {
-	tracing_subscriber::fmt()
-		.with_env_filter(
-			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-		)
-		.init();
+	// tracing_subscriber::fmt()
+	// 	.with_env_filter(
+	// 		EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+	// 	)
+	// 	.init();
 
 	let (mut eth_client_harness, mut mvt_client_harness, config) =
 		TestHarness::new_with_eth_and_movement().await?;
@@ -158,6 +164,12 @@ async fn test_bridge_transfer_movement_eth_happy_path() -> Result<(), anyhow::Er
 			break;
 		}
 	}
+
+	// Gracefully stop monitoring
+	tracing::info!("Stopping monitoring tasks.");
+	drop(mvt_monitoring);
+	drop(eth_monitoring);
+	tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
 
 	Ok(())
 }

--- a/protocol-units/bridge/integration-tests/tests/bridge_e2e_test_framework.rs
+++ b/protocol-units/bridge/integration-tests/tests/bridge_e2e_test_framework.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::Address;
 use anyhow::Result;
 use aptos_types::account_address::AccountAddress;
 use bridge_integration_tests::{HarnessEthClient, TestHarness};
@@ -32,7 +33,7 @@ async fn test_bridge_transfer_eth_movement_happy_path() -> Result<(), anyhow::Er
 
 	{
 		let faucet_client = mvt_client_harness.faucet_client.write().unwrap();
-		faucet_client.fund(movement_client_signer_address, 100_000_000).await?;
+		faucet_client.fund(movement_client_signer_address, 100_000_000_000).await?;
 	}
 
 	let recipient_privkey = mvt_client_harness.fund_account().await;
@@ -69,7 +70,6 @@ async fn test_bridge_transfer_eth_movement_happy_path() -> Result<(), anyhow::Er
 	let (_mvt_health_tx, mvt_health_rx) = tokio::sync::mpsc::channel(10);
 	let mut mvt_monitoring =
 		MovementMonitoring::build(&config.movement, mvt_health_rx).await.unwrap();
-
 	// Wait for InitiatorCompleted event
 	tracing::info!("Wait for Completed event.");
 	loop {
@@ -77,7 +77,7 @@ async fn test_bridge_transfer_eth_movement_happy_path() -> Result<(), anyhow::Er
 			tokio::time::timeout(std::time::Duration::from_secs(30), mvt_monitoring.next()).await?;
 		if let Some(Ok(BridgeContractEvent::Completed(detail))) = event {
 			assert_eq!(detail.bridge_transfer_id, bridge_transfer_id);
-			let addr_vec: Vec<u8> = EthAddress(HarnessEthClient::get_initiator(&config)).into();
+			let addr_vec: Vec<u8> = EthAddress(HarnessEthClient::get_initiator_address(&config)).into();
 			assert_eq!(detail.initiator.0, addr_vec);
 			assert_eq!(detail.recipient, BridgeAddress(recipient));
 			assert_eq!(detail.amount, amount);
@@ -91,7 +91,6 @@ async fn test_bridge_transfer_eth_movement_happy_path() -> Result<(), anyhow::Er
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_bridge_transfer_movement_eth_happy_path() -> Result<(), anyhow::Error> {
 	tracing_subscriber::fmt()
 		.with_env_filter(
@@ -101,7 +100,8 @@ async fn test_bridge_transfer_movement_eth_happy_path() -> Result<(), anyhow::Er
 
 	let (mut eth_client_harness, mut mvt_client_harness, config) =
 		TestHarness::new_with_eth_and_movement().await?;
-	let (_, mvt_health_rx) = tokio::sync::mpsc::channel(10);
+	// must include name of sender channel to avoid it being dropped
+	let (_mvt_health_tx, mvt_health_rx) = tokio::sync::mpsc::channel(10);
 	let mut mvt_monitoring =
 		MovementMonitoring::build(&config.movement, mvt_health_rx).await.unwrap();
 
@@ -109,28 +109,26 @@ async fn test_bridge_transfer_movement_eth_happy_path() -> Result<(), anyhow::Er
 	let movement_client_signer_address = mvt_client_harness.movement_client.signer().address();
 	let initiator_privkey = mvt_client_harness.fund_account().await;
 	let initiator_address = MovementAddress(initiator_privkey.address());
-
+	tracing::info!("Initiator address: {:?}", initiator_address);
+	let recipient_address = HarnessEthClient::get_recipient_address(&config).to_vec();
 	{
 		let faucet_client = mvt_client_harness.faucet_client.write().unwrap();
-		faucet_client.fund(movement_client_signer_address, 100_000_000).await?;
-		faucet_client.fund(initiator_privkey.address(), 100_000_000).await?;
+		faucet_client.fund(movement_client_signer_address, 100_000_000_000_000).await?;
+		faucet_client.fund(initiator_privkey.address(), 100_000_000_000_000).await?;
 	}
+	let bridge_fee = mvt_client_harness.get_bridge_fee().await?;
 
-	let recipient = HarnessEthClient::get_recipeint_address(&config);
-	let amount = Amount(1);
+	tracing::info!("Before initiate_bridge_transfer");
+	let res = BridgeClientContract::initiate_bridge_transfer(
+		&mut mvt_client_harness.movement_client,
+		BridgeAddress(recipient_address.clone()),
+		Amount(100_000_000_000),
+	)
+	.await?;
 
-	// initiate Eth transfer
-	let mut initiator_mvt_client =
-		MovementClientFramework::build_with_signer(initiator_privkey, &config.movement).await?;
-	// Call using initiator private key.
-	let recipient_vec: Vec<u8> = EthAddress(recipient).into();
-	initiator_mvt_client
-		.initiate_bridge_transfer(BridgeAddress(recipient_vec), amount)
-		.await
-		.expect("Failed to initiate bridge transfer");
-	tracing::info!("Hash lock pre-image for Movement initiate transfer.");
+	tracing::info!("Initiate result: {:?}", res);
 
-	// Wait for the Eth-side lock event
+	// Wait for the Movement-side Initiated event
 	tracing::info!("Wait for Mvt-side Initiated event.");
 	let bridge_transfer_id;
 	let nonce;
@@ -146,76 +144,20 @@ async fn test_bridge_transfer_movement_eth_happy_path() -> Result<(), anyhow::Er
 	}
 	tracing::info!("Bridge transfer ID from Mvt Initiated event: {:?}", bridge_transfer_id);
 	tracing::info!("Wait for Completed event.");
-	let (_, eth_health_rx) = tokio::sync::mpsc::channel(10);
+	let (_eth_health_tx, eth_health_rx) = tokio::sync::mpsc::channel(10);
 	let mut eth_monitoring = EthMonitoring::build(&config.eth, eth_health_rx).await.unwrap();
 	loop {
 		let event =
 			tokio::time::timeout(std::time::Duration::from_secs(30), eth_monitoring.next()).await?;
 		if let Some(Ok(BridgeContractEvent::Completed(detail))) = event {
 			assert_eq!(detail.bridge_transfer_id, bridge_transfer_id);
-			let initiator_vec: Vec<u8> = initiator_address.into();
-			assert_eq!(detail.initiator.0, initiator_vec);
-			assert_eq!(detail.recipient, BridgeAddress(EthAddress(recipient)));
-			assert_eq!(detail.amount, amount);
+			// assert_eq!(detail.initiator.0, initiator_address.0.to_vec());
+			assert_eq!(detail.recipient.0.0.to_vec(), recipient_address);
+			assert_eq!(detail.amount, Amount(100_000_000_000 - bridge_fee));
 			assert_eq!(detail.nonce, nonce);
 			break;
 		}
 	}
-
-	Ok(())
-}
-
-#[tokio::test]
-#[ignore]
-async fn test_movement_event() -> Result<(), anyhow::Error> {
-	tracing_subscriber::fmt()
-		.with_env_filter(
-			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-		)
-		.init();
-
-	println!("Start test_movement_event",);
-
-	let config = TestHarness::read_bridge_config().await?;
-	println!("after test_movement_event",);
-
-	use bridge_integration_tests::MovementToEthCallArgs;
-
-	let mut movement_client =
-		MovementClientFramework::build_with_config(&config.movement).await.unwrap();
-
-	let args = MovementToEthCallArgs::default();
-
-	{
-		let res = BridgeClientContract::initiate_bridge_transfer(
-			&mut movement_client,
-			BridgeAddress(args.recipient.clone()),
-			Amount(args.amount),
-		)
-		.await?;
-
-		tracing::info!("Initiate result: {:?}", res);
-	}
-
-	//Wait for the tx to be executed
-	let _ = tokio::time::sleep(tokio::time::Duration::from_millis(2000)).await;
-	let event_type = format!("{}::native_bridge::BridgeEvents", FRAMEWORK_ADDRESS);
-
-	let res = test_get_events_by_account_event_handle(
-		&config.movement.mvt_rpc_connection_url(),
-		&config.movement.movement_native_address,
-		&event_type,
-	)
-	.await;
-	println!("res: {res:?}",);
-
-	let res = fetch_account_events(
-		&config.movement.mvt_rpc_connection_url(),
-		&config.movement.movement_native_address,
-		&event_type,
-	)
-	.await;
-	println!("res: {res:?}",);
 
 	Ok(())
 }

--- a/protocol-units/bridge/integration-tests/tests/client_mvt_tests.rs
+++ b/protocol-units/bridge/integration-tests/tests/client_mvt_tests.rs
@@ -104,11 +104,6 @@ async fn test_movement_client_complete_transfer() -> Result<(), anyhow::Error> {
 	// Random nonce
 	let incoming_nonce = TestHarness::create_nonce();
 
-        tracing::info!("Initiator: {:?}", initiator.clone().0);
-        tracing::info!("Recipient: {:?}", recipient);
-        tracing::info!("Amount: {:?}", amount);
-        tracing::info!("Incoming nonce: {:?}", incoming_nonce);
-
 	let bridge_transfer_id = HarnessMvtClient::calculate_bridge_transfer_id(
 		initiator.clone().0,
 		recipient,

--- a/protocol-units/bridge/integration-tests/tests/client_mvt_tests.rs
+++ b/protocol-units/bridge/integration-tests/tests/client_mvt_tests.rs
@@ -2,16 +2,12 @@ use anyhow::Result;
 use aptos_sdk::coin_client::CoinClient;
 use bridge_integration_tests::HarnessEthClient;
 use bridge_integration_tests::HarnessMvtClient;
-use bridge_integration_tests::{MovementToEthCallArgs, TestHarness};
+use bridge_integration_tests::TestHarness;
 use bridge_service::chains::movement::event_monitoring::MovementMonitoring;
 use bridge_service::{
-	chains::{
-		movement::utils::MovementAddress,
-		ethereum::types::EthAddress
-	},
+	chains::{ethereum::types::EthAddress, movement::utils::MovementAddress},
 	types::{Amount, BridgeAddress},
 };
-use bridge_util::types::Nonce;
 use bridge_util::BridgeClientContract;
 use bridge_util::BridgeContractEvent;
 use bridge_util::BridgeRelayerContract;
@@ -20,80 +16,75 @@ use tokio::{self};
 
 #[tokio::test]
 async fn test_movement_client_initiate_transfer() -> Result<(), anyhow::Error> {
-        let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::INFO).try_init();
-        let (mut mvt_client_harness, config) =
-                TestHarness::new_with_movement().await.expect("Bridge config file not set");
-        let args = MovementToEthCallArgs::default();
+	let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::INFO).try_init();
+	let (mut mvt_client_harness, config) =
+		TestHarness::new_with_movement().await.expect("Bridge config file not set");
+	let (_mvt_health_tx, mvt_health_rx) = tokio::sync::mpsc::channel(10);
+	let mut mvt_monitoring =
+		MovementMonitoring::build(&config.movement, mvt_health_rx).await.unwrap();
+	let recipient_address = HarnessEthClient::get_recipient_address(&config).to_vec();
 
-        let test_result = async {
-                mvt_client_harness
-                        .fund_signer_and_check_balance_framework(100_000_000_000)
-                        .await?;
-                {
-                        tracing::info!("Before initiate_bridge_transfer");
-                        let res = BridgeClientContract::initiate_bridge_transfer(
-                                &mut mvt_client_harness.movement_client,
-                                BridgeAddress(args.recipient.clone()),
-                                Amount(args.amount),
-                        )
-                        .await?;
+	let test_result = async {
+		mvt_client_harness
+			.fund_signer_and_check_balance_framework(100_000_000_000)
+			.await?;
+		{
+			tracing::info!("Before initiate_bridge_transfer");
+			let res = BridgeClientContract::initiate_bridge_transfer(
+				&mut mvt_client_harness.movement_client,
+				BridgeAddress(recipient_address.clone()),
+				Amount(100_000_000_000),
+			)
+			.await?;
 
-                        tracing::info!("Initiate result: {:?}", res);
-                }
+			tracing::info!("Initiate result: {:?}", res);
+		}
 
-                let bridge_fee = mvt_client_harness.get_bridge_fee().await?;
+		let bridge_fee = mvt_client_harness.get_bridge_fee().await?;
 
-                // Wait for the Movement Initiated event
-                tracing::info!("Wait for Movement-side Initiated event.");
-                let (_, mvt_health_rx) = tokio::sync::mpsc::channel(10);
-                let mut mvt_monitoring =
-                        MovementMonitoring::build(&config.movement, mvt_health_rx)
-                                .await
-                                .unwrap();
+		// Wait for the Movement Initiated event
+		tracing::info!("Wait for Movement-side Initiated event.");
+		let mut received_event = None;
 
-                let mut received_event = None;
+		// Use a loop to wait for the Initiated event
+		loop {
+			let event =
+				tokio::time::timeout(std::time::Duration::from_secs(30), mvt_monitoring.next())
+					.await
+					.expect("Wait for initiated event timeout.");
 
-                // Use a loop to wait for the Initiated event
-                loop {
-                        let event = tokio::time::timeout(
-                                std::time::Duration::from_secs(30),
-                                mvt_monitoring.next(),
-                        )
-                        .await
-                        .expect("Wait for initiated event timeout.");
+			if let Some(Ok(BridgeContractEvent::Initiated(detail))) = event {
+				tracing::info!("Initiated details: {:?}", detail);
 
-                        if let Some(Ok(BridgeContractEvent::Initiated(detail))) = event {
-                                tracing::info!("Initiated details: {:?}", detail);
+				received_event = Some((
+					detail.bridge_transfer_id,
+					detail.initiator,
+					detail.recipient,
+					detail.amount,
+					detail.nonce,
+				));
+				break;
+			}
+		}
 
-                                received_event = Some((
-                                        detail.bridge_transfer_id,
-                                        detail.initiator,
-                                        detail.recipient,
-                                        detail.amount,
-                                        detail.nonce,
-                                ));
-                                break;
-                        }
-                }
+		let (bridge_transfer_id, initiator, recipient, amount, _nonce) =
+			received_event.expect("No initiated event received");
 
-                let (bridge_transfer_id, initiator, recipient, amount, nonce) =
-                        received_event.expect("No initiated event received");
+		tracing::info!("Received bridge_transfer_id: {:?}", bridge_transfer_id);
 
-                tracing::info!("Received bridge_transfer_id: {:?}", bridge_transfer_id);
+		assert_eq!(initiator.0 .0, mvt_client_harness.signer_address());
+		assert_eq!(recipient, BridgeAddress(recipient_address));
+		assert_eq!(amount, Amount(100_000_000_000 - bridge_fee));
 
-                assert_eq!(initiator.0 .0, mvt_client_harness.signer_address());
-                assert_eq!(recipient, BridgeAddress(args.recipient.clone()));
-                assert_eq!(amount, Amount(args.amount - bridge_fee));
+		Ok(())
+	}
+	.await;
 
-                Ok(())
-        }
-        .await;
-
-        test_result
+	test_result
 }
 
 #[tokio::test]
-async fn test_movement_client_complete_transfer() -> Result<(), anyhow::Error> {
+async fn test_movement_client_complete_transfer_old() -> Result<(), anyhow::Error> {
         let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::INFO).try_init();
         let (mut mvt_client_harness, config) =
                 TestHarness::new_with_movement().await.expect("Bridge config file not set");
@@ -187,3 +178,95 @@ async fn test_movement_client_complete_transfer() -> Result<(), anyhow::Error> {
         Ok(())
 }
 
+#[tokio::test]
+async fn test_movement_client_complete_transfer() -> Result<(), anyhow::Error> {
+	let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::INFO).try_init();
+	let (mut mvt_client_harness, config) =
+		TestHarness::new_with_movement().await.expect("Bridge config file not set");
+	let (_mvt_health_tx, mvt_health_rx) = tokio::sync::mpsc::channel(10);
+	let mut mvt_monitoring =
+		MovementMonitoring::build(&config.movement, mvt_health_rx).await.unwrap();
+
+	// Set initiator as bytes
+	let initiator = EthAddress(HarnessEthClient::get_initiator_address(&config));
+
+	// Set recipient address
+	let recipient = HarnessMvtClient::gen_aptos_account().address();
+
+	// Set amount to 1
+	let amount = Amount(100_000_000_000);
+
+	// Random nonce
+	let incoming_nonce = TestHarness::create_nonce();
+
+        tracing::info!("Initiator: {:?}", initiator.clone().0);
+        tracing::info!("Recipient: {:?}", recipient);
+        tracing::info!("Amount: {:?}", amount);
+        tracing::info!("Incoming nonce: {:?}", amount);
+
+	let bridge_transfer_id = HarnessMvtClient::calculate_bridge_transfer_id(
+		initiator.clone().0,
+		recipient,
+		amount,
+		incoming_nonce,
+	);
+
+	let coin_client = CoinClient::new(&mvt_client_harness.rest_client);
+	let movement_client_signer = mvt_client_harness.movement_client.signer();
+
+	// Fund accounts
+	{
+		let faucet_client = mvt_client_harness.faucet_client.write().unwrap();
+		faucet_client.fund(movement_client_signer.address(), 100_000_000).await?;
+		faucet_client.fund(recipient, 100_000_000).await?;
+	}
+
+	// Assert the balance is sufficient
+	let balance = coin_client.get_account_balance(&movement_client_signer.address()).await?;
+	assert!(
+		balance >= 100_000_000,
+		"Expected Movement Client to have at least 100_000_000, but found {}",
+		balance
+	);
+
+	// Call the complete_bridge_transfer function
+	BridgeRelayerContract::complete_bridge_transfer(
+		&mut mvt_client_harness.movement_client,
+		bridge_transfer_id,
+		BridgeAddress(initiator.clone().to_vec()),
+		BridgeAddress(MovementAddress(recipient)),
+		amount,
+		incoming_nonce,
+	)
+	.await
+	.expect("Failed to complete bridge transfer");
+
+	// Wait for the Movement-side Completed event
+	tracing::info!("Wait for Movement-side Completed event.");
+	loop {
+		let event = tokio::time::timeout(std::time::Duration::from_secs(30), mvt_monitoring.next())
+			.await
+			.expect("Wait for completed event timeout.");
+		if let Some(Ok(BridgeContractEvent::Completed(detail))) = event {
+			tracing::info!("Completed details: {:?}", detail);
+			assert_eq!(
+				detail.bridge_transfer_id, bridge_transfer_id,
+				"Bad transfer id in completed event"
+			);
+			assert_eq!(detail.nonce, incoming_nonce, "Bad nonce in completed event");
+			assert_eq!(detail.amount, amount, "Bad amount in completed event");
+			assert_eq!(
+				detail.initiator,
+				BridgeAddress(initiator.to_vec()),
+				"Bad initiator address in completed event"
+			);
+			assert_eq!(
+				detail.recipient.0 .0, recipient,
+				"Bad recipient address in completed event"
+			);
+			break;
+		}
+	}
+
+	Ok(())
+}

--- a/protocol-units/bridge/integration-tests/tests/client_mvt_tests.rs
+++ b/protocol-units/bridge/integration-tests/tests/client_mvt_tests.rs
@@ -173,9 +173,5 @@ async fn test_movement_client_complete_transfer() -> Result<(), anyhow::Error> {
 		}
 	}
 
-        // Gracefully stop monitoring
-	tracing::info!("Stopping monitoring tasks.");
-	drop(mvt_monitoring); // Drop Mvt monitoring object
-
 	Ok(())
 }

--- a/protocol-units/bridge/service/src/chains/movement/client_framework.rs
+++ b/protocol-units/bridge/service/src/chains/movement/client_framework.rs
@@ -114,7 +114,7 @@ impl BridgeClientContract<MovementAddress> for MovementClientFramework {
 
 		Ok(())
 	}
-
+	
 	async fn get_bridge_transfer_details(
 		&mut self,
 		bridge_transfer_id: BridgeTransferId,


### PR DESCRIPTION
# Summary
- Client and E2E tests for MIP-58 bridge model: **RFCs**: https://github.com/movementlabsxyz/MIP/pull/58/
- Correct amount and account for bridge fee in `test_movement_client_initiate_transfer`
- Fixes flaky behavior in eth and movement event monitoring

- Due to the new bridge fee, there's a minimum amount. Here transfer amount is updated to 100 MOVE rather than 100 octas. (If Amount is 100 then that's 1*10^-7 MOVE, rather than 100 MOVE)
- A `get_bridge_fee` helper function calls the `native_bridge_configuration::bridge_fee()` Move function to be able to assert on the amount after `initiate_bridge_transfer` is called. 
- Fix normalization of 32 bytes to calculate correct bridge transfer ID
- Remove unneeded `MovementToEthCallArgs` and `EthToMovementCallArgs`

# Testing
- Run local node with `CELESTIA_LOG_LEVEL=FATAL CARGO_PROFILE=release CARGO_PROFILE_FLAGS=--release nix develop --extra-experimental-features nix-command --extra-experimental-features flakes --command bash -c "just bridge native build.setup.eth-local.celestia-local.bridge --keep-tui"`
- Movement client tests: `RUST_BACKTRACE=1 DOT_MOVEMENT_PATH="$(pwd)/.movement" cargo test --test client_mvt_tests -- --nocapture --test-threads=1`
- Eth client tests: `RUST_BACKTRACE=1 DOT_MOVEMENT_PATH="$(pwd)/.movement" cargo test --test client_eth_tests -- --nocapture --test-threads=1`
- E2E tests: `RUST_BACKTRACE=1 DOT_MOVEMENT_PATH="$(pwd)/.movement" cargo test --test bridge_e2e_test_framework -- --nocapture --test-threads=1` 

# Outstanding issues
- Need CI implemented (in separate PR)
- Sometimes bridge transfer ID doesn't match in E2E tests; it seems like event listening is somehow getting an old event. It matches the vast majority of the time. 
- Sometimes on the first time running E2E Movement -> Eth tests, there's an "odd number of digits" / failed to deserialze event error, despite the cross-chain transfer completing successfully.