### PR TITLE
Test Lock and Mint

### DIFF
--- a/networks/movement/movement-client/Cargo.toml
+++ b/networks/movement/movement-client/Cargo.toml
@@ -39,6 +39,10 @@ path = "src/bin/e2e/whitelist.rs"
 name = "movement-tests-e2e-ggp-gas-fee"
 path = "src/bin/e2e/ggp_gas_fee.rs"
 
+[[bin]]
+name = "movement-tests-e2e-lock-mint"
+path = "src/bin/e2e/lock_mint.rs"
+
 
 [dependencies]
 aptos-sdk = { workspace = true }

--- a/networks/movement/movement-client/src/bin/e2e/lock_mint.rs
+++ b/networks/movement/movement-client/src/bin/e2e/lock_mint.rs
@@ -1,0 +1,273 @@
+#![allow(unused_imports)]
+use anyhow::Context;
+use aptos_sdk::move_types::{
+	identifier::Identifier, language_storage::ModuleId, language_storage::TypeTag,
+};
+use aptos_sdk::types::{
+	account_address::AccountAddress, chain_id::ChainId, transaction::EntryFunction, LocalAccount,
+};
+use aptos_sdk::{
+	rest_client::{
+		aptos_api_types::{
+			Address, EntryFunctionId, IdentifierWrapper, MoveModule, MoveModuleId, MoveStructTag,
+			MoveType, ViewRequest,
+		},
+		Response,
+	},
+	transaction_builder::TransactionBuilder,
+};
+use aptos_types::transaction::TransactionPayload;
+use movement_client::{
+	coin_client::CoinClient,
+	rest_client::{Client, FaucetClient},
+};
+use once_cell::sync::Lazy;
+use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tracing;
+use url::Url;
+
+static SUZUKA_CONFIG: Lazy<movement_config::Config> = Lazy::new(|| {
+	let dot_movement = dot_movement::DotMovement::try_from_env().unwrap();
+	let config = dot_movement.try_get_config_from_json::<movement_config::Config>().unwrap();
+	config
+});
+
+static NODE_URL: Lazy<Url> = Lazy::new(|| {
+	let node_connection_address = SUZUKA_CONFIG
+		.execution_config
+		.maptos_config
+		.client
+		.maptos_rest_connection_hostname
+		.clone();
+	let node_connection_port = SUZUKA_CONFIG
+		.execution_config
+		.maptos_config
+		.client
+		.maptos_rest_connection_port
+		.clone();
+	let node_connection_url =
+		format!("http://{}:{}", node_connection_address, node_connection_port);
+	Url::from_str(node_connection_url.as_str()).unwrap()
+});
+
+static FAUCET_URL: Lazy<Url> = Lazy::new(|| {
+	let faucet_listen_address = SUZUKA_CONFIG
+		.execution_config
+		.maptos_config
+		.client
+		.maptos_faucet_rest_connection_hostname
+		.clone();
+	let faucet_listen_port = SUZUKA_CONFIG
+		.execution_config
+		.maptos_config
+		.client
+		.maptos_faucet_rest_connection_port
+		.clone();
+	let faucet_listen_url = format!("http://{}:{}", faucet_listen_address, faucet_listen_port);
+	Url::from_str(faucet_listen_url.as_str()).unwrap()
+});
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+	let rest_client = Client::new(NODE_URL.clone());
+	let faucet_client = FaucetClient::new(FAUCET_URL.clone(), NODE_URL.clone());
+	let coin_client = CoinClient::new(&rest_client);
+	let dead_address = AccountAddress::from_str(
+		"000000000000000000000000000000000000000000000000000000000000dead",
+	)?;
+	let chain_id = rest_client
+		.get_index()
+		.await
+		.context("failed to get chain ID")?
+		.inner()
+		.chain_id;
+
+	// Create account for transactions and gas collection
+	let private_key = SUZUKA_CONFIG
+		.execution_config
+		.maptos_config
+		.chain
+		.maptos_private_key
+		.to_string();
+	let mut core_resources_account = LocalAccount::from_private_key(
+		"0x0000000000000000000000000000000000000000000000000000000000000001",
+		0,
+	)?;
+
+	tracing::info!("Created core resources account");
+	tracing::debug!("core_resources_account address: {}", core_resources_account.address());
+
+	// Fund the core_resources_account account
+	faucet_client
+		.fund(core_resources_account.address(), 1_000_000_000_000_000)
+		.await
+		.context("Failed to fund core_resources_account account")?;
+
+	let create_dead_transaction =
+		core_resources_account.sign_with_transaction_builder(TransactionBuilder::new(
+			TransactionPayload::EntryFunction(EntryFunction::new(
+				ModuleId::new(
+					AccountAddress::from_hex_literal("0x1")?,
+					Identifier::new("aptos_account")?,
+				),
+				Identifier::new("create_account")?,
+				vec![],
+				vec![bcs::to_bytes(&dead_address)?],
+			)),
+			SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() + 60,
+			ChainId::new(chain_id),
+		).sequence_number(core_resources_account.sequence_number()));
+
+	rest_client
+		.submit_and_wait(&create_dead_transaction)
+		.await
+		.context("Failed to create dead account")?;
+
+	coin_client
+		.transfer(
+			&mut core_resources_account,
+			AccountAddress::from_str(
+				"000000000000000000000000000000000000000000000000000000000000dead",
+			)
+			.unwrap(),
+			1,
+			None,
+		)
+		.await
+		.context("Failed to transfer coins to dead account")?;
+
+	// Retrieve and log balances
+	let dead_balance = coin_client
+		.get_account_balance(&dead_address)
+		.await
+		.context("Failed to retrieve dead account balance")?;
+	let core_balance = coin_client
+		.get_account_balance(&core_resources_account.address())
+		.await
+		.context("Failed to retrieve core resources account balance")?;
+
+	tracing::info!(
+		"Core account balance: {}, Dead account balance: {}",
+		core_balance,
+		dead_balance
+	);
+
+	// Burn coins from the dead account
+	let burn_transaction =
+		core_resources_account.sign_with_transaction_builder(TransactionBuilder::new(
+			TransactionPayload::EntryFunction(EntryFunction::new(
+				ModuleId::new(AccountAddress::from_hex_literal("0x1")?, Identifier::new("coin")?),
+				Identifier::new("burn_frozen")?,
+				vec![TypeTag::from_str("0x1::aptos_coin::AptosCoin")?],
+				vec![bcs::to_bytes(&dead_address)?, bcs::to_bytes(&1u64)?],
+			)),
+			SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() + 60,
+			ChainId::new(chain_id),
+		).sequence_number(core_resources_account.sequence_number()));
+
+
+	rest_client
+		.submit_and_wait(&burn_transaction)
+		.await
+		.context("Failed to burn coins from dead account")?;
+
+	tracing::info!("Burn transaction successfully executed.");
+
+	// assert_eq!(core_resorces_balance, 999_999_999_999_999, "Core resources account balance is not what is expected");
+	// assert_eq!(dead_balance, 1, "Dead account balance is not what is expected");
+
+	// rest_client.submit_and_wait(
+	// 	&core_resources_account.sign_with_transaction_builder(
+	// 		core_resources_account.transaction_builder().burn_from(1, 0),
+	// 	),
+	// ).await;
+
+	// let view_req = ViewRequest {
+	// 	function: EntryFunctionId {
+	// 		module: MoveModuleId {
+	// 			address: Address::from_str("0x1").unwrap(),
+	// 			name: IdentifierWrapper::from_str("coin").unwrap(),
+	// 		},
+	// 		name: IdentifierWrapper::from_str("balance").unwrap(),
+	// 	},
+	// 	type_arguments: vec![MoveType::Struct(MoveStructTag::new(
+	//         Address::from_str("0x1").unwrap(),
+	//         IdentifierWrapper::from_str("aptos_coin").unwrap(),
+	//         IdentifierWrapper::from_str("AptosCoin").unwrap(),
+	//         vec![],
+	//     ))],
+	// 	arguments: vec!["0xdead".into()],
+	// };
+
+	// let view_res: Response<Vec<serde_json::Value>> = rest_client
+	// 	.view(&view_req, None)
+	// 	.await
+	// 	.context("Failed to get dead address balance")?;
+
+	// // Extract the inner field from the response
+	// let inner_value = serde_json::to_value(view_res.inner())
+	// 	.context("Failed to convert response inner to serde_json::Value")?;
+
+	// // Deserialize the inner value into your AddressResponse struct
+	// let ggp_address: Vec<String> =
+	// 	serde_json::from_value(inner_value).context("Failed to deserialize AddressResponse")?;
+
+	// assert_eq!(
+	// 	ggp_address,
+	// 	vec!["0xb08e0478ac871400e082f34e003145570bf4a9e4d88f17964b21fb110e93d77a"],
+	// 	"Governed Gas Pool Resource account is not what is expected"
+	// );
+
+	// let ggp_account_address =
+	// 	AccountAddress::from_str(&ggp_address[0]).expect("Failed to parse address");
+
+	// // Get initial balances
+	// let initial_ggp_balance = coin_client
+	// 	.get_account_balance(&ggp_account_address)
+	// 	.await
+	// 	.context("Failed to get initial framework balance")?;
+
+	// tracing::info!("Initial ggp Balance: {}", initial_ggp_balance);
+
+	// // Simple transaction that will generate gas fees
+	// tracing::info!("Executing test transaction...");
+	// let txn_hash = coin_client
+	// 	.transfer(&mut core_resources_account, beneficiary.address(), 1_000, None)
+	// 	.await
+	// 	.context("Failed to submit transfer transaction")?;
+
+	// rest_client
+	// 	.wait_for_transaction(&txn_hash)
+	// 	.await
+	// 	.context("Failed when waiting for transfer transaction")?;
+	// tracing::info!("Test transaction completed: {:?}", txn_hash);
+
+	// // Get post-transaction balance
+	// let post_ggp_balance = coin_client
+	// 	.get_account_balance(&ggp_account_address)
+	// 	.await
+	// 	.context("Failed to get post-transaction framework balance")?;
+
+	// tracing::info!("Initial ggp Balance: {}", initial_ggp_balance);
+
+	// // Verify gas fees collection
+	// assert!(post_ggp_balance > initial_ggp_balance, "Gas fees were not collected as expected");
+
+	// // Wait to verify no additional deposits
+	// tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+	// // Check final balance
+	// let final_framework_balance = coin_client
+	// 	.get_account_balance(&ggp_account_address)
+	// 	.await
+	// 	.context("Failed to get final framework balance")?;
+
+	// // Verify no additional deposits occurred
+	// assert_eq!(
+	// 	post_ggp_balance, final_framework_balance,
+	// 	"Additional unexpected deposits were detected"
+	// );
+
+	Ok(())
+}

--- a/process-compose/movement-full-node/process-compose.test-lock-mint.yml
+++ b/process-compose/movement-full-node/process-compose.test-lock-mint.yml
@@ -1,0 +1,13 @@
+version: "3"
+
+environment:
+
+processes:
+  test-lock-mint:
+    command: |
+      cargo run --bin movement-tests-e2e-lock-mint
+    depends_on:
+      movement-full-node:
+        condition: process_healthy
+      movement-faucet:
+        condition: process_healthy


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

https://github.com/movementlabsxyz/movement/issues/1009

Burn elsa's supply.

# Changelog

moved away from native_bridge integration to e2e testing

# Testing

networks/movement/movement-client/src/bin/e2e/lock_mint.rs

# Outstanding issues
We might need to add a burn_from entry function on the core_resources_account.