### PR TITLE
Musitdev/signapi take2

### DIFF
--- a/util/signing/signer/src/cryptography/ed25519.rs
+++ b/util/signing/signer/src/cryptography/ed25519.rs
@@ -1,5 +1,5 @@
 use crate::cryptography::Curve;
-use crate::{Bytes, PublicKey, Signature, VerifierError, VerifierOperations};
+use crate::{Bytes, PublicKey, Signature, SignerError, VerifierOperations};
 use anyhow::Context;
 use ring_compat::signature::{
 	ed25519::{self, VerifyingKey},
@@ -19,15 +19,15 @@ impl VerifierOperations<Ed25519> for Ed25519 {
 		&self,
 		message: Bytes,
 		signature: Signature,
-		public_key: PublicKey,
-	) -> Result<bool, VerifierError> {
-		let verifying_key = VerifyingKey::from_slice(public_key.0 .0.as_slice())
+		public_key: PublicKey<Ed25519>,
+	) -> Result<bool, SignerError> {
+		let verifying_key = VerifyingKey::from_slice(public_key.data.0.as_slice())
 			.context("Failed to create verifying key")
-			.map_err(|e| VerifierError::Verify(e.to_string()))?;
+			.map_err(|e| SignerError::Verify(e.to_string()))?;
 
-		let signature = ed25519::Signature::from_slice(signature.0 .0.as_slice())
+		let signature = ed25519::Signature::from_slice(signature.data.0.as_slice())
 			.context("Failed to create signature")
-			.map_err(|e| VerifierError::Verify(e.to_string()))?;
+			.map_err(|e| SignerError::Verify(e.to_string()))?;
 
 		Ok(verifying_key.verify(message.0.as_slice(), &signature).is_ok())
 	}

--- a/util/signing/signer/src/cryptography/ed25519.rs
+++ b/util/signing/signer/src/cryptography/ed25519.rs
@@ -14,7 +14,7 @@ impl Curve for Ed25519 {}
 
 /// Built-in verifier for Ed25519.
 #[async_trait::async_trait]
-impl VerifierOperations<Ed25519> for Ed25519 {
+impl VerifierOperations<Ed25519> for PublicKey<Ed25519> {
 	async fn verify(
 		&self,
 		message: Bytes,

--- a/util/signing/signer/src/cryptography/secp256k1.rs
+++ b/util/signing/signer/src/cryptography/secp256k1.rs
@@ -1,5 +1,5 @@
 use crate::cryptography::Curve;
-use crate::{Bytes, PublicKey, Signature, VerifierError, VerifierOperations};
+use crate::{Bytes, PublicKey, Signature, SignerError, VerifierOperations};
 use anyhow::Context;
 use k256::ecdsa::{self, VerifyingKey};
 use k256::pkcs8::DecodePublicKey;
@@ -18,15 +18,15 @@ impl VerifierOperations<Secp256k1> for Secp256k1 {
 		&self,
 		message: Bytes,
 		signature: Signature,
-		public_key: PublicKey,
-	) -> Result<bool, VerifierError> {
-		let verifying_key = VerifyingKey::from_public_key_der(&public_key.0 .0)
+		public_key: PublicKey<Secp256k1>,
+	) -> Result<bool, SignerError> {
+		let verifying_key = VerifyingKey::from_public_key_der(&public_key.data.0)
 			.context("Failed to create verifying key")
-			.map_err(|e| VerifierError::Verify(e.to_string()))?;
+			.map_err(|e| SignerError::Verify(e.to_string()))?;
 
-		let signature = ecdsa::Signature::from_der(&signature.0 .0)
+		let signature = ecdsa::Signature::from_der(&signature.data.0)
 			.context("Failed to create signature")
-			.map_err(|e| VerifierError::Verify(e.to_string()))?;
+			.map_err(|e| SignerError::Verify(e.to_string()))?;
 
 		match verifying_key.verify(message.0.as_slice(), &signature) {
 			Ok(_) => Ok(true),

--- a/util/signing/signer/src/cryptography/secp256k1.rs
+++ b/util/signing/signer/src/cryptography/secp256k1.rs
@@ -13,7 +13,7 @@ impl Curve for Secp256k1 {}
 
 /// Built-in verifier for secp256k1.
 #[async_trait::async_trait]
-impl VerifierOperations<Secp256k1> for Secp256k1 {
+impl VerifierOperations<Secp256k1> for PublicKey<Secp256k1> {
 	async fn verify(
 		&self,
 		message: Bytes,

--- a/util/signing/signer/src/lib.rs
+++ b/util/signing/signer/src/lib.rs
@@ -29,7 +29,7 @@ pub struct KeyId {
 
 /// A public key.
 #[derive(Debug, Clone)]
-pub struct PublicKey<C> {
+pub struct PublicKey<C: cryptography::Curve> {
 	pub key_id: KeyId,
 	pub curve: C,
 	pub data: Bytes,
@@ -104,22 +104,6 @@ impl KeyManager {
 		&self,
 		key_id: KeyId,
 	) -> Result<Box<dyn SignerOperationsSync<C>>, SignerError> {
-		todo!()
-	}
-
-	/// Get async signer for a key.
-	pub fn get_async_verifier<C: cryptography::Curve>(
-		&self,
-		key_id: KeyId,
-	) -> Result<Box<dyn VerifierOperations<C>>, SignerError> {
-		todo!()
-	}
-
-	/// Get sync signer for a key.
-	pub fn get_sync_verifier<C: cryptography::Curve>(
-		&self,
-		key_id: KeyId,
-	) -> Result<Box<dyn VerifierOperationsSync<C>>, SignerError> {
 		todo!()
 	}
 }


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

<!--
Add your summary text here. 
 -->
From the discussion we add, the implementation I've started this is a new proposition that integrate the signing part and the key management part.
# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->