### PR TITLE
[test]- Split leader archive file in smaller chunk.

### DIFF
--- a/util/syncador/src/backend/archive/gzip/mod.rs
+++ b/util/syncador/src/backend/archive/gzip/mod.rs
@@ -1,2 +1,95 @@
 pub mod pull;
 pub mod push;
+
+pub(crate) const DEFAULT_CHUNK_SIZE: usize = 500 * 1024 * 1024; // 500 MB per chunk (adjustable)
+pub(crate) const BUFFER_SIZE: usize = 10 * 1024 * 1024; // 10 MB buffer for each read/write operation
+
+#[cfg(test)]
+pub mod test {
+
+	use crate::backend::archive::gzip::pull::Pull;
+	use crate::backend::archive::gzip::push::Push;
+	use crate::backend::PullOperations;
+	use crate::backend::PushOperations;
+	use crate::files::package::{Package, PackageElement};
+	use std::fs::File;
+	use std::io::BufWriter;
+	use std::io::Write;
+	use std::path::PathBuf;
+
+	#[tokio::test]
+	pub async fn test_archive_split() -> Result<(), anyhow::Error> {
+		// 1) Chunk size is bigger than the archive. No split in chunk.
+		process_archive_test("test_archive_split.tmp", 10 * 1024, 1024).await?;
+		// 2) Chunk size is smaller than the archive. Several chunk is create and reconstructed.
+		process_archive_test("test_archive_split2.tmp", 2024, 1024).await?;
+		Ok(())
+	}
+
+	async fn process_archive_test(
+		temp_file_name: &str,
+		chunk_size: usize,
+		buffer_size: usize,
+	) -> Result<(), anyhow::Error> {
+		//Create source and destination temp dir.
+		let source_dir = tempfile::tempdir()?;
+		let destination_dir = tempfile::tempdir()?;
+
+		//1) First test file too small doesn't archive.
+
+		let archive_file_path = source_dir.path().join(temp_file_name);
+		{
+			let file = File::create(&archive_file_path)?;
+			let mut writer = BufWriter::new(file);
+			//Fill with some data. 10 Mb
+			let data: Vec<u8> = vec![2; 1024 * 1024];
+			(0..10).try_for_each(|_| writer.write_all(&data))?;
+		}
+
+		let push = Push { archives_dir: source_dir.path().to_path_buf(), chunk_size, buffer_size };
+
+		let element = PackageElement {
+			sync_files: vec![archive_file_path],
+			root_dir: source_dir.path().to_path_buf(),
+		};
+		let package = Package(vec![element]);
+		let archive_package = push.push(package).await?;
+		println!("TEST archive_package: {:?}", archive_package);
+
+		let file_metadata = std::fs::metadata(&archive_package.0[0].sync_files[0])?;
+		let file_size = file_metadata.len() as usize;
+		println!("TEST Dest chunk file size: {file_size}",);
+
+		// Unarchive and verify
+		//move archive to dest folder.
+		let dest_files = archive_package
+			.0
+			.into_iter()
+			.flat_map(|element| element.sync_files)
+			.map(|absolute_path| {
+				let dest = destination_dir.path().join(absolute_path.file_name().unwrap());
+				println!("TEST move file source:{absolute_path:?} dest:{dest:?}");
+				std::fs::rename(&absolute_path, &dest)?;
+				Ok(dest)
+			})
+			.collect::<std::io::Result<Vec<PathBuf>>>()?;
+
+		let pull = Pull { destination_dir: destination_dir.path().to_path_buf() };
+		let element = PackageElement {
+			sync_files: dest_files,
+			root_dir: destination_dir.path().to_path_buf(),
+		};
+		let package = Package(vec![element]);
+
+		let dest_package = pull.pull(Some(package)).await;
+		println!("ICICICIC dest_package: {:?}", dest_package);
+
+		//verify the dest file has the right size
+		let file_metadata = std::fs::metadata(&destination_dir.path().join(temp_file_name))?;
+		let file_size = file_metadata.len() as usize;
+		println!("Dest fiel size: {file_size}",);
+		assert_eq!(file_size, 10 * 1024 * 1024, "dest file hasn't the right size: {file_size}");
+
+		Ok(())
+	}
+}

--- a/util/syncador/src/backend/archive/gzip/pull.rs
+++ b/util/syncador/src/backend/archive/gzip/pull.rs
@@ -63,7 +63,8 @@ impl Pull {
 		// Unpack each archive in the manifest
 		for (_relative_path, absolute_path) in manifest.try_path_tuples()? {
 			// Recreate splited file if any
-			let absolute_path = recreate_archive(absolute_path.to_path_buf())?;
+			let path_buf = absolute_path.to_path_buf();
+			let absolute_path = task::spawn_blocking(move || recreate_archive(path_buf)).await??;
 
 			println!("PULL absolute_path {absolute_path:?}",);
 			println!("PULL destination {destination:?}",);

--- a/util/syncador/src/backend/archive/gzip/pull.rs
+++ b/util/syncador/src/backend/archive/gzip/pull.rs
@@ -1,8 +1,12 @@
+use crate::backend::archive::gzip::BUFFER_SIZE;
 use crate::backend::PullOperations;
 use crate::files::package::{Package, PackageElement};
 use flate2::read::GzDecoder;
 use std::collections::VecDeque;
 use std::fs::File;
+use std::fs::OpenOptions;
+use std::io::BufReader;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use tar::Archive;
 use tokio::{fs, task};
@@ -51,8 +55,28 @@ impl Pull {
 		// Create the destination directory if it doesn't exist
 		fs::create_dir_all(&destination).await?;
 
+		println!("PULL manifest:{:?}", manifest);
+
+		let mut unsplit_manifest =
+			PackageElement { sync_files: vec![], root_dir: manifest.root_dir.clone() };
+
 		// Unpack each archive in the manifest
 		for (_relative_path, absolute_path) in manifest.try_path_tuples()? {
+			// Recreate splited file if any
+			let absolute_path = recreate_archive(absolute_path.to_path_buf())?;
+
+			println!("PULL absolute_path {absolute_path:?}",);
+			println!("PULL destination {destination:?}",);
+
+			if !unsplit_manifest.sync_files.contains(&absolute_path) {
+				unsplit_manifest.sync_files.push(absolute_path)
+			}
+		}
+
+		println!("PULL unsplit_manifest:{:?}", unsplit_manifest);
+
+		// Unpack each archive in the manifest
+		for (_relative_path, absolute_path) in unsplit_manifest.try_path_tuples()? {
 			let tar_gz = File::open(&absolute_path)?;
 			let decoder = GzDecoder::new(tar_gz);
 			let mut archive = Archive::new(decoder);
@@ -96,4 +120,70 @@ impl PullOperations for Pull {
 		}
 		Ok(Some(Package(manifests)))
 	}
+}
+
+fn recreate_archive(archive_chunk: PathBuf) -> Result<PathBuf, anyhow::Error> {
+	if archive_chunk
+		.extension()
+		.map(|ext| {
+			println!("ext:{ext:?}",);
+			ext != "chunk"
+		})
+		.unwrap_or(true)
+	{
+		//not a chunk file return.
+		return Ok(archive_chunk);
+	}
+
+	let arhive_file_name = archive_chunk
+		.file_name()
+		.and_then(|file_name| file_name.to_str())
+		.and_then(|file_name_str| file_name_str.strip_suffix(".chunk"))
+		.and_then(|base_filename| {
+			let base_filename_parts: Vec<&str> = base_filename.rsplitn(2, '_').collect();
+			(base_filename_parts.len() > 1).then(|| base_filename_parts[1].to_string())
+		})
+		.ok_or(anyhow::anyhow!(format!(
+			"Archive filename not found for chunk path:{:?}",
+			archive_chunk.to_str()
+		)))?;
+
+	println!("PULL arhive_file_name:{:?}", arhive_file_name);
+
+	let archive_path = archive_chunk.parent().map(|parent| parent.join(arhive_file_name)).ok_or(
+		anyhow::anyhow!(format!(
+			"Archive filename no root dir in path:{:?}",
+			archive_chunk.to_str()
+		)),
+	)?;
+
+	println!("PULL archive_path:{:?}", archive_path);
+	let mut archive_file = OpenOptions::new()
+		.create(true) // Create the file if it doesn't exist
+		.append(true) // Open in append mode (do not overwrite)
+		.open(&archive_path)?;
+
+	let mut buffer = vec![0; BUFFER_SIZE];
+
+	println!("PULL archive_chunk:{:?}", archive_chunk);
+	let chunk_file = File::open(&archive_chunk)?;
+	let mut chunk_reader = BufReader::new(chunk_file);
+
+	loop {
+		// Read a part of the chunk into the buffer
+		let bytes_read = chunk_reader.read(&mut buffer)?;
+
+		if bytes_read == 0 {
+			break; // End of chunk file
+		}
+
+		// Write the buffer data to the output file
+		archive_file.write_all(&buffer[..bytes_read])?;
+	}
+
+	let file_metadata = std::fs::metadata(&archive_path)?;
+	let file_size = file_metadata.len() as usize;
+	println!("PULL {archive_path:?} archive_chunk size: {file_size}",);
+
+	Ok(archive_path)
 }

--- a/util/syncador/src/backend/archive/gzip/push.rs
+++ b/util/syncador/src/backend/archive/gzip/push.rs
@@ -91,19 +91,11 @@ fn split_archive<P: AsRef<Path>>(
 	let output_dir = root_dir.as_ref();
 
 	// Check the file size before proceeding with the split
-	let file_metadata = std::fs::metadata(&archive)?;
-	let file_size = file_metadata.len() as usize;
-	println!("Push split file size{file_size} chunksize:{chunk_size}",);
 	if file_size <= chunk_size {
 		return Ok(vec![archive]);
 	}
 
 	let archive_file = File::open(&archive)?;
-
-	let file_metadata = std::fs::metadata(&archive)?;
-	let file_size = file_metadata.len() as usize;
-	println!("PUSH {archive:?} archive_file size: {file_size}",);
-
 	std::fs::create_dir_all(output_dir)?;
 
 	let mut chunk_num = 0;
@@ -121,14 +113,12 @@ fn split_archive<P: AsRef<Path>>(
 			chunk_num
 		));
 
-		println!("PUSH create chunk_path: {chunk_path:?}",);
 		let mut chunk_file = File::create(&chunk_path)?;
 
 		let mut all_read_bytes = 0;
 		let end = loop {
 			// Read a part of the chunk into the buffer
 			let bytes_read = input_reader.read(&mut buffer)?;
-			println!("PUSH Read bytes: {bytes_read}",);
 			if bytes_read == 0 {
 				break true; // End of chunk file
 			}
@@ -136,7 +126,6 @@ fn split_archive<P: AsRef<Path>>(
 			// Write the buffer data to the output file
 			chunk_file.write_all(&buffer[..bytes_read])?;
 			all_read_bytes += bytes_read;
-			println!("PUSH all_read_bytes {all_read_bytes:?} chunk_size:{chunk_size}",);
 			if all_read_bytes >= chunk_size {
 				break false;
 			}
@@ -148,7 +137,7 @@ fn split_archive<P: AsRef<Path>>(
 
 		let file_metadata = std::fs::metadata(&chunk_path)?;
 		let file_size = file_metadata.len() as usize;
-		println!("{chunk_path:?} chunk_file size: {file_size}",);
+		println!("PUSH {chunk_path:?} chunk_file size: {file_size}",);
 
 		chunk_num += 1;
 		chunk_list.push(chunk_path);
@@ -157,6 +146,5 @@ fn split_archive<P: AsRef<Path>>(
 		}
 	}
 
-	println!("split_archive return {chunk_list:?}",);
 	Ok(chunk_list)
 }

--- a/util/syncador/src/backend/archive/gzip/push.rs
+++ b/util/syncador/src/backend/archive/gzip/push.rs
@@ -91,11 +91,20 @@ fn split_archive<P: AsRef<Path>>(
 	let output_dir = root_dir.as_ref();
 
 	// Check the file size before proceeding with the split
+	let file_metadata = std::fs::metadata(&archive)?;
+	let file_size = file_metadata.len() as usize;
+	println!("Push split file size{file_size} chunksize:{chunk_size}",);
+
 	if file_size <= chunk_size {
 		return Ok(vec![archive]);
 	}
 
 	let archive_file = File::open(&archive)?;
+
+	let file_metadata = std::fs::metadata(&archive)?;
+	let file_size = file_metadata.len() as usize;
+	println!("PUSH {archive:?} archive_file size: {file_size}",);
+
 	std::fs::create_dir_all(output_dir)?;
 
 	let mut chunk_num = 0;
@@ -137,7 +146,7 @@ fn split_archive<P: AsRef<Path>>(
 
 		let file_metadata = std::fs::metadata(&chunk_path)?;
 		let file_size = file_metadata.len() as usize;
-		println!("PUSH {chunk_path:?} chunk_file size: {file_size}",);
+		println!("{chunk_path:?} chunk_file size: {file_size}",);
 
 		chunk_num += 1;
 		chunk_list.push(chunk_path);
@@ -146,5 +155,6 @@ fn split_archive<P: AsRef<Path>>(
 		}
 	}
 
+	println!("split_archive return {chunk_list:?}",);
 	Ok(chunk_list)
 }

--- a/util/syncador/src/backend/archive/gzip/push.rs
+++ b/util/syncador/src/backend/archive/gzip/push.rs
@@ -1,19 +1,25 @@
+use crate::backend::archive::gzip::BUFFER_SIZE;
+use crate::backend::archive::gzip::DEFAULT_CHUNK_SIZE;
 use crate::backend::PushOperations;
 use crate::files::package::{Package, PackageElement};
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use std::fs::File;
+use std::io::{BufReader, Read, Write};
+use std::path::Path;
 use std::path::PathBuf;
 use tar::Builder;
 
 #[derive(Debug, Clone)]
 pub struct Push {
 	pub archives_dir: PathBuf,
+	pub chunk_size: usize,
+	pub buffer_size: usize,
 }
 
 impl Push {
 	pub fn new(archives_dir: PathBuf) -> Self {
-		Self { archives_dir }
+		Self { archives_dir, chunk_size: DEFAULT_CHUNK_SIZE, buffer_size: BUFFER_SIZE }
 	}
 
 	/// Tar GZips a manifest.
@@ -21,22 +27,30 @@ impl Push {
 		manifest: PackageElement,
 		root_dir: PathBuf,
 		destination: PathBuf,
+		chunk_size: usize,
+		buffer_size: usize,
 	) -> Result<PackageElement, anyhow::Error> {
 		// create the archive builder
 		let file = File::create(destination.clone())?;
-		let encoder = GzEncoder::new(file, Compression::default());
-		let mut tar_builder = Builder::new(encoder);
+		{
+			let encoder = GzEncoder::new(file, Compression::default());
+			let mut tar_builder = Builder::new(encoder);
 
-		for (relative_path, absolute_path) in manifest.try_path_tuples()? {
-			let file = &mut std::fs::File::open(absolute_path)?;
-			tar_builder.append_file(relative_path, file)?;
+			for (relative_path, absolute_path) in manifest.try_path_tuples()? {
+				let file = &mut std::fs::File::open(absolute_path)?;
+				tar_builder.append_file(relative_path, file)?;
+			}
+
+			// Finish writing the tar archive
+			tar_builder.finish()?;
 		}
 
-		// Finish writing the tar archive
-		tar_builder.finish()?;
-
+		// Split the archive if needed
+		let destinations = split_archive(destination, &root_dir, chunk_size, buffer_size)?;
 		let mut new_manifest = PackageElement::new(root_dir);
-		new_manifest.add_sync_file(destination);
+		for dest in destinations {
+			new_manifest.add_sync_file(dest);
+		}
 		Ok(new_manifest)
 	}
 }
@@ -50,9 +64,90 @@ impl PushOperations for Push {
 				manifest,
 				self.archives_dir.clone(),
 				self.archives_dir.join(format!("{}.tar.gz", i)),
+				self.chunk_size,
+				self.buffer_size,
 			)?;
 			manifests.push(new_manifest);
 		}
 		Ok(Package(manifests))
 	}
+}
+
+fn split_archive<P: AsRef<Path>>(
+	archive: PathBuf,
+	root_dir: P,
+	chunk_size: usize,
+	buffer_size: usize,
+) -> Result<Vec<PathBuf>, anyhow::Error> {
+	let output_dir = root_dir.as_ref();
+
+	// Check the file size before proceeding with the split
+	let file_metadata = std::fs::metadata(&archive)?;
+	let file_size = file_metadata.len() as usize;
+	println!("Push split file size{file_size} chunksize:{chunk_size}",);
+	if file_size <= chunk_size {
+		return Ok(vec![archive]);
+	}
+
+	let archive_file = File::open(&archive)?;
+
+	let file_metadata = std::fs::metadata(&archive)?;
+	let file_size = file_metadata.len() as usize;
+	println!("PUSH {archive:?} archive_file size: {file_size}",);
+
+	std::fs::create_dir_all(output_dir)?;
+
+	let mut chunk_num = 0;
+	let mut buffer = vec![0; buffer_size];
+
+	let archive_relative_path = archive.strip_prefix(&output_dir)?;
+	let mut input_reader = BufReader::new(archive_file);
+
+	let mut chunk_list = vec![];
+	loop {
+		// Create a new file for the chunk
+		let chunk_path = output_dir.join(format!(
+			"{}_{:03}.chunk",
+			archive_relative_path.to_string_lossy(),
+			chunk_num
+		));
+
+		println!("PUSH create chunk_path: {chunk_path:?}",);
+		let mut chunk_file = File::create(&chunk_path)?;
+
+		let mut all_read_bytes = 0;
+		let end = loop {
+			// Read a part of the chunk into the buffer
+			let bytes_read = input_reader.read(&mut buffer)?;
+			println!("PUSH Read bytes: {bytes_read}",);
+			if bytes_read == 0 {
+				break true; // End of chunk file
+			}
+
+			// Write the buffer data to the output file
+			chunk_file.write_all(&buffer[..bytes_read])?;
+			all_read_bytes += bytes_read;
+			println!("PUSH all_read_bytes {all_read_bytes:?} chunk_size:{chunk_size}",);
+			if all_read_bytes >= chunk_size {
+				break false;
+			}
+		};
+
+		if all_read_bytes == 0 {
+			break; // End of chunk file and discard the current one.
+		}
+
+		let file_metadata = std::fs::metadata(&chunk_path)?;
+		let file_size = file_metadata.len() as usize;
+		println!("{chunk_path:?} chunk_file size: {file_size}",);
+
+		chunk_num += 1;
+		chunk_list.push(chunk_path);
+		if end {
+			break; // End of chunk file
+		}
+	}
+
+	println!("split_archive return {chunk_list:?}",);
+	Ok(chunk_list)
 }

--- a/util/syncador/src/backend/s3/shared_bucket/mod.rs
+++ b/util/syncador/src/backend/s3/shared_bucket/mod.rs
@@ -2,6 +2,8 @@ use super::bucket_connection;
 use aws_types::region::Region;
 use tracing::info;
 
+const UPLOAD_COMPLETE_MARKER_FILE_NAME: &str = "upload_complete.txt";
+
 pub mod metadata;
 pub mod pull;
 pub mod push;

--- a/util/syncador/src/backend/s3/shared_bucket/push.rs
+++ b/util/syncador/src/backend/s3/shared_bucket/push.rs
@@ -25,8 +25,8 @@ impl Push {
 
 	pub(crate) async fn upload_path(
 		&self,
-		relative_path: &std::path::Path,
-		full_path: &std::path::Path,
+		relative_path: std::path::PathBuf,
+		full_path: std::path::PathBuf,
 	) -> Result<(PutObjectOutput, PathBuf), anyhow::Error> {
 		let bucket = self.bucket_connection.bucket.clone();
 		let key =
@@ -55,7 +55,7 @@ impl Push {
 		// upload each file
 		let mut manifest_futures = Vec::new();
 		for (relative_path, full_path) in path_tuples {
-			let future = self.upload_path(&relative_path, &full_path);
+			let future = self.upload_path(relative_path, full_path);
 			manifest_futures.push(future);
 		}
 

--- a/util/syncador/src/files/package/mod.rs
+++ b/util/syncador/src/files/package/mod.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 /// A package is a collection of file system locations that are synced together.
 #[derive(Debug, Clone)]
@@ -34,10 +34,13 @@ impl PackageElement {
 		Self { sync_files: Vec::new(), root_dir }
 	}
 
-	pub fn try_path_tuples(&self) -> Result<Vec<(&Path, &PathBuf)>, anyhow::Error> {
+	pub fn try_path_tuples(&self) -> Result<Vec<(PathBuf, PathBuf)>, anyhow::Error> {
 		let mut tuples = Vec::new();
-		for file in &self.sync_files {
-			let relative_path = file.strip_prefix(&self.root_dir)?;
+		// Order file in case of chunk files that must be processed in order.
+		let mut ordered_files = self.sync_files.clone();
+		ordered_files.sort();
+		for file in ordered_files {
+			let relative_path = file.strip_prefix(&self.root_dir)?.to_path_buf();
 			tuples.push((relative_path, file));
 		}
 		Ok(tuples)


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

PR to test the leader sync file split in smaller chunks to avoid S3 transfer too big file error.
To test with current burdock rev.

<!--
Add your summary text here. 
 -->

# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->