### PR TITLE
Fix 965

### DIFF
--- a/protocol-units/execution/maptos/opt-executor/src/executor/initialization.rs
+++ b/protocol-units/execution/maptos/opt-executor/src/executor/initialization.rs
@@ -134,6 +134,7 @@ impl Executor {
 
 		// replace the db path with the temporary directory
 		maptos_config.chain.maptos_db_path.replace(tempdir.path().to_path_buf());
+
 		let executor = Self::try_from_config(maptos_config)?;
 		Ok((executor, tempdir))
 	}


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**: `protocol-units`

Resolves #965.

# Testing

1. e2e tests only so far.

# Outstanding issues
1. This is going to require a fair bit of reworking of the transaction pipe, testing setup, and some small changes to `aptos-core` to have appropriate integration tests. 