### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/protocol-units/bridge/util/src/states.rs
+++ b/protocol-units/bridge/util/src/states.rs
@@ -85,14 +85,14 @@ impl TransferState {
 				// already present invalid
 				Err(InvalidEventError::InitAnAlreadyExist)
 			}
-			// Lock event must on on the counter part chain.
+			// Lock event must on the counter part chain.
 			(BridgeContractEvent::Locked(_), TransferStateType::Initialized) => (event.chain
 				!= self.init_chain)
 				.then_some(())
 				.ok_or(InvalidEventError::BadChain),
 			// Lock event is only applied on Initialized swap state
 			(BridgeContractEvent::Locked(details), _) => Err(InvalidEventError::BadEvent(format!("Received a locked event with state not Initialized, transfer_id: {} state:{} details: {details:?}", self.transfer_id, self.state))),
-			// CounterPartCompleted event must on on the counter part chain.
+			// CounterPartCompleted event must on the counter part chain.
 			(BridgeContractEvent::CounterPartyCompleted(_, _), TransferStateType::Locked) => {
 				(event.chain != self.init_chain)
 					.then_some(())
@@ -102,7 +102,7 @@ impl TransferState {
 			(BridgeContractEvent::CounterPartyCompleted(_, _), _) => {
 				Err(InvalidEventError::BadEvent(format!("Received a CounterPartCompleted event with state not Locked, transfer_id: {} state:{}", self.transfer_id, self.state)))
 			}
-			// InitiatorCompleted event must on on the init chain.
+			// InitiatorCompleted event must on the init chain.
 			(BridgeContractEvent::InitiatorCompleted(_), TransferStateType::SecretReceived) => {
 				(event.chain == self.init_chain)
 					.then_some(())

--- a/util/movement-algs/src/grouping_heuristic/mod.rs
+++ b/util/movement-algs/src/grouping_heuristic/mod.rs
@@ -10,7 +10,7 @@ use std::fmt::Debug;
 /// A failure type for a single member of the heuristically formed group.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ElementalFailure<T> {
-	/// An instrumental failure is intended to be be passed on in future iterations.
+	/// An instrumental failure is intended to be passed on in future iterations.
 	Instrumental(T),
 	/// A terminal failure is intended to be dropped or pause the execution altogether.
 	Terminal(T),


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

<!--
Add your summary text here. 
 -->

remove redundant words in comment


# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->