### PR TITLE
chore(protocol-units): fix error message

### DIFF
--- a/protocol-units/bridge/integration-tests/tests/client_eth_tests.rs
+++ b/protocol-units/bridge/integration-tests/tests/client_eth_tests.rs
@@ -131,7 +131,7 @@ async fn test_eth_client_initiator_complete_transfer() {
 		Some(Ok(BridgeContractEvent::Initiated(detail))) => detail.bridge_transfer_id,
 		Some(Err(e)) => panic!("Error in bridge contract event: {:?}", e),
 		None => panic!("No event received"),
-		_ => panic!("Not a an Initiated event: {:?}", event_option),
+		_ => panic!("Not an Initiated event: {:?}", event_option),
 	};
 
 	tracing::info!("Received bridge_transfer_id: {}", bridge_transfer_id);
@@ -196,7 +196,7 @@ async fn test_eth_client_refund_transfer() {
 		Some(Ok(BridgeContractEvent::Initiated(detail))) => detail.bridge_transfer_id,
 		Some(Err(e)) => panic!("Error in bridge contract event: {:?}", e),
 		None => panic!("No event received"),
-		_ => panic!("Not a an Initiated event: {:?}", event_option),
+		_ => panic!("Not an Initiated event: {:?}", event_option),
 	};
 
 	tracing::info!("Received bridge_transfer_id: {}", bridge_transfer_id);

--- a/protocol-units/bridge/integration-tests/tests/client_mvt_tests.rs
+++ b/protocol-units/bridge/integration-tests/tests/client_mvt_tests.rs
@@ -139,7 +139,7 @@ async fn test_movement_client_initiate_transfer() -> Result<(), anyhow::Error> {
 			Some(Ok(BridgeContractEvent::Initiated(detail))) => detail.bridge_transfer_id,
 			Some(Err(e)) => panic!("Error in bridge contract event: {:?}", e),
 			None => panic!("No event received"),
-			_ => panic!("Not a an Initiated event: {:?}", event_option),
+			_ => panic!("Not an Initiated event: {:?}", event_option),
 		};
 
 		tracing::info!("Received bridge_transfer_id: {:?}", bridge_transfer_id);
@@ -282,7 +282,7 @@ async fn test_movement_client_initiator_complete_transfer() -> Result<(), anyhow
 		Some(Ok(BridgeContractEvent::Initiated(detail))) => detail.bridge_transfer_id,
 		Some(Err(e)) => panic!("Error in bridge contract event: {:?}", e),
 		None => panic!("No event received"),
-		_ => panic!("Not a an Initiated event: {:?}", event_option),
+		_ => panic!("Not an Initiated event: {:?}", event_option),
 	};
 
 	tracing::info!("Received bridge_transfer_id: {:?}", bridge_transfer_id);
@@ -357,7 +357,7 @@ async fn test_movement_client_refund_transfer() -> Result<(), anyhow::Error> {
 		Some(Ok(BridgeContractEvent::Initiated(detail))) => detail.bridge_transfer_id,
 		Some(Err(e)) => panic!("Error in bridge contract event: {:?}", e),
 		None => panic!("No event received"),
-		_ => panic!("Not a an Initiated event: {:?}", event_option),
+		_ => panic!("Not an Initiated event: {:?}", event_option),
 	};
 
 	tracing::info!("Received bridge_transfer_id: {:?}", bridge_transfer_id);


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**: `protocol-units`.

<!--
Add your summary text here. 
 -->

# Changelog
Remove redundant words in error messages.
<!-- 

-->

# Testing
No.
<!--

-->

# Outstanding issues
No
<!--

-->