### PR TITLE
DEVOP-53 automatically deploy main branch to devNet

### DIFF
--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -1023,7 +1023,7 @@ jobs:
         RUN_ID: ${{ steps.get_run_id.outputs.run_id }}
         TOKEN: ${{ secrets.INFRA_GH_TOKEN }}
       run: |
-        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${run_id}"
+        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${RUN_ID}"
         while true; do
           job_data=$(curl -sSL -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${TOKEN}" \

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -998,8 +998,8 @@ jobs:
         BRANCH: main
       id: get_run_id
       run: |
-        sleep 30
         API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/${WORKFLOW_ID}/runs?branch=${BRANCH}&status=in_progress&per_page=1"
+        sleep 15
         run_data=$(curl -sSL -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: token ${{ secrets.INFRA_GH_TOKEN }}" \
           "$API_URL")
@@ -1031,7 +1031,6 @@ jobs:
             -H "Authorization: token ${TOKEN}" \
             "$API_URL")
           job_status=$(echo "$job_data" | jq -r '.status')
-          echo "Run $job_status..."
           if [ "$job_status" = "completed" ]; then
             completion_code=$(echo "$job_data" | jq -r '.conclusion')
             if [ "$completion_code" = "success" ]; then
@@ -1040,14 +1039,19 @@ jobs:
               completion_msg="❌ Deployment failed, please check workflow for errors."
               # exit 1
             fi
+            echo "$completion_msg"
             echo "completion_code=$completion_code" >> $GITHUB_OUTPUT
             echo "completion_msg=$completion_msg" >> $GITHUB_OUTPUT
             echo '### $completion_msg' >> $GITHUB_STEP_SUMMARY
             break
-          fi
-          if [ "$job_status" != "in_progress" ] || [ "$job_status" != "completed" ]; then
-            echo "Job failed with unknown status"
+          elif [ "$job_status" = "queued" ]; then
+            echo "⚫ Job queued, waiting for it to start..."
             break
+          elif [ "$job_status" != "completed" ] && [ "$job_status" != 'in_progress' ]; then
+            echo "❌ Job failed with unknown status"
+            break
+          else
+            echo "⚪ Job is still running..."
           fi
-          sleep 10
+          sleep 15
         done

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -975,11 +975,15 @@ jobs:
         run: |
           ./scripts/movement/manifest helios
 
-  deploy-to-devNet:
+  deploy-trigger:
     # if: github.event.label.name == 'cicd:movement-containers' ||  github.ref == 'refs/heads/main'
     # needs: [container-checks]
-    name: Deploy to devNet
+    name: Trigger devNet deployment
     runs-on: ubuntu-latest
+    outputs:
+      run_id: ${{ steps.get_run_id.outputs.run_id }}
+      run_url: ${{ steps.get_run_id.outputs.run_url }}
+      run_name: ${{ steps.get_run_id.outputs.run_name }}
     steps:
     - name: Dispatch Workflow
       id: deploy
@@ -1017,12 +1021,18 @@ jobs:
         echo "run_id=${run_id}" >> $GITHUB_OUTPUT
         echo "run_url=$run_url" >> $GITHUB_OUTPUT
         echo "### [${run_name}](${run_url})" >> $GITHUB_STEP_SUMMARY
+  deploy-status:
+    # if: github.event.label.name == 'cicd:movement-containers' ||  github.ref == 'refs/heads/main'
+    needs: [deploy-trigger]
+    name: Deployment Status
+    runs-on: ubuntu-latest
+    steps:
     - name: Wait for the deployment to complete
       id: wait
       env:
         OWNER: movement-infra
         REPO: cdktf-mvmt-networks
-        RUN_ID: ${{ steps.get_run_id.outputs.run_id }}
+        RUN_ID: ${{ needs.deploy-trigger.outputs.run_id }}
         TOKEN: ${{ secrets.INFRA_GH_TOKEN }}
       run: |
         API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${RUN_ID}"

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -1042,7 +1042,7 @@ jobs:
             echo "${completion_msg}"
             echo "completion_code=${completion_code}" >> $GITHUB_OUTPUT
             echo "completion_msg=${completion_msg}" >> $GITHUB_OUTPUT
-            echo "### ${completion_msg}"" >> $GITHUB_STEP_SUMMARY
+            echo "### ${completion_msg}" >> $GITHUB_STEP_SUMMARY
             break
           elif [ "$job_status" = "queued" ]; then
             echo "⚫ Job queued, waiting for it to start..."

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -1042,7 +1042,7 @@ jobs:
             echo "${completion_msg}"
             echo "completion_code=${completion_code}" >> $GITHUB_OUTPUT
             echo "completion_msg=${completion_msg}" >> $GITHUB_OUTPUT
-            echo '### ${completion_msg}' >> $GITHUB_STEP_SUMMARY
+            echo "### ${completion_msg}"" >> $GITHUB_STEP_SUMMARY
             break
           elif [ "$job_status" = "queued" ]; then
             echo "⚫ Job queued, waiting for it to start..."

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -999,7 +999,7 @@ jobs:
       id: get_run_id
       run: |
         API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/${WORKFLOW_ID}/runs?branch=${BRANCH}&status=in_progress&per_page=1"
-        sleep 15
+        sleep 30
         run_data=$(curl -sSL -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: token ${{ secrets.INFRA_GH_TOKEN }}" \
           "$API_URL")

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -985,7 +985,7 @@ jobs:
         ref: main
         token: ${{ secrets.INFRA_GH_TOKEN }}
         repo: movement-infra/cdktf-mvmt-networks
-        workflow: update-container-tag.yml
+        workflow: environment-deploy.yml
         inputs: '{"environment":"devNet","containerTag":"${{ github.sha }}"}'
 
   

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -1025,7 +1025,7 @@ jobs:
         RUN_ID: ${{ steps.get_run_id.outputs.run_id }}
         TOKEN: ${{ secrets.INFRA_GH_TOKEN }}
       run: |
-        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${run_id}"
+        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${RUN_ID}"
         while true; do
           job_data=$(curl -sSL -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${TOKEN}" \

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -975,11 +975,14 @@ jobs:
         run: |
           ./scripts/movement/manifest helios
 
-  update-infra-container-tag:
-    name: Update Infra Container Tag
+  deploy-to-devNet:
+    # if: github.event.label.name == 'cicd:movement-containers' ||  github.ref == 'refs/heads/main'
+    # needs: [container-checks]
+    name: Deploy to devNet
     runs-on: ubuntu-latest
     steps:
     - name: Dispatch Workflow
+      id: deploy
       uses: benc-uk/workflow-dispatch@v1
       with:
         ref: main
@@ -987,5 +990,7 @@ jobs:
         repo: movement-infra/cdktf-mvmt-networks
         workflow: environment-deploy.yml
         inputs: '{"environment":"devNet","containerTag":"${{ github.sha }}"}'
+    - name: Add link to summary
+      run: echo "${{ steps.deploy.outputs.workflow_url }}"
 
   

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -1023,26 +1023,27 @@ jobs:
     - name: Wait for the deployment to complete
       id: wait
       run: |
-        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${{ steps.get_run_id.outputs.run_id }}/jobs"
+        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${{ steps.get_run_id.outputs.run_id }}"
         while true; do
           job_data=$(curl -sSL -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ secrets.INFRA_GH_TOKEN }}" \
             "$API_URL")
-          job_status=$(echo "$job_data" | jq -r '.jobs[0].status')
-          echo "Job Status: $job_status"
+          job_status=$(echo "$job_data" | jq -r '.status')
+          echo "Waiting for job to complete..."
           if [ "$job_status" = "completed" ]; then
+            echo "Job completed!"
             break
           fi
-          sleep 30
+          sleep 10
         done
     - name: Get the deployment job status
       id: get_job_status
       run: |
-        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${{ steps.get_run_id.outputs.run_id }}/jobs"
+        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${{ steps.get_run_id.outputs.run_id }}"
         job_data=$(curl -sSL -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: token ${{ secrets.INFRA_GH_TOKEN }}" \
           "$API_URL")
-        status_code=$(echo "$job_data" | jq -r '.jobs[0].conclusion')
+        status_code=$(echo "$job_data" | jq -r '.conclusion')
         if [ "$status_code" = "success" ]; then
           status_msg="✅ Deployment was successful"
           

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -1014,9 +1014,9 @@ jobs:
 
         # Setting the output for other steps in the same job
         echo "run_name=$run_name" >> $GITHUB_OUTPUT
-        echo "run_id=$run_id" >> $GITHUB_OUTPUT
+        echo "run_id=${run_id}" >> $GITHUB_OUTPUT
         echo "run_url=$run_url" >> $GITHUB_OUTPUT
-        echo '### [$run_name]($run_url)' >> $GITHUB_STEP_SUMMARY
+        echo "### [${run_name}](${run_url})" >> $GITHUB_STEP_SUMMARY
     - name: Wait for the deployment to complete
       id: wait
       env:
@@ -1039,10 +1039,10 @@ jobs:
               completion_msg="❌ Deployment failed, please check workflow for errors."
               # exit 1
             fi
-            echo "$completion_msg"
-            echo "completion_code=$completion_code" >> $GITHUB_OUTPUT
-            echo "completion_msg=$completion_msg" >> $GITHUB_OUTPUT
-            echo '### $completion_msg' >> $GITHUB_STEP_SUMMARY
+            echo "${completion_msg}"
+            echo "completion_code=${completion_code}" >> $GITHUB_OUTPUT
+            echo "completion_msg=${completion_msg}" >> $GITHUB_OUTPUT
+            echo '### ${completion_msg}' >> $GITHUB_STEP_SUMMARY
             break
           elif [ "$job_status" = "queued" ]; then
             echo "⚫ Job queued, waiting for it to start..."

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -975,4 +975,16 @@ jobs:
         run: |
           ./scripts/movement/manifest helios
 
+  update-infra-container-tag:
+    name: Update Infra Container Tag
+    runs-on: ubuntu-latest
+    steps:
+    - name: Dispatch Workflow
+      uses: benc-uk/workflow-dispatch@v1
+      with:
+        token: ${{ secrets.INFRA_GH_TOKEN }}
+        repo: movement-infra/cdktf-mvmt-networks
+        workflow: update-container-tag.yml
+        inputs: '{"environment":"devNet","containerTag":"${{ github.sha }}"}'
+
   

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -1004,7 +1004,6 @@ jobs:
           -H "Authorization: token ${{ secrets.INFRA_GH_TOKEN }}" \
           "$API_URL")
         run_name=$(echo "$run_data" | jq -r '.workflow_runs[0].name')
-        run_title=$(echo "$run_data" | jq -r '.workflow_runs[0].display_title')
         run_id=$(echo "$run_data" | jq -r '.workflow_runs[0].id')
         run_url=$(echo "$run_data" | jq -r '.workflow_runs[0].html_url')
 
@@ -1015,43 +1014,38 @@ jobs:
 
         # Setting the output for other steps in the same job
         echo "run_name=$run_name" >> $GITHUB_OUTPUT
-        echo "run_title=$run_title" >> $GITHUB_OUTPUT
         echo "run_id=$run_id" >> $GITHUB_OUTPUT
         echo "run_url=$run_url" >> $GITHUB_OUTPUT
         echo '### [$run_name]($run_url)' >> $GITHUB_STEP_SUMMARY
     - name: Wait for the deployment to complete
       id: wait
+      env:
+        RUN_ID: ${{ steps.get_run_id.outputs.run_id }}
+        TOKEN: ${{ secrets.INFRA_GH_TOKEN }}
       run: |
-        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${{ steps.get_run_id.outputs.run_id }}"
+        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${run_id}"
         while true; do
           job_data=$(curl -sSL -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.INFRA_GH_TOKEN }}" \
+            -H "Authorization: token ${TOKEN}" \
             "$API_URL")
           job_status=$(echo "$job_data" | jq -r '.status')
           echo "Run $job_status..."
           if [ "$job_status" = "completed" ]; then
-            echo "Job $job_status with conclusion of $job_conclusion!"
+            completion_code=$(echo "$job_data" | jq -r '.conclusion')
+            if [ "$completion_code" = "success" ]; then
+              completion_msg="✅ Deployment was successful"
+            else
+              completion_msg="❌ Deployment failed, please check workflow for errors."
+              # exit 1
+            fi
+            echo "completion_code=$completion_code" >> $GITHUB_OUTPUT
+            echo "completion_msg=$completion_msg" >> $GITHUB_OUTPUT
+            echo '### $completion_msg' >> $GITHUB_STEP_SUMMARY
+            break
+          fi
+          if [ "$job_status" != "in_progress" ] || [ "$job_status" != "completed" ]; then
+            echo "Job failed with unknown status"
             break
           fi
           sleep 10
         done
-    - name: Get the deployment job status
-      id: get_job_status
-      run: |
-        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${{ steps.get_run_id.outputs.run_id }}"
-        job_data=$(curl -sSL -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: token ${{ secrets.INFRA_GH_TOKEN }}" \
-          "$API_URL")
-        status_code=$(echo "$job_data" | jq -r '.conclusion')
-        if [ "$status_code" = "success" ]; then
-          status_msg="✅ Deployment was successful"
-          
-        else
-          status_msg="❌ Deployment failed, please check workflow for errors."
-          # exit 1
-        fi
-        echo "$status_code"
-        echo "$status_msg"
-        echo "status_code=$status_code" >> $GITHUB_OUTPUT
-        echo "status_msg=$status_msg" >> $GITHUB_OUTPUT
-        echo '### $status_msg' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -976,8 +976,8 @@ jobs:
           ./scripts/movement/manifest helios
 
   deploy-trigger:
-    # if: github.event.label.name == 'cicd:movement-containers' ||  github.ref == 'refs/heads/main'
-    # needs: [container-checks]
+    if: github.event.label.name == 'cicd:movement-containers' ||  github.ref == 'refs/heads/main'
+    needs: [container-checks]
     name: Trigger devNet deployment
     runs-on: ubuntu-latest
     outputs:
@@ -1021,10 +1021,10 @@ jobs:
         echo "run_id=${run_id}" >> $GITHUB_OUTPUT
         echo "run_url=$run_url" >> $GITHUB_OUTPUT
         echo "### [${run_name}](${run_url})" >> $GITHUB_STEP_SUMMARY
-  deploy-status:
-    # if: github.event.label.name == 'cicd:movement-containers' ||  github.ref == 'refs/heads/main'
+  deploy-check:
+    if: github.event.label.name == 'cicd:movement-containers' ||  github.ref == 'refs/heads/main'
     needs: [deploy-trigger]
-    name: Deployment Status
+    name: Deployment Check
     runs-on: ubuntu-latest
     steps:
     - name: Wait for the deployment to complete

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -982,6 +982,7 @@ jobs:
     - name: Dispatch Workflow
       uses: benc-uk/workflow-dispatch@v1
       with:
+        ref: main
         token: ${{ secrets.INFRA_GH_TOKEN }}
         repo: movement-infra/cdktf-mvmt-networks
         workflow: update-container-tag.yml

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -1010,7 +1010,6 @@ jobs:
 
         echo "Workflow Run Info"
         echo "NAME: $run_name"
-        echo "TITLE: $run_title"
         echo "ID: $run_id"
         echo "URL: $run_url"
 
@@ -1019,7 +1018,7 @@ jobs:
         echo "run_title=$run_title" >> $GITHUB_OUTPUT
         echo "run_id=$run_id" >> $GITHUB_OUTPUT
         echo "run_url=$run_url" >> $GITHUB_OUTPUT
-        echo '### [$run_title]($run_url)' >> $GITHUB_STEP_SUMMARY
+        echo '### [$run_name]($run_url)' >> $GITHUB_STEP_SUMMARY
     - name: Wait for the deployment to complete
       id: wait
       run: |
@@ -1029,9 +1028,9 @@ jobs:
             -H "Authorization: token ${{ secrets.INFRA_GH_TOKEN }}" \
             "$API_URL")
           job_status=$(echo "$job_data" | jq -r '.status')
-          echo "Waiting for job to complete..."
+          echo "Run $job_status..."
           if [ "$job_status" = "completed" ]; then
-            echo "Job completed!"
+            echo "Job $job_status with conclusion of $job_conclusion!"
             break
           fi
           sleep 10

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -998,23 +998,59 @@ jobs:
         BRANCH: main
       id: get_run_id
       run: |
-        # API URL to get the workflow runs
         API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/${WORKFLOW_ID}/runs?branch=${BRANCH}&status=completed&per_page=1"
         run_data=$(curl -sSL -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: token ${{ secrets.INFRA_GH_TOKEN }}" \
           "$API_URL")
+        run_name=$(echo "$run_data" | jq -r '.workflow_runs[0].name')
+        run_title=$(echo "$run_data" | jq -r '.workflow_runs[0].display_title')
         run_id=$(echo "$run_data" | jq -r '.workflow_runs[0].id')
         run_url=$(echo "$run_data" | jq -r '.workflow_runs[0].html_url')
 
-        echo "Latest workflow run ID is: $run_id"
-        echo "Latest workflow run URL is: $run_url"
+        echo "Workflow Run Info"
+        echo "NAME: $run_name"
+        echo "TITLE: $run_title"
+        echo "ID: $run_id"
+        echo "URL: $run_url"
 
         # Setting the output for other steps in the same job
+        echo "run_name=$run_name" >> $GITHUB_OUTPUT
+        echo "run_title=$run_title" >> $GITHUB_OUTPUT
         echo "run_id=$run_id" >> $GITHUB_OUTPUT
         echo "run_url=$run_url" >> $GITHUB_OUTPUT
-    - name: Add the url to the job summary
+        echo '### [$run_title]($run_url)' >> $GITHUB_STEP_SUMMARY
+    - name: Wait for the deployment to complete
+      id: wait
       run: |
-        echo '### [Deployment Pipeline](${{ steps.get_run_id.outputs.run_url }})' >> $GITHUB_STEP_SUMMARY
-      
-
-  
+        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${{ steps.get_run_id.outputs.run_id }}/jobs"
+        while true; do
+          job_data=$(curl -sSL -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.INFRA_GH_TOKEN }}" \
+            "$API_URL")
+          job_status=$(echo "$job_data" | jq -r '.jobs[0].status')
+          echo "Job Status: $job_status"
+          if [ "$job_status" = "completed" ]; then
+            break
+          fi
+          sleep 30
+        done
+    - name: Get the deployment job status
+      id: get_job_status
+      run: |
+        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${{ steps.get_run_id.outputs.run_id }}/jobs"
+        job_data=$(curl -sSL -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ secrets.INFRA_GH_TOKEN }}" \
+          "$API_URL")
+        status_code=$(echo "$job_data" | jq -r '.jobs[0].conclusion')
+        if [ "$status_code" = "success" ]; then
+          status_msg="✅ Deployment was successful"
+          
+        else
+          status_msg="❌ Deployment failed, please check workflow for errors."
+          # exit 1
+        fi
+        echo "$status_code"
+        echo "$status_msg"
+        echo "status_code=$status_code" >> $GITHUB_OUTPUT
+        echo "status_msg=$status_msg" >> $GITHUB_OUTPUT
+        echo '### $status_msg' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -998,7 +998,7 @@ jobs:
         BRANCH: main
       id: get_run_id
       run: |
-        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/${WORKFLOW_ID}/runs?branch=${BRANCH}&status=completed&per_page=1"
+        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/${WORKFLOW_ID}/runs?branch=${BRANCH}&per_page=1"
         run_data=$(curl -sSL -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: token ${{ secrets.INFRA_GH_TOKEN }}" \
           "$API_URL")

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -1014,7 +1014,7 @@ jobs:
         echo "run_url=$run_url" >> $GITHUB_OUTPUT
     - name: Add the url to the job summary
       run: |
-        echo "Deployment workflow run: ${{ steps.get_run_id.outputs.run_url }}"
+        echo '### [Deployment Pipeline](${{ steps.get_run_id.outputs.run_url }})' >> $GITHUB_STEP_SUMMARY
       
 
   

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -998,7 +998,8 @@ jobs:
         BRANCH: main
       id: get_run_id
       run: |
-        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/${WORKFLOW_ID}/runs?branch=${BRANCH}&per_page=1"
+        sleep 10
+        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/${WORKFLOW_ID}/runs?branch=${BRANCH}&status=in_progress&per_page=1"
         run_data=$(curl -sSL -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: token ${{ secrets.INFRA_GH_TOKEN }}" \
           "$API_URL")

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -1020,10 +1020,12 @@ jobs:
     - name: Wait for the deployment to complete
       id: wait
       env:
+        OWNER: movement-infra
+        REPO: cdktf-mvmt-networks
         RUN_ID: ${{ steps.get_run_id.outputs.run_id }}
         TOKEN: ${{ secrets.INFRA_GH_TOKEN }}
       run: |
-        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${RUN_ID}"
+        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${run_id}"
         while true; do
           job_data=$(curl -sSL -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${TOKEN}" \

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -998,7 +998,7 @@ jobs:
         BRANCH: main
       id: get_run_id
       run: |
-        sleep 10
+        sleep 30
         API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/${WORKFLOW_ID}/runs?branch=${BRANCH}&status=in_progress&per_page=1"
         run_data=$(curl -sSL -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: token ${{ secrets.INFRA_GH_TOKEN }}" \

--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -990,7 +990,31 @@ jobs:
         repo: movement-infra/cdktf-mvmt-networks
         workflow: environment-deploy.yml
         inputs: '{"environment":"devNet","containerTag":"${{ github.sha }}"}'
-    - name: Add link to summary
-      run: echo "${{ steps.deploy.outputs.workflow_url }}"
+    - name: Retrieve workflow run ID of the deployment
+      env:
+        OWNER: movement-infra
+        REPO: cdktf-mvmt-networks
+        WORKFLOW_ID: ${{ steps.deploy.outputs.workflowId }}
+        BRANCH: main
+      id: get_run_id
+      run: |
+        # API URL to get the workflow runs
+        API_URL="https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/${WORKFLOW_ID}/runs?branch=${BRANCH}&status=completed&per_page=1"
+        run_data=$(curl -sSL -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ secrets.INFRA_GH_TOKEN }}" \
+          "$API_URL")
+        run_id=$(echo "$run_data" | jq -r '.workflow_runs[0].id')
+        run_url=$(echo "$run_data" | jq -r '.workflow_runs[0].html_url')
+
+        echo "Latest workflow run ID is: $run_id"
+        echo "Latest workflow run URL is: $run_url"
+
+        # Setting the output for other steps in the same job
+        echo "run_id=$run_id" >> $GITHUB_OUTPUT
+        echo "run_url=$run_url" >> $GITHUB_OUTPUT
+    - name: Add the url to the job summary
+      run: |
+        echo "Deployment workflow run: ${{ steps.get_run_id.outputs.run_url }}"
+      
 
   


### PR DESCRIPTION
# Summary
- **Categories**: `cicd`

Adds workflow jobs for triggering new deployment to k8s pipeline.

# Changelog

Modified the build-push-containers to trigger and check a workflow in the movement-infra org that deploys the movement-network helm chart to the kubernetes clusters in the devNet environment. This happens after the container checks so that it's guaranteed the containers are built and tested.

# Testing

I've done some pretty extensive testing with triggering the workflow both in this repo and the infrastructure repo. I added error handling in the pipeline to make debugging failed deployments a easier.

But once there's a commit on main or a branch is tagged to build the containers we should see this pipeline trigger the devNet deploy.

# Outstanding issues
The helm chart sometimes errors out but this shouldn't interfere with the deployment pipeline but will inform in the build-push-containers workflow that triggers the deploy.