### PR TITLE
Remove unused Ethereum deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,26 +166,11 @@ processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors
 server-framework = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "7658338eb9224abd9698c1e02dbc6ca526c268ce" }
 
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
-ethereum-types = "0.14.1"
-ethers = "=2.0.10"
-ethers-core = { version = "=2.0.10", default-features = false }
-ethers-contract = "=2.0.10"
-ethers-providers = { version = "=2.0.10", default-features = false }
-ethers-signers = { version = "=2.0.10", default-features = false }
-ethers-middleware = { version = "=2.0.10", default-features = false }
+
 move-binary-format = { git = "https://github.com/diem/move" }
 move-table-extension = { git = "https://github.com/diem/move" }
 move-core-types = { git = "https://github.com/diem/move" }
-### https://github.com/paradigmxyz/reth/tree/c0655fed8915490f82d4acf8900a16a10554cbfb
-reth-interfaces = { git = "https://github.com/paradigmxyz/reth", rev = "c0655fed8915490f82d4acf8900a16a10554cbfb" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c0655fed8915490f82d4acf8900a16a10554cbfb", default-features = false }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "c0655fed8915490f82d4acf8900a16a10554cbfb" }
-reth-rpc-types = { git = "https://github.com/paradigmxyz/reth", rev = "c0655fed8915490f82d4acf8900a16a10554cbfb" }
-reth-rpc-types-compat = { git = "https://github.com/paradigmxyz/reth", rev = "c0655fed8915490f82d4acf8900a16a10554cbfb" }
-### Matches reth dependency. Using exact revision for matching our tightly coupled usage of both reth and revm crates
-revm = { version = "8.0.0", default-features = false, features = ["serde"] }
-### Used just to be safe about breaking changes
-revm-primitives = { version = "=2.0.0", default-features = false }
+
 secp256k1 = { version = "0.27", default-features = false, features = [
     "global-context",
     "rand-std",
@@ -321,8 +306,8 @@ regex = "1.10.6"
 globset = "0.4.15"
 glob = "0.3.1"
 hyper = "1.4"
-hyper-util = { version = "0.1.4"}
-tower = { version = "0.5"}
+hyper-util = { version = "0.1.4" }
+tower = { version = "0.5" }
 http-body-util = "0.1"
 
 # trying to pin diesel


### PR DESCRIPTION
# Summary
- **Categories**: `misc`.

Clean up outdated Ethereum library dependencies from `Cargo.lock`.

# Testing

Everything still builds.
