### PR TITLE
Fix bridge process-compose links

### DIFF
--- a/process-compose/bridge/process-compose.yml
+++ b/process-compose/bridge/process-compose.yml
@@ -43,7 +43,7 @@ processes:
     
   movement-full-node:
     command: |
-      movement-full-node
+      movement-full-node run
     depends_on:
       movement-celestia-da-light-node:
         condition: process_healthy


### PR DESCRIPTION
# Summary
- The `movement-full-node` command was updated in main. This PR updates the bridge .yml scripts.

# Testing
```
CELESTIA_LOG_LEVEL=FATAL CARGO_PROFILE=release CARGO_PROFILE_FLAGS=--release nix develop --extra-experimental-features nix-command --extra-experimental-features flakes --command bash -c "just bridge native build.setup.eth-local.celestia-local.bridge.bridge-indexer --keep-tui
```
