### PR TITLE
Only Inbound Rate Limiting 

### DIFF
--- a/protocol-units/bridge/contracts/src/INativeBridge.sol
+++ b/protocol-units/bridge/contracts/src/INativeBridge.sol
@@ -21,6 +21,7 @@ interface INativeBridge {
 
     event InsuranceFundUpdated(address insuranceFund);
     event PauseToggled(bool paused);
+    event RiskDenominatorUpdated(uint256 riskDenominator);
 
     error ZeroAmount();
     error MOVETransferFailed();
@@ -31,6 +32,7 @@ interface INativeBridge {
     error InvalidNonce();
     error OutboundRateLimitExceeded();
     error InboundRateLimitExceeded();
+    error InvalidRiskDenominator();
 
     /**
      * @dev Creates a new bridge

--- a/protocol-units/bridge/contracts/test/NativeBridge.t.sol
+++ b/protocol-units/bridge/contracts/test/NativeBridge.t.sol
@@ -71,26 +71,6 @@ contract NativeBridgeTest is Test {
         vm.stopPrank();
     }
 
-    function testOutboundRateLimitFuzz(address sender, uint256 _amount) public {
-        excludeSender(deployer);
-        _amount = bound(_amount, 3, 1000000000 * 10 ** 8);
-        moveToken.transfer(sender, _amount);
-
-        vm.startPrank(sender);
-        moveToken.approve(address(nativeBridge), _amount);
-        nativeBridge.initiateBridgeTransfer(keccak256(abi.encodePacked(sender)), _amount / 2);
-
-        vm.warp(1 days - 1);
-        if (_amount >= moveToken.balanceOf(insuranceFund) / 4) {
-            vm.expectRevert(INativeBridge.OutboundRateLimitExceeded.selector);
-            nativeBridge.initiateBridgeTransfer(keccak256(abi.encodePacked(sender)), _amount / 2);
-            vm.warp(1 days + 1);
-            nativeBridge.initiateBridgeTransfer(keccak256(abi.encodePacked(sender)), _amount / 2);
-        } else {
-            nativeBridge.initiateBridgeTransfer(keccak256(abi.encodePacked(sender)), _amount / 2);
-        }
-    }
-
     function testInboundRateLimitFuzz(address receiver, uint256 _amount) public {
         _amount = bound(_amount, 3, 1000000000 * 10 ** 8);
         moveToken.transfer(address(nativeBridge), _amount);


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

Because we will be switching to Inbound Rate Limiting only, moving the Outbound Rate Limiting to the Move side of the bridge, we needed to remove the outbound rate limiter locally.
This PR also addresses Rate Limiting concerns raised on feature/trusted-relayer

# Changelog

- Removal of OutboundRateLimiter
- setRiskDenominator

# Testing

- Rate Limiting Tests including change of denominator 

# Outstanding issues