### PR TITLE
Server for HSM demo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3606,7 +3606,11 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper 0.1.2",
+ "tokio",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
@@ -7522,12 +7526,16 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-kms",
+ "axum 0.6.20",
  "base64 0.13.1",
  "ed25519 2.2.3",
  "google-cloud-kms",
  "k256",
  "rand 0.7.3",
+ "reqwest 0.12.9",
  "ring-compat",
+ "serde",
+ "serde_json",
  "tokio",
  "vaultrs",
 ]
@@ -13622,6 +13630,16 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7528,6 +7528,7 @@ dependencies = [
  "aws-sdk-kms",
  "axum 0.6.20",
  "base64 0.13.1",
+ "dotenv",
  "ed25519 2.2.3",
  "google-cloud-kms",
  "k256",

--- a/demo/hsm/Cargo.toml
+++ b/demo/hsm/Cargo.toml
@@ -10,10 +10,10 @@ publish = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
 async-trait = { workspace = true }
-anyhow = { workspace = true }
 vaultrs = { workspace = true }
+anyhow = { workspace = true }
 aws-sdk-kms = { workspace = true }
 aws-config = { workspace = true }
 rand = { workspace = true }
@@ -22,6 +22,10 @@ ed25519 = { workspace = true }
 ring-compat = { workspace = true }
 k256 = { workspace = true, features = ["ecdsa", "pkcs8"] }
 google-cloud-kms = { workspace = true }
+reqwest = { version = "0.12", features = ["json"] }
+axum = "0.6"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [lints]
 workspace = true

--- a/demo/hsm/Cargo.toml
+++ b/demo/hsm/Cargo.toml
@@ -18,6 +18,7 @@ aws-sdk-kms = { workspace = true }
 aws-config = { workspace = true }
 rand = { workspace = true }
 base64 = { workspace = true }
+dotenv = "0.15"
 ed25519 = { workspace = true }
 ring-compat = { workspace = true }
 k256 = { workspace = true, features = ["ecdsa", "pkcs8"] }

--- a/demo/hsm/src/hsm/aws_kms.rs
+++ b/demo/hsm/src/hsm/aws_kms.rs
@@ -12,7 +12,7 @@ use ring_compat::signature::Verifier;
 pub struct AwsKms {
 	client: Client,
 	key_id: String,
-	public_key: PublicKey,
+	pub public_key: PublicKey,
 }
 
 impl AwsKms {

--- a/demo/hsm/src/hsm/aws_kms.rs
+++ b/demo/hsm/src/hsm/aws_kms.rs
@@ -51,6 +51,7 @@ impl AwsKms {
 	/// Fills the public key from the key id
 	pub async fn fill_with_public_key(mut self) -> Result<Self, anyhow::Error> {
 		let res = self.client.get_public_key().key_id(&self.key_id).send().await?;
+		println!("AWS KMS Response: {:?}", res);
 		let public_key = PublicKey(Bytes(
 			res.public_key().context("No public key available")?.as_ref().to_vec(),
 		));

--- a/demo/hsm/src/hsm/aws_kms.rs
+++ b/demo/hsm/src/hsm/aws_kms.rs
@@ -3,6 +3,7 @@ use anyhow::Context;
 use aws_sdk_kms::primitives::Blob;
 use aws_sdk_kms::types::{KeySpec, KeyUsageType, SigningAlgorithmSpec};
 use aws_sdk_kms::Client;
+use dotenv::dotenv;
 use k256::ecdsa::{self, VerifyingKey};
 use k256::pkcs8::DecodePublicKey;
 use ring_compat::signature::Verifier;
@@ -22,6 +23,7 @@ impl AwsKms {
 
 	/// Tries to create a new AWS KMS HSM from the environment
 	pub async fn try_from_env() -> Result<Self, anyhow::Error> {
+		dotenv().ok();
 		let key_id = std::env::var("AWS_KMS_KEY_ID").context("AWS_KMS_KEY_ID not set")?;
 		let public_key = std::env::var("AWS_KMS_PUBLIC_KEY").unwrap_or_default();
 

--- a/demo/hsm/src/hsm/cli.rs
+++ b/demo/hsm/src/hsm/cli.rs
@@ -1,0 +1,61 @@
+mod cli;
+mod hsm;
+
+use anyhow::Result;
+use clap::Parser;
+use cli::{Cli, Service};
+use hsm::{aws::AwsKms, google::GoogleKms, vault::HashiCorpVault};
+use dotenv::dotenv;
+use hsm_demo::{action_stream, Application};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    dotenv().ok(); // Load environment variables from .env file
+    let cli = Cli::parse();
+
+    // Select the HSM implementation based on CLI input
+    let hsm = match cli.service {
+        Service::Aws(args) => {
+            println!("Using AWS KMS with {:?} key", args.key_type);
+            AwsKms::try_from_env()
+                .await?
+                .create_key()
+                .await?
+                .fill_with_public_key()
+                .await?
+        }
+        Service::Gcp(args) => {
+            println!("Using Google Cloud KMS with {:?} key", args.key_type);
+            GoogleKms::try_from_env()
+                .await?
+                .create_key_ring()
+                .await?
+                .create_key()
+                .await?
+                .fill_with_public_key()
+                .await?
+        }
+        Service::Vault(args) => {
+            println!("Using HashiCorp Vault with {:?} key", args.key_type);
+            HashiCorpVault::try_from_env()
+                .and_then(|vault| vault.create_key())
+                .await?
+                .fill_with_public_key()
+                .await?
+        }
+    };
+
+    // Initialize the streams
+    let random_stream = action_stream::random::Random;
+    let notify_verify_stream = action_stream::notify_verify::NotifyVerify::new();
+    let join_stream = action_stream::join::Join::new(vec![
+        Box::new(random_stream),
+        Box::new(notify_verify_stream),
+    ]);
+
+    // Run the application
+    let mut app = Application::new(Box::new(hsm), Box::new(join_stream));
+    app.run().await?;
+
+    Ok(())
+}

--- a/demo/hsm/src/hsm/hashi_corp_vault.rs
+++ b/demo/hsm/src/hsm/hashi_corp_vault.rs
@@ -15,7 +15,7 @@ pub struct HashiCorpVault {
 	client: VaultClient,
 	key_name: String,
 	mount_name: String,
-	public_key: PublicKey,
+	pub public_key: PublicKey,
 }
 
 impl HashiCorpVault {

--- a/demo/hsm/src/lib.rs
+++ b/demo/hsm/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod action_stream;
 pub mod hsm;
+pub mod server;
 
 /// A collection of bytes.
 #[derive(Debug, Clone)]

--- a/demo/hsm/src/main.rs
+++ b/demo/hsm/src/main.rs
@@ -95,7 +95,7 @@ impl hsm_demo::Hsm for HttpHsmProxy {
             .await?;
 
         let signature = hsm_demo::Signature(Bytes(response.signature));
-        let public_key = hsm_demo::PublicKey(Bytes(vec![])); // Public key is not returned here
+        let public_key = hsm_demo::PublicKey(Bytes(vec![])); // Public key is not returned here... maybe not necessary?
 
         Ok((message, public_key, signature))
     }

--- a/demo/hsm/src/main.rs
+++ b/demo/hsm/src/main.rs
@@ -7,15 +7,12 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::task;
 
+use hsm_demo::{action_stream, Application};
 use hsm_demo::server::create_server;
-
-#[derive(Serialize)]
-struct SignRequest {
-    message: Vec<u8>,
-}
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
+    // Initialize AWS KMS HSM
     let aws_kms_hsm = hsm::aws_kms::AwsKms::try_from_env()
         .await?
         .create_key()
@@ -25,6 +22,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let shared_hsm = Arc::new(Mutex::new(aws_kms_hsm));
 
+    // Start the server task
     let server_hsm = shared_hsm.clone();
     let server_task = task::spawn(async move {
         let app = create_server(server_hsm);
@@ -39,39 +37,76 @@ async fn main() -> Result<(), anyhow::Error> {
 
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
+    // Start the Application
     let client = Client::new();
-    let messages = vec![
-        Bytes(b"Hello, AWS KMS!".to_vec()),
-        Bytes(b"Signing this message.".to_vec()),
-        Bytes(b"Test message 12345.".to_vec()),
-    ];
+    let random_stream = action_stream::random::Random;
+    let notify_verify_stream = action_stream::notify_verify::NotifyVerify::new();
+    let join_stream = action_stream::join::Join::new(vec![
+        Box::new(random_stream),
+        Box::new(notify_verify_stream),
+    ]);
 
-    for message in messages {
-        let payload = SignRequest { message: message.0 };
+    // Replace HSM with the HTTP client that sends requests to the server
+    let hsm_proxy = HttpHsmProxy::new(client, "http://127.0.0.1:3000/sign".to_string());
+    let mut app = Application::new(Box::new(hsm_proxy), Box::new(join_stream));
 
-        let response = client
-            .post("http://127.0.0.1:3000/sign")
-            .json(&payload)
-            .send()
-            .await
-            .expect("Failed to send request");
-
-        let signed_response: SignedResponse = response
-            .json()
-            .await
-            .expect("Failed to parse response");
-
-        println!(
-            "Signed Message: {:?}, Signature: {:?}",
-            payload.message, signed_response.signature
-        );
-    }
+    app.run().await?;
 
     server_task.await?;
     Ok(())
 }
 
+#[derive(Serialize)]
+struct SignRequest {
+    message: Vec<u8>,
+}
+
 #[derive(serde::Deserialize)]
 struct SignedResponse {
     signature: Vec<u8>,
+}
+
+struct HttpHsmProxy {
+    client: Client,
+    server_url: String,
+}
+
+impl HttpHsmProxy {
+    pub fn new(client: Client, server_url: String) -> Self {
+        Self { client, server_url }
+    }
+}
+
+#[async_trait::async_trait]
+impl hsm_demo::Hsm for HttpHsmProxy {
+    async fn sign(
+        &self,
+        message: Bytes,
+    ) -> Result<(Bytes, hsm_demo::PublicKey, hsm_demo::Signature), anyhow::Error> {
+        let payload = SignRequest { message: message.0.clone() };
+
+        let response = self
+            .client
+            .post(&self.server_url)
+            .json(&payload)
+            .send()
+            .await?
+            .json::<SignedResponse>()
+            .await?;
+
+        let signature = hsm_demo::Signature(Bytes(response.signature));
+        let public_key = hsm_demo::PublicKey(Bytes(vec![])); // Public key is not returned here
+
+        Ok((message, public_key, signature))
+    }
+
+    async fn verify(
+        &self,
+        _message: Bytes,
+        _public_key: hsm_demo::PublicKey,
+        _signature: hsm_demo::Signature,
+    ) -> Result<bool, anyhow::Error> {
+        // Verification would need another endpoint or can be skipped for now
+        Ok(true)
+    }
 }

--- a/demo/hsm/src/main.rs
+++ b/demo/hsm/src/main.rs
@@ -106,7 +106,7 @@ impl hsm_demo::Hsm for HttpHsmProxy {
         _public_key: hsm_demo::PublicKey,
         _signature: hsm_demo::Signature,
     ) -> Result<bool, anyhow::Error> {
-        // Verification would need another endpoint or can be skipped for now
+        // Verification would need another endpoint or can be skipped because Application already verifies
         Ok(true)
     }
 }

--- a/demo/hsm/src/main.rs
+++ b/demo/hsm/src/main.rs
@@ -1,24 +1,77 @@
-use hsm_demo::{action_stream, hsm, Application};
+use axum::Server;
+use hsm_demo::{hsm, Bytes};
+use reqwest::Client;
+use serde::Serialize;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio::task;
+
+use hsm_demo::server::create_server;
+
+#[derive(Serialize)]
+struct SignRequest {
+    message: Vec<u8>,
+}
 
 #[tokio::main]
-pub async fn main() -> Result<(), anyhow::Error> {
-	let random_stream = action_stream::random::Random;
-	let notify_verify_stream = action_stream::notify_verify::NotifyVerify::new();
-	let join_stream = action_stream::join::Join::new(vec![
-		Box::new(random_stream),
-		Box::new(notify_verify_stream),
-	]);
+async fn main() -> Result<(), anyhow::Error> {
+    let aws_kms_hsm = hsm::aws_kms::AwsKms::try_from_env()
+        .await?
+        .create_key()
+        .await?
+        .fill_with_public_key()
+        .await?;
 
-	let hsm = hsm::aws_kms::AwsKms::try_from_env()
-		.await?
-		.create_key()
-		.await?
-		.fill_with_public_key()
-		.await?;
+    let shared_hsm = Arc::new(Mutex::new(aws_kms_hsm));
 
-	let mut app = Application::new(Box::new(hsm), Box::new(join_stream));
+    let server_hsm = shared_hsm.clone();
+    let server_task = task::spawn(async move {
+        let app = create_server(server_hsm);
+        let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+        println!("Server listening on {}", addr);
 
-	app.run().await?;
+        Server::bind(&addr)
+            .serve(app.into_make_service())
+            .await
+            .expect("Server failed");
+    });
 
-	Ok(())
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    let client = Client::new();
+    let messages = vec![
+        Bytes(b"Hello, AWS KMS!".to_vec()),
+        Bytes(b"Signing this message.".to_vec()),
+        Bytes(b"Test message 12345.".to_vec()),
+    ];
+
+    for message in messages {
+        let payload = SignRequest { message: message.0 };
+
+        let response = client
+            .post("http://127.0.0.1:3000/sign")
+            .json(&payload)
+            .send()
+            .await
+            .expect("Failed to send request");
+
+        let signed_response: SignedResponse = response
+            .json()
+            .await
+            .expect("Failed to parse response");
+
+        println!(
+            "Signed Message: {:?}, Signature: {:?}",
+            payload.message, signed_response.signature
+        );
+    }
+
+    server_task.await?;
+    Ok(())
+}
+
+#[derive(serde::Deserialize)]
+struct SignedResponse {
+    signature: Vec<u8>,
 }

--- a/demo/hsm/src/server.rs
+++ b/demo/hsm/src/server.rs
@@ -1,0 +1,44 @@
+use axum::{
+    routing::post,
+    extract::State,
+    Json, Router,
+    http::StatusCode,
+};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use crate::{Bytes, Hsm}; 
+
+pub fn create_server(hsm: Arc<Mutex<dyn Hsm + Send + Sync>>) -> Router {
+    Router::new()
+        .route("/sign", post(sign_handler))
+        .with_state(hsm)
+}
+
+async fn sign_handler(
+    State(hsm): State<Arc<Mutex<dyn Hsm + Send + Sync>>>,
+    Json(payload): Json<SignRequest>,
+) -> Result<Json<SignedResponse>, StatusCode> {
+    let message_bytes = Bytes(payload.message);
+
+    let (_message, _public_key, signature) = hsm
+        .lock()
+        .await
+        .sign(message_bytes)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(SignedResponse {
+        signature: signature.0 .0, 
+    }))
+}
+
+#[derive(serde::Deserialize)]
+pub struct SignRequest {
+    pub message: Vec<u8>,
+}
+
+#[derive(serde::Serialize)]
+pub struct SignedResponse {
+    pub signature: Vec<u8>,
+}


### PR DESCRIPTION
# Summary
- Add server and make main send transactions to the server.
- Runs and signs a few hard-coded messages

# Changelog
- Temporarily don't run `Application` with `random_stream` in `https://github.com/movementlabsxyz/movement/blob/l-monninger/hsm-demo/demo/hsm/src/main.rs`. Instead send a few hard-coded messages to the server for signing.

# Testing

- `cargo run`

# Outstanding issues

- Restore `Application` with `random_stream` for demonstration purposes