### PR TITLE
test: fix unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12219,6 +12219,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "ed25519-dalek 2.1.1",
+ "hex",
  "maptos-dof-execution",
  "maptos-execution-util",
  "movement-signer",

--- a/protocol-units/da/movement/protocol/util/src/blob/ir/blob.rs
+++ b/protocol-units/da/movement/protocol/util/src/blob/ir/blob.rs
@@ -13,17 +13,17 @@ pub struct InnerSignedBlobV1<C>
 where
 	C: Curve,
 {
-	pub data: InnerSignedBlobV1Data<C>,
-	pub signature: Vec<u8>,
-	pub signer: Vec<u8>,
-	pub id: Id,
+	data: InnerSignedBlobV1Data<C>,
+	signature: Vec<u8>,
+	signer: Vec<u8>,
+	id: Id,
 }
 
 impl<C> InnerSignedBlobV1<C>
 where
 	C: Curve + Verify<C> + Digester<C>,
 {
-	pub fn new(
+	pub(crate) fn new(
 		data: InnerSignedBlobV1Data<C>,
 		signature: Vec<u8>,
 		signer: Vec<u8>,
@@ -162,29 +162,6 @@ where
 			DaBlob::SignedV1(inner) => inner.try_verify(),
 			DaBlob::DigestV1(_) => Ok(()),
 		}
-	}
-}
-
-#[cfg(test)]
-pub mod test {
-
-	use super::*;
-	use movement_da_light_node_signer::Signer;
-	use movement_signer::cryptography::secp256k1::Secp256k1;
-	use movement_signer_local::signer::LocalSigner;
-
-	#[tokio::test]
-	async fn test_cannot_change_id_and_verify() -> Result<(), anyhow::Error> {
-		let blob = InnerSignedBlobV1Data::new(vec![1, 2, 3], 123);
-		let signer = Signer::new(LocalSigner::<Secp256k1>::random());
-		let signed_blob = blob.try_to_sign(&signer).await?;
-
-		let mut changed_blob = signed_blob.clone();
-		changed_blob.id = Id::new(vec![1, 2, 3, 4]);
-
-		assert!(changed_blob.try_verify().is_err());
-
-		Ok(())
 	}
 }
 

--- a/protocol-units/execution/maptos/opt-executor/src/executor/execution.rs
+++ b/protocol-units/execution/maptos/opt-executor/src/executor/execution.rs
@@ -212,11 +212,14 @@ mod tests {
 		ed25519::{Ed25519PrivateKey, Ed25519Signature},
 		HashValue, PrivateKey, Uniform,
 	};
-	use aptos_sdk::{transaction_builder::TransactionFactory, types::LocalAccount};
+	use aptos_sdk::{
+		transaction_builder::TransactionFactory,
+		types::{AccountKey, LocalAccount},
+	};
 	use aptos_storage_interface::state_view::DbStateViewAtVersion;
 	use aptos_types::{
 		account_address::AccountAddress,
-		account_config::AccountResource,
+		account_config::{aptos_test_root_address, AccountResource},
 		block_executor::partitioner::ExecutableTransactions,
 		block_metadata::BlockMetadata,
 		chain_id::ChainId,
@@ -295,8 +298,11 @@ mod tests {
 			.maptos_private_key_signer_identifier
 			.try_raw_private_key()?;
 		let private_key = Ed25519PrivateKey::try_from(raw_private_key.as_slice())?;
-		let root_account =
-			LocalAccount::from_private_key(private_key.to_encoded_string()?.as_str(), 0)?;
+		let root_account = LocalAccount::new(
+			aptos_test_root_address(),
+			AccountKey::from_private_key(private_key),
+			0,
+		);
 
 		// Seed for random number generator, used here to generate predictable results in a test environment.
 		let seed = [3u8; 32];
@@ -403,8 +409,11 @@ mod tests {
 			.maptos_private_key_signer_identifier
 			.try_raw_private_key()?;
 		let private_key = Ed25519PrivateKey::try_from(raw_private_key.as_slice())?;
-		let root_account =
-			LocalAccount::from_private_key(private_key.to_encoded_string()?.as_str(), 0)?;
+		let root_account = LocalAccount::new(
+			aptos_test_root_address(),
+			AccountKey::from_private_key(private_key),
+			0,
+		);
 
 		// Seed for random number generator, used here to generate predictable results in a test environment.
 		let seed = [3u8; 32];

--- a/util/signing/testing/Cargo.toml
+++ b/util/signing/testing/Cargo.toml
@@ -19,7 +19,7 @@ async-trait = { workspace = true }
 maptos-dof-execution = { workspace = true }
 maptos-execution-util = { workspace = true }
 movement-signing-aptos = { workspace = true }
-movement-signer-loader = { workspace = true }   
+movement-signer-loader = { workspace = true }
 movement-signer-local = { workspace = true }
 movement-signer-aws-kms = { workspace = true }
 movement-signing-eth = { workspace = true }
@@ -28,6 +28,7 @@ aptos-types = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
 ed25519-dalek = { workspace = true, features = ["rand_core"] }
+hex = { workspace = true }
 # Workspace is on rand 0.7 due largely to aptos-core
 rand = "0.8"
 sha3 = "0.10.8"

--- a/util/signing/testing/tests/execute.rs
+++ b/util/signing/testing/tests/execute.rs
@@ -12,7 +12,6 @@ use aptos_types::transaction::{
 };
 
 use anyhow::Context;
-use aptos_crypto::ValidCryptoMaterialStringExt;
 use movement_signer_loader::identifiers::{local::Local, SignerIdentifier};
 use tempfile::TempDir;
 
@@ -45,9 +44,9 @@ async fn execute_signed_transaction() -> Result<(), anyhow::Error> {
 	let private_key = Ed25519PrivateKey::generate_for_testing();
 	let mut config = Config::default();
 	let signing_key = ed25519_dalek::SigningKey::from_bytes(&private_key.to_bytes());
-	config.chain.maptos_private_key_signer_identifier = SignerIdentifier::Local(Local {
-		private_key_hex_bytes: private_key.to_encoded_string()?.to_string(),
-	});
+	let private_key_hex_bytes = hex::encode(&private_key.to_bytes());
+	config.chain.maptos_private_key_signer_identifier =
+		SignerIdentifier::Local(Local { private_key_hex_bytes });
 	let signer = TestSigner::new(signing_key);
 	let (executor, _tempdir) = setup(config)?;
 	let transaction = create_signed_transaction(&signer).await?;


### PR DESCRIPTION
# Summary

- **Categories**: `protocol-units`.

Reverting the LocalAccount initialization to the way it was done before remote signing (#993) was merged makes the tests pass, though I don't yet understand why.

# Testing

```
nix develop --extra-experimental-features "nix-command flakes" --command bash -c "cargo test -p maptos-opt-executor"
```

# Outstanding issues

Why does use of `aptos_test_root_address()` make the transactions be accepted by the executor, while the address and the signing key don't actually match?