### PR TITLE
SignerIdentifier::try_raw_private_key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10684,6 +10684,7 @@ version = "0.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
+ "hex",
  "movement-signer",
  "movement-signer-aws-kms",
  "movement-signer-hashicorp-vault",

--- a/util/signing/util/loader/Cargo.toml
+++ b/util/signing/util/loader/Cargo.toml
@@ -10,14 +10,16 @@ publish = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = { workspace = true }
 movement-signer = { workspace = true }
 movement-signer-aws-kms = { workspace = true }
 movement-signer-hashicorp-vault = { workspace = true }
 movement-signer-local = { workspace = true }
+
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+hex = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
-async-trait = { workspace = true }
 tracing = { workspace = true }
 
 [lints]

--- a/util/signing/util/loader/src/identifiers/mod.rs
+++ b/util/signing/util/loader/src/identifiers/mod.rs
@@ -2,6 +2,7 @@ pub mod aws_kms;
 pub mod hashi_corp_vault;
 pub mod local;
 
+use anyhow::anyhow;
 use movement_signer::{cryptography::Curve, key::TryFromCanonicalString};
 use serde::{Deserialize, Serialize};
 
@@ -18,6 +19,18 @@ impl SignerIdentifier {
 		C: Curve,
 	{
 		TypedSignerIdentifier::new(self)
+	}
+
+	/// Returns the bytes of the private key if it can be extracted from
+	/// the identifier. This method is only used for testing.
+	pub fn try_raw_private_key(&self) -> Result<Vec<u8>, anyhow::Error> {
+		match self {
+			SignerIdentifier::Local(local::Local { private_key_hex_bytes }) => {
+				let key = hex::decode(private_key_hex_bytes)?;
+				Ok(key)
+			}
+			_ => Err(anyhow!("")),
+		}
 	}
 }
 


### PR DESCRIPTION
Add a method to extract private key bytes from
`SignerIdentifier`, to use in tests.