### PR TITLE
Config parameter for celestia light node store directory

### DIFF
--- a/protocol-units/da/movement/protocol/celestia-runners/src/celestia_light/arabica.rs
+++ b/protocol-units/da/movement/protocol/celestia-runners/src/celestia_light/arabica.rs
@@ -1,5 +1,5 @@
-use std::ffi::OsStr;
-use std::iter;
+use commander::Run;
+use tokio::process::Command;
 
 #[derive(Debug, Clone)]
 pub struct Arabica;
@@ -11,37 +11,30 @@ impl Arabica {
 
 	pub async fn run(
 		&self,
-		dot_movement: dot_movement::DotMovement,
+		_dot_movement: dot_movement::DotMovement,
 		config: movement_da_util::config::Config,
 	) -> Result<(), anyhow::Error> {
-		let node_store_dir = dot_movement
-			.get_path()
-			.join("celestia")
-			.join(&config.appd.celestia_chain_id)
-			.join(".celestia-light");
-
-		commander::run_command(
-			"celestia",
-			[
-				"light",
-				"start",
-				"--keyring.backend",
-				"test",
-				"--keyring.keyname",
-				&config.light.key_name,
-				"--core.ip",
-				"validator-1.celestia-arabica-11.com",
-				"--p2p.network",
-				"arabica",
-				"--log.level",
-				"FATAL",
-				"--node.store",
-			]
-			.iter()
-			.map(AsRef::<OsStr>::as_ref)
-			.chain(iter::once(node_store_dir.as_ref())),
-		)
-		.await?;
+		let mut command = Command::new("celestia");
+		command.args([
+			"light",
+			"start",
+			"--keyring.backend",
+			"test",
+			"--keyring.keyname",
+			&config.light.key_name,
+			"--core.ip",
+			"validator-1.celestia-arabica-11.com",
+			"--p2p.network",
+			"arabica",
+			"--log.level",
+			"FATAL",
+		]);
+		if let Some(path) = &config.light.node_store {
+			command.arg("--node.store");
+			command.arg(path);
+		}
+		// FIXME: don't need to capture output
+		command.run_and_capture_output().await?;
 
 		Ok(())
 	}

--- a/protocol-units/da/movement/protocol/celestia-runners/src/celestia_light/arabica.rs
+++ b/protocol-units/da/movement/protocol/celestia-runners/src/celestia_light/arabica.rs
@@ -1,5 +1,4 @@
-use commander::Run;
-use tokio::process::Command;
+use commander::Command;
 
 #[derive(Debug, Clone)]
 pub struct Arabica;

--- a/protocol-units/da/movement/protocol/celestia-runners/src/celestia_light/mainnet.rs
+++ b/protocol-units/da/movement/protocol/celestia-runners/src/celestia_light/mainnet.rs
@@ -1,5 +1,4 @@
-use commander::Run;
-use tokio::process::Command;
+use commander::Command;
 
 #[derive(Debug, Clone)]
 pub struct Mainnet;

--- a/protocol-units/da/movement/protocol/celestia-runners/src/celestia_light/mainnet.rs
+++ b/protocol-units/da/movement/protocol/celestia-runners/src/celestia_light/mainnet.rs
@@ -1,4 +1,5 @@
-use std::{ffi::OsStr, iter};
+use commander::Run;
+use tokio::process::Command;
 
 #[derive(Debug, Clone)]
 pub struct Mainnet;
@@ -10,37 +11,30 @@ impl Mainnet {
 
 	pub async fn run(
 		&self,
-		dot_movement: dot_movement::DotMovement,
+		_dot_movement: dot_movement::DotMovement,
 		config: movement_da_util::config::Config,
 	) -> Result<(), anyhow::Error> {
-		let node_store_dir = dot_movement
-			.get_path()
-			.join("celestia")
-			.join(&config.appd.celestia_chain_id)
-			.join(".celestia-light");
-
-		commander::run_command(
+		let mut command = Command::new("celestia");
+		command.args([
+			"light",
+			"start",
+			"--keyring.backend",
+			"test",
+			"--keyring.keyname",
+			&config.light.key_name,
+			"--core.ip",
+			"rpc.celestia.pops.one",
+			"--p2p.network",
 			"celestia",
-			[
-				"light",
-				"start",
-				"--keyring.backend",
-				"test",
-				"--keyring.keyname",
-				&config.light.key_name,
-				"--core.ip",
-				"rpc.celestia.pops.one",
-				"--p2p.network",
-				"celestia",
-				"--log.level",
-				"FATAL",
-				"--node.store",
-			]
-			.iter()
-			.map(AsRef::<OsStr>::as_ref)
-			.chain(iter::once(node_store_dir.as_ref())),
-		)
-		.await?;
+			"--log.level",
+			"FATAL",
+		]);
+		if let Some(path) = &config.light.node_store {
+			command.arg("--node.store");
+			command.arg(path);
+		}
+		// FIXME: don't need to capture output
+		command.run_and_capture_output().await?;
 
 		Ok(())
 	}

--- a/protocol-units/da/movement/protocol/celestia-runners/src/celestia_light/mocha.rs
+++ b/protocol-units/da/movement/protocol/celestia-runners/src/celestia_light/mocha.rs
@@ -1,5 +1,4 @@
-use commander::Run;
-use tokio::process::Command;
+use commander::Command;
 
 #[derive(Debug, Clone)]
 pub struct Mocha;

--- a/protocol-units/da/movement/protocol/celestia-runners/src/celestia_light/mocha.rs
+++ b/protocol-units/da/movement/protocol/celestia-runners/src/celestia_light/mocha.rs
@@ -1,4 +1,5 @@
-use std::{ffi::OsStr, iter};
+use commander::Run;
+use tokio::process::Command;
 
 #[derive(Debug, Clone)]
 pub struct Mocha;
@@ -10,37 +11,30 @@ impl Mocha {
 
 	pub async fn run(
 		&self,
-		dot_movement: dot_movement::DotMovement,
+		_dot_movement: dot_movement::DotMovement,
 		config: movement_da_util::config::Config,
 	) -> Result<(), anyhow::Error> {
-		let node_store_dir = dot_movement
-			.get_path()
-			.join("celestia")
-			.join(&config.appd.celestia_chain_id)
-			.join(".celestia-light");
-
-		commander::run_command(
-			"celestia",
-			[
-				"light",
-				"start",
-				"--keyring.backend",
-				"test",
-				"--keyring.keyname",
-				&config.light.key_name,
-				"--core.ip",
-				"rpc-mocha.pops.one",
-				"--p2p.network",
-				"mocha",
-				"--log.level",
-				"FATAL",
-				"--node.store",
-			]
-			.iter()
-			.map(AsRef::<OsStr>::as_ref)
-			.chain(iter::once(node_store_dir.as_ref())),
-		)
-		.await?;
+		let mut command = Command::new("celestia");
+		command.args([
+			"light",
+			"start",
+			"--keyring.backend",
+			"test",
+			"--keyring.keyname",
+			&config.light.key_name,
+			"--core.ip",
+			"rpc-mocha.pops.one",
+			"--p2p.network",
+			"mocha",
+			"--log.level",
+			"FATAL",
+		]);
+		if let Some(path) = &config.light.node_store {
+			command.arg("--node.store");
+			command.arg(path);
+		}
+		// FIXME: don't need to capture output
+		command.run_and_capture_output().await?;
 
 		Ok(())
 	}

--- a/protocol-units/da/movement/protocol/setup/src/common/celestia.rs
+++ b/protocol-units/da/movement/protocol/setup/src/common/celestia.rs
@@ -1,14 +1,13 @@
 use crate::common;
 use anyhow::Context;
 use celestia_types::nmt::Namespace;
-use commander::run_command;
+use commander::Run;
 use dot_movement::DotMovement;
 use movement_da_util::config::Config;
 use rand::Rng;
+use tokio::process::Command;
 use tracing::info;
 
-use std::ffi::OsStr;
-use std::iter;
 use std::path::PathBuf;
 
 fn random_10_bytes() -> [u8; 10] {
@@ -42,6 +41,12 @@ pub fn initialize_celestia_config(
 		config.appd.celestia_chain_id.clone()
 	};
 
+	// set the node store directory accordingly to the chain id
+	config
+		.light
+		.node_store
+		.replace(celestia_chain_dir(&dot_movement, &config).join(".celestia-light"));
+
 	// update the app path with the chain id
 	config.appd.celestia_path.replace(
 		celestia_chain_dir(&dot_movement, &config)
@@ -64,41 +69,36 @@ pub fn initialize_celestia_config(
 }
 
 pub async fn celestia_light_init(
-	dot_movement: &DotMovement,
+	_dot_movement: &DotMovement,
 	config: &Config,
 	network: &str,
 ) -> Result<(), anyhow::Error> {
-	let node_store_dir = celestia_chain_dir(dot_movement, config).join(".celestia-light");
 	// celestia light init --p2p.network <network> --keyring.backend test --node_store <dir>
-	run_command(
-		"celestia",
-		["light", "init", "--p2p.network", network, "--keyring.backend", "test", "--node.store"]
-			.iter()
-			.map(AsRef::<OsStr>::as_ref)
-			.chain(iter::once(node_store_dir.as_ref())),
-	)
-	.await?;
+	let mut command = Command::new("celestia");
+	command.args(["light", "init", "--p2p.network", network, "--keyring.backend", "test"]);
+	if let Some(path) = &config.light.node_store {
+		command.arg("--node.store");
+		command.arg(path);
+	}
+	// FIXME: the output does not need to be captured
+	command.run_and_capture_output().await?;
 
 	Ok(())
 }
 
 pub async fn get_auth_token(
-	dot_movement: &DotMovement,
+	_dot_movement: &DotMovement,
 	config: &Config,
 	network: &str,
 ) -> Result<String, anyhow::Error> {
-	let node_store_dir = celestia_chain_dir(dot_movement, config).join(".celestia-light");
 	// celestia light auth admin --p2p.network mocha --node.store <dir>
-	let auth_token = run_command(
-		"celestia",
-		["light", "auth", "admin", "--p2p.network", network, "--node.store"]
-			.iter()
-			.map(AsRef::<OsStr>::as_ref)
-			.chain(iter::once(node_store_dir.as_ref())),
-	)
-	.await?
-	.trim()
-	.to_string();
+	let mut command = Command::new("celestia");
+	command.args(["light", "auth", "admin", "--p2p.network", network]);
+	if let Some(path) = &config.light.node_store {
+		command.arg("--node.store");
+		command.arg(path);
+	}
+	let auth_token = command.run_and_capture_output().await?.trim().to_string();
 
 	Ok(auth_token)
 }

--- a/protocol-units/da/movement/protocol/setup/src/common/celestia.rs
+++ b/protocol-units/da/movement/protocol/setup/src/common/celestia.rs
@@ -1,11 +1,10 @@
 use crate::common;
 use anyhow::Context;
 use celestia_types::nmt::Namespace;
-use commander::Run;
+use commander::Command;
 use dot_movement::DotMovement;
 use movement_da_util::config::Config;
 use rand::Rng;
-use tokio::process::Command;
 use tracing::info;
 
 use std::path::PathBuf;

--- a/protocol-units/da/movement/protocol/util/src/config/default.rs
+++ b/protocol-units/da/movement/protocol/util/src/config/default.rs
@@ -3,6 +3,7 @@ use celestia_types::nmt::Namespace;
 use godfig::env_default;
 
 use std::env;
+use std::path::PathBuf;
 
 // The default hostname for the Celestia RPC
 env_default!(
@@ -182,3 +183,7 @@ env_default!(
 	String,
 	"movement_celestia_light".into()
 );
+
+pub fn default_celestia_light_node_store() -> Option<PathBuf> {
+	std::env::var_os("CELESTIA_LIGHT_NODE_STORE").map(Into::into)
+}

--- a/protocol-units/da/movement/protocol/util/src/config/light.rs
+++ b/protocol-units/da/movement/protocol/util/src/config/light.rs
@@ -1,15 +1,24 @@
-use super::default::default_celestia_light_node_key_name;
+use super::default::{default_celestia_light_node_key_name, default_celestia_light_node_store};
 
 use serde::{Deserialize, Serialize};
+
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Config {
 	/// Name of the node's signing key in the keyring
+	#[serde(default = "default_celestia_light_node_key_name")]
 	pub key_name: String,
+	/// Path name of the node store directory
+	#[serde(default)]
+	pub node_store: Option<PathBuf>,
 }
 
 impl Default for Config {
 	fn default() -> Self {
-		Self { key_name: default_celestia_light_node_key_name() }
+		Self {
+			key_name: default_celestia_light_node_key_name(),
+			node_store: default_celestia_light_node_store(),
+		}
 	}
 }

--- a/util/commander/src/lib.rs
+++ b/util/commander/src/lib.rs
@@ -4,7 +4,6 @@ use itertools::Itertools;
 use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::signal::unix::{signal, SignalKind};
-use tokio::task::JoinHandle;
 use tracing::info;
 
 use std::ffi::OsStr;
@@ -115,58 +114,6 @@ where
 	}
 
 	Ok(stdout_output)
-}
-
-/// Runs a command, piping its output to stdout and stderr, and returns the stdout output if successful.
-pub async fn spawn_command(
-	command: String,
-	args: Vec<String>,
-) -> Result<(Option<u32>, JoinHandle<Result<String, anyhow::Error>>)> {
-	// print command out with args joined by space
-	tracing::info!("spawn command: {} {}", command, args.join(" "));
-
-	let mut child = Command::new(&command)
-		.args(&args)
-		.stdout(Stdio::piped())
-		.stderr(Stdio::piped())
-		.spawn()?;
-
-	let process_id = child.id();
-	let join_handle = tokio::spawn({
-		async move {
-			let stdout = child.stdout.take().ok_or_else(|| {
-				anyhow::anyhow!("Failed to capture standard output from command {}", command)
-			})?;
-			let stderr = child.stderr.take().ok_or_else(|| {
-				anyhow::anyhow!("Failed to capture standard error from command {}", command)
-			})?;
-
-			let mut stdout_output = String::new();
-			let mut stderr_output = String::new();
-
-			let stdout_writer = io::stdout();
-			let stderr_writer = io::stderr();
-
-			let stdout_future = pipe_output(stdout, stdout_writer, &mut stdout_output);
-			let stderr_future = pipe_error_output(stderr, stderr_writer, &mut stderr_output);
-
-			let _ = try_join(stdout_future, stderr_future).await;
-
-			let status = child.wait().await?;
-			if !status.success() {
-				return Err(anyhow::anyhow!(
-					"Command {} spawn failed with args {:?}\nError Output: {}",
-					command,
-					args,
-					stderr_output
-				));
-			}
-
-			Ok(stdout_output)
-		}
-	});
-
-	Ok((process_id, join_handle))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add a configuration field for the `--node.store` parameter passed to the light node runner.
The default is overridable with the `CELESTIA_LIGHT_NODE_STORE` environment variable.

`commander` gets its own `Command` wrapper to improve ergonomics.