### PR TITLE
Fix Move scripts so they compile

### DIFF
--- a/protocol-units/bridge/move-modules/scripts/store_mint_burn_caps.move
+++ b/protocol-units/bridge/move-modules/scripts/store_mint_burn_caps.move
@@ -1,13 +1,13 @@
 script {
     use aptos_framework::aptos_governance;
     use aptos_framework::transaction_fee;
-    use aptos_framework::native_bridge_core;
+    use aptos_framework::native_bridge;
 
     fun store_mint_burn_caps(core_resources: &signer) {
         let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @aptos_framework);
         let (mint, burn) = transaction_fee::copy_capabilities_for_native_bridge(&framework_signer);
 
-        native_bridge_core::store_aptos_coin_mint_cap(&framework_signer, mint);
-        native_bridge_core::store_aptos_coin_burn_cap(&framework_signer, burn);
+        native_bridge::store_aptos_coin_mint_cap(&framework_signer, mint);
+        native_bridge::store_aptos_coin_burn_cap(&framework_signer, burn);
     }
 }

--- a/protocol-units/bridge/move-modules/scripts/update_bridge_fee.move
+++ b/protocol-units/bridge/move-modules/scripts/update_bridge_fee.move
@@ -1,10 +1,9 @@
 script {
-    use aptos_framework::aptos_account;
     use aptos_framework::aptos_governance;
-    use aptos_framework::native_bridge_configuration;
+    use aptos_framework::native_bridge;
 
     fun update_bridge_fee(core_resources: &signer, new_fee: u64) {
         let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @aptos_framework);
-        native_bridge_configuration::update_bridge_fee(&framework_signer, new_fee);
+        native_bridge::update_bridge_fee(&framework_signer, new_fee);
     }
 } 

--- a/protocol-units/bridge/move-modules/scripts/update_bridge_relayer.move
+++ b/protocol-units/bridge/move-modules/scripts/update_bridge_relayer.move
@@ -1,11 +1,11 @@
 script {
     use aptos_framework::aptos_account;
     use aptos_framework::aptos_governance;
-    use aptos_framework::native_bridge_configuration;
+    use aptos_framework::native_bridge;
 
     fun update_bridge_relayer(core_resources: &signer, new_relayer: address) {
         let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @aptos_framework);
-        native_bridge_configuration::update_bridge_relayer(&framework_signer, new_relayer);
+        native_bridge::update_bridge_relayer(&framework_signer, new_relayer);
         aptos_account::create_account(@0x00000000000000000000000000face);
     }
 } 


### PR DESCRIPTION
# Summary
- Make calls to `native_bridge` module only, rather than `native_bridge_core` or `native_bridge_configuration`

# Testing

- movement move compile --package-dir protocol-units/bridge/move-modules
