### PR TITLE
[Node] Add retry on DA connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11882,6 +11882,7 @@ dependencies = [
  "tonic 0.12.3",
  "tonic-web",
  "tower 0.5.1",
+ "tracing",
 ]
 
 [[package]]

--- a/protocol-units/da/movement/protocol/client/Cargo.toml
+++ b/protocol-units/da/movement/protocol/client/Cargo.toml
@@ -20,6 +20,7 @@ tower = { workspace = true }
 http-body-util = { workspace = true }
 bytes = { workspace = true } 
 anyhow = { workspace = true }
+tracing = { workspace = true }
 
 
 [lints]

--- a/util/godfig/src/backend/config_file/mod.rs
+++ b/util/godfig/src/backend/config_file/mod.rs
@@ -44,7 +44,7 @@ impl ConfigFile {
 		}
 
 		let json: serde_json::Value = serde_json::from_str(&contents)
-			.map_err(|e| GodfigBackendError::TypeContractMismatch(e.to_string()))?;
+			.map_err(|e| GodfigBackendError::ConfigDeserializationError(e.to_string()))?;
 
 		let keys = key.into();
 		let mut current = &json;

--- a/util/godfig/src/backend/mod.rs
+++ b/util/godfig/src/backend/mod.rs
@@ -7,8 +7,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum GodfigBackendError {
-	#[error("Type Contract Mismatch")]
-	TypeContractMismatch(String),
+	#[error("An error occurs during config deserialization: {0}")]
+	ConfigDeserializationError(String),
 	#[error("Backend Error: {0}")]
 	BackendError(#[from] anyhow::Error),
 	#[error("IO Error: {0}")]

--- a/util/signing/interface/src/key/mod.rs
+++ b/util/signing/interface/src/key/mod.rs
@@ -217,18 +217,18 @@ impl TryFromCanonicalString for Key {
 	/// Example canonical string: "movement/prod/full_node/mcr_settlement/signer/validator/0"
 	fn try_from_canonical_string(s: &str) -> Result<Self, String> {
 		let parts: Vec<&str> = s.split('/').collect();
-		if parts.len() != 7 {
-			return Err(format!("invalid key: {}", s));
+		if parts.len() != 8 {
+			return Err(format!("invalid key, bad number of elements {:?}: '{}'", parts, s));
 		}
 
 		Ok(Self {
-			org: Organization::try_from_canonical_string(parts[0])?,
-			environment: Environment::try_from_canonical_string(parts[1])?,
-			software_unit: SoftwareUnit::try_from_canonical_string(parts[2])?,
-			usage: Usage::try_from_canonical_string(parts[3])?,
-			allowed_roles: AllowedRoles::try_from_canonical_string(parts[4])?,
-			key_name: parts[5].to_string(),
-			app_replica: Some(parts[6].to_string()),
+			org: Organization::try_from_canonical_string(parts[1])?,
+			environment: Environment::try_from_canonical_string(parts[2])?,
+			software_unit: SoftwareUnit::try_from_canonical_string(parts[3])?,
+			usage: Usage::try_from_canonical_string(parts[4])?,
+			allowed_roles: AllowedRoles::try_from_canonical_string(parts[5])?,
+			key_name: parts[6].to_string(),
+			app_replica: Some(parts[7].to_string()),
 		})
 	}
 }


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.
- 
Sometime during the docker container start, the full node start too early and the DA light node didn't have opened its entry point. It results in an error during the full node start, then a restart of the whole stack.
This scenario can repeat several times until the timing is correct.
This PR add a retry for this connection so that full node start is less sensible to timing issues during the start.

I've changed the error message when the config can't be parsed.

<!--
Add your summary text here. 
 -->

# Changelog
* Ad a retry when the Http2 connection fails during init. 
* add a better error message when the config can't be parsed
* 
<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->
To test, you can start a leader and its follower:
```
CELESTIA_LOG_LEVEL=FATAL nix develop --extra-experimental-features nix-command --extra-experimental-features flakes --command bash  -c "just movement-full-node native build.setup.eth-local.celestia-local.test-followers --keep-tui"
```
The test execution should have no errors.
# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->