### PR TITLE
[postconfirmation] attester rewards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ venv
 *.env
 .debug
 .out
+
+.aiconfig

--- a/protocol-units/settlement/mcr/contracts/script/DeployMCRDev.s.sol
+++ b/protocol-units/settlement/mcr/contracts/script/DeployMCRDev.s.sol
@@ -32,7 +32,7 @@ contract DeployMCRDev is Script {
         address[] memory custodians = new address[](1);
         custodians[0] = address(moveTokenProxy);
         bytes memory mcrData = abi.encodeCall(
-            MCR.initialize, (IMovementStaking(address(movementStakingProxy)), 0, 10, 4 seconds, custodians, 1 days)
+            MCR.initialize, (IMovementStaking(address(movementStakingProxy)), 0, 10, 4 seconds, custodians, 1 days, address(moveTokenProxy))
         );
         address mcrProxy = address(new ERC1967Proxy(address(mcrImplementation), mcrData));
         MCR mcr = MCR(mcrProxy);

--- a/protocol-units/settlement/mcr/contracts/src/settlement/MCR.sol
+++ b/protocol-units/settlement/mcr/contracts/src/settlement/MCR.sol
@@ -48,7 +48,8 @@ contract MCR is Initializable, BaseSettlement, MCRStorage, IMCR {
         uint256 _leadingSuperBlockTolerance,
         uint256 _epochDuration, // in time units
         address[] memory _custodians,
-        uint256 _acceptorTerm // in time units
+        uint256 _acceptorTerm, // in time units
+        address _moveTokenAddress  // the primary custodian for rewards in the staking contract
     ) public initializer {
         __BaseSettlement_init_unchained();
         stakingContract = _stakingContract;
@@ -58,6 +59,7 @@ contract MCR is Initializable, BaseSettlement, MCRStorage, IMCR {
         grantCommitmentAdmin(msg.sender);
         grantTrustedAttester(msg.sender);
         acceptorTerm = _acceptorTerm;
+        moveTokenAddress = _moveTokenAddress;
     }
 
     function grantCommitmentAdmin(address account) public {
@@ -349,6 +351,7 @@ contract MCR is Initializable, BaseSettlement, MCRStorage, IMCR {
     /// @dev Moreover, due to the leadingBlockTolerance, the assigned epoch for a height could be ahead of the actual epoch. 
     /// @dev solution is to move to the next epoch and count votes there
     function attemptPostconfirmOrRollover(uint256 superBlockHeight) internal returns (bool) {
+        console.log("[attemptPostconfirmOrRollover] attempting postconfirm or rollover at superblock height %s", superBlockHeight);
         uint256 superBlockEpoch = superBlockHeightAssignedEpoch[superBlockHeight];
         if (getLastPostconfirmedSuperBlockHeight() == 0) {
             console.log("[attemptPostconfirmOrRollover] genesis");
@@ -467,6 +470,14 @@ contract MCR is Initializable, BaseSettlement, MCRStorage, IMCR {
             revert UnacceptableSuperBlockCommitment();
         }
 
+        // Record reward points for all attesters who committed to the winning commitment
+        address[] memory attesters = getStakedAttestersForAcceptingEpoch();
+        for (uint256 i = 0; i < attesters.length; i++) {
+            if (commitments[superBlockCommitment.height][attesters[i]].commitment == superBlockCommitment.commitment) {
+                attesterRewardPoints[currentAcceptingEpoch][attesters[i]]++;
+            }
+        }
+
         versionedPostconfirmedSuperBlocks[postconfirmedSuperBlocksVersion][superBlockCommitment.height] = superBlockCommitment;
         lastPostconfirmedSuperBlockHeight = superBlockCommitment.height;
         postconfirmedBy[superBlockCommitment.height] = attester;
@@ -491,10 +502,30 @@ contract MCR is Initializable, BaseSettlement, MCRStorage, IMCR {
         // stakingContract.slash(custodians, attesters, amounts, refundAmounts);
     }
 
-    /**
-     * @dev nonReentrant because there is no need to reenter this function. It should be called iteratively. Marked on the internal method to simplify risks from complex calling patterns. This also calls an external contract.
-     */
+    /// @dev nonReentrant because there is no need to reenter this function. It should be called iteratively. 
+    /// @dev Marked on the internal method to simplify risks from complex calling patterns. This also calls an external contract.
     function rollOverEpoch() internal {
+        // Get all attesters who earned points in the current epoch
+        uint256 acceptingEpoch = getAcceptingEpoch();
+        address[] memory attesters = getStakedAttestersForAcceptingEpoch();
+        
+        console.log("[rollOverEpoch] Attesters length %s", attesters.length);
+        // reward
+        // TODO we should optimize to not loop over the entire custodian set
+        for (uint256 i = 0; i < attesters.length; i++) {
+            if (attesterRewardPoints[acceptingEpoch][attesters[i]] > 0) {
+                // TODO: make this configurable and set it on instance creation
+                uint256 rewardPerPoint = 1;
+                uint256 reward = attesterRewardPoints[acceptingEpoch][attesters[i]] * rewardPerPoint * getAttesterStakeForAcceptingEpoch(attesters[i]);
+                // the staking contract is the custodian
+                console.log("[rollOverEpoch] Rewarding attester %s with %s", attesters[i], reward);
+                console.log("[rollOverEpoch] Staking contract is %s", address(stakingContract));
+                console.log("[rollOverEpoch] Move token address is %s", moveTokenAddress);
+                stakingContract.reward(attesters[i], reward, moveTokenAddress);
+                delete attesterRewardPoints[acceptingEpoch][attesters[i]];
+            }
+        }
+
         stakingContract.rollOverEpoch();
         setAcceptor();
     }
@@ -526,5 +557,13 @@ contract MCR is Initializable, BaseSettlement, MCRStorage, IMCR {
     /// @notice get the timestamp when a commitment was first seen
     function getCommitmentFirstSeenAt(uint256 height, bytes32 commitment) public view returns (uint256) {
         return commitmentFirstSeenAt[height][commitment];
+    }
+
+    /// @notice Gets the reward points for an attester in a given epoch
+    /// @param epoch The epoch to get the reward points for
+    /// @param attester The attester to get the reward points for
+    /// @return The reward points for the attester in the given epoch
+    function getAttesterRewardPoints(uint256 epoch, address attester) public view returns (uint256) {
+        return attesterRewardPoints[epoch][attester];
     }
 }

--- a/protocol-units/settlement/mcr/contracts/src/settlement/MCR.sol
+++ b/protocol-units/settlement/mcr/contracts/src/settlement/MCR.sol
@@ -514,7 +514,6 @@ contract MCR is Initializable, BaseSettlement, MCRStorage, IMCR {
         
         console.log("[rollOverEpoch] Attesters length at epoch %s is %s", acceptingEpoch, attesters.length);
         // reward
-        // TODO we should optimize to not loop over the entire custodian set
         for (uint256 i = 0; i < attesters.length; i++) {
             if (attesterRewardPoints[acceptingEpoch][attesters[i]] > 0) {
                 // TODO: make this configurable and set it on instance creation
@@ -525,6 +524,7 @@ contract MCR is Initializable, BaseSettlement, MCRStorage, IMCR {
                 console.log("[rollOverEpoch] Staking contract is %s", address(stakingContract));
                 console.log("[rollOverEpoch] Move token address is %s", moveTokenAddress);
                 console.log("[rollOverEpoch] msg.sender is %s", msg.sender);
+                // rewards are currently paid out from the mcr domain
                 stakingContract.rewardFromDomain(attesters[i], reward, moveTokenAddress);
                 delete attesterRewardPoints[acceptingEpoch][attesters[i]];
             }

--- a/protocol-units/settlement/mcr/contracts/src/settlement/MCR.sol
+++ b/protocol-units/settlement/mcr/contracts/src/settlement/MCR.sol
@@ -377,6 +377,7 @@ contract MCR is Initializable, BaseSettlement, MCRStorage, IMCR {
         while (getAcceptingEpoch() < superBlockEpoch) {
             // TODO only permit rollover after some liveness criteria for the acceptor, as this is related to the reward model (rollovers should be rewarded)
             rollOverEpoch();
+            console.log("[attemptPostconfirmOrRollover] rolled over epoch to %s", getAcceptingEpoch());
         }
 
         // TODO only permit postconfirmation after some liveness criteria for the acceptor, as this is related to the reward model (postconfirmation should be rewarded)
@@ -401,6 +402,7 @@ contract MCR is Initializable, BaseSettlement, MCRStorage, IMCR {
             if (totalStakeOnCommitment >= supermajority) {
                 _postconfirmSuperBlockCommitment(superBlockCommitment, msg.sender);
                 successfulPostconfirmation = true;
+                console.log("[attemptPostconfirmOrRollover] successful postconfirmation at height %s", superBlockHeight);
 
                 // TODO: for rewards we have to run through all the attesters, as we need to acknowledge that they get rewards. 
 
@@ -414,9 +416,10 @@ contract MCR is Initializable, BaseSettlement, MCRStorage, IMCR {
         // we rollover the epoch to give the next attesters a chance
         if (!successfulPostconfirmation && getPresentEpoch() > getAcceptingEpoch()) {
             rollOverEpoch();
+            console.log("[attemptPostconfirmOrRollover] rolled over to epoch", getAcceptingEpoch());
             return true; // we have to retry the postconfirmation at the next epoch again
         }
-
+        console.log("[attemptPostconfirmOrRollover] no successful postconfirmation");
         return false;
     }
 
@@ -521,7 +524,8 @@ contract MCR is Initializable, BaseSettlement, MCRStorage, IMCR {
                 console.log("[rollOverEpoch] Rewarding attester %s with %s", attesters[i], reward);
                 console.log("[rollOverEpoch] Staking contract is %s", address(stakingContract));
                 console.log("[rollOverEpoch] Move token address is %s", moveTokenAddress);
-                stakingContract.reward(attesters[i], reward, moveTokenAddress);
+                console.log("[rollOverEpoch] msg.sender is %s", msg.sender);
+                stakingContract.rewardFromDomain(attesters[i], reward, moveTokenAddress);
                 delete attesterRewardPoints[acceptingEpoch][attesters[i]];
             }
         }

--- a/protocol-units/settlement/mcr/contracts/src/settlement/MCR.sol
+++ b/protocol-units/settlement/mcr/contracts/src/settlement/MCR.sol
@@ -512,7 +512,7 @@ contract MCR is Initializable, BaseSettlement, MCRStorage, IMCR {
         uint256 acceptingEpoch = getAcceptingEpoch();
         address[] memory attesters = getStakedAttestersForAcceptingEpoch();
         
-        console.log("[rollOverEpoch] Attesters length %s", attesters.length);
+        console.log("[rollOverEpoch] Attesters length at epoch %s is %s", acceptingEpoch, attesters.length);
         // reward
         // TODO we should optimize to not loop over the entire custodian set
         for (uint256 i = 0; i < attesters.length; i++) {

--- a/protocol-units/settlement/mcr/contracts/src/settlement/MCRStorage.sol
+++ b/protocol-units/settlement/mcr/contracts/src/settlement/MCRStorage.sol
@@ -8,6 +8,9 @@ contract MCRStorage {
 
     IMovementStaking public stakingContract;
 
+    // The MOVE token address, which is the primary custodian for rewards in the staking contract
+    address public moveTokenAddress;
+
     // the number of superBlocks that can be submitted ahead of the lastPostconfirmedSuperBlockHeight
     // this allows for things like batching to take place without some attesters locking down the attester set by pushing too far ahead
     // ? this could be replaced by a 2/3 stake vote on the superBlock height to epoch assignment
@@ -83,6 +86,9 @@ contract MCRStorage {
     // versioned scheme for postconfirmed superBlocks
     mapping(uint256 => mapping(uint256 superBlockHeight => SuperBlockCommitment)) public versionedPostconfirmedSuperBlocks;
     uint256 public postconfirmedSuperBlocksVersion;
+
+    // track reward points for attesters
+    mapping(uint256 epoch => mapping(address attester => uint256 points)) public attesterRewardPoints;
 
     uint256[47] internal __gap;
 

--- a/protocol-units/settlement/mcr/contracts/src/settlement/MCRStorage.sol
+++ b/protocol-units/settlement/mcr/contracts/src/settlement/MCRStorage.sol
@@ -54,6 +54,9 @@ contract MCRStorage {
     // track the total stake accumulate for each commitment for each superBlock height
     mapping(uint256 superBlockHeight => mapping(bytes32 commitement => uint256 stake)) public commitmentStakes;
 
+    // track when each commitment was first seen for each superBlock height
+    mapping(uint256 superBlockHeight => mapping(bytes32 commitment => uint256 timestamp)) public commitmentFirstSeenAt;
+
     // Track which attester postconfirmed a given superBlock height
     mapping(uint256 superBlockHeight => address attester) public postconfirmedBy;
 

--- a/protocol-units/settlement/mcr/contracts/src/staking/MovementStaking.sol
+++ b/protocol-units/settlement/mcr/contracts/src/staking/MovementStaking.sol
@@ -319,7 +319,7 @@ contract MovementStaking is
         // check the balance of the token before transfer
         uint256 balanceBefore = token.balanceOf(address(this));
 
-        // transfer the stake to the contract
+        // transfer the stake to the staking contract
         // if the transfer is not using a custodian, the custodian is the token itself
         // hence this works
         // ! In general with this pattern, the custodian must be careful about not over-approving the token.
@@ -385,6 +385,10 @@ contract MovementStaking is
         address custodian,
         address attester
     ) internal {
+        console.log("[rollOverAttester] domain:", domain);
+        console.log("[rollOverAttester] epochNumber:", epochNumber);
+        console.log("[rollOverAttester] custodian:", custodian);
+        console.log("[rollOverAttester] attester:", attester);
         // the amount of stake rolled over is stake[currentAcceptingEpoch] - unstake[nextEpoch]
         uint256 stakeAmount = getStake(
             domain,
@@ -410,7 +414,7 @@ contract MovementStaking is
         // there's not risk of double payout, so long as rollOverattester is only called once per epoch
         // this should be guaranteed by the implementation, but we may want to create a withdrawal mapping to ensure this
         if (unstakeAmount > 0) {
-            _payAttesterFromExternalDirectly(address(this), attester, custodian, unstakeAmount);
+            _payAttesterFromContractDirectly(address(this), attester, custodian, unstakeAmount);
         }
 
         emit AttesterEpochRolledOver(
@@ -632,16 +636,16 @@ contract MovementStaking is
     // This is, currently, there is no added benefit of issuing a reward through this contract--other than Riccardian clarity.
     function _payAttesterFromExternalDirectly(address from, address attester, address custodian, uint256 amount) internal {
         console.log("[payAttesterFromExternalDirectly] from:", from);
-        console.log("[payAttesterFromExternalDirectly] attester:", attester);
-        console.log("[payAttesterFromExternalDirectly] custodian:", custodian);
+        console.log("[payAttesterFromExternalDirectly] to attester:", attester);
+        // console.log("[payAttesterFromExternalDirectly] custodian:", custodian);
         console.log("[payAttesterFromExternalDirectly] amount:", amount);
         require(msg.sender != address(this), "Only external calls");
         require(address(token) == custodian, "Must use base token");
-        uint256 balanceBefore = token.balanceOf(attester);
+        console.log("[payAttesterFromExternalDirectly] From balance before:", token.balanceOf(from));
+        console.log("[payAttesterFromExternalDirectly] To   balance before:", token.balanceOf(attester));
         token.transferFrom(from, attester, amount);
-        uint256 balanceAfter = token.balanceOf(attester);
-        console.log("[payAttesterFromExternalDirectly] balanceBefore:", balanceBefore);
-        console.log("[payAttesterFromExternalDirectly] balanceAfter:", balanceAfter);
+        console.log("[payAttesterFromExternalDirectly] From balance after:", token.balanceOf(from));
+        console.log("[payAttesterFromExternalDirectly] To   balance after:", token.balanceOf(attester));
     }
 
     /// @notice External account pays attester through custodian token

--- a/protocol-units/settlement/mcr/contracts/src/staking/MovementStaking.sol
+++ b/protocol-units/settlement/mcr/contracts/src/staking/MovementStaking.sol
@@ -409,7 +409,7 @@ contract MovementStaking is
 
         _addStake(domain, epochNumber + 1, custodian, attester, remainder);
 
-        // the unstake is then paid out
+        // the unstake is paid out from the staking contract (all stakes are collected in the staking contract)
         // note: this is the only place this takes place
         // there's not risk of double payout, so long as rollOverattester is only called once per epoch
         // this should be guaranteed by the implementation, but we may want to create a withdrawal mapping to ensure this

--- a/protocol-units/settlement/mcr/contracts/src/staking/MovementStaking.sol
+++ b/protocol-units/settlement/mcr/contracts/src/staking/MovementStaking.sol
@@ -409,7 +409,9 @@ contract MovementStaking is
         // note: this is the only place this takes place
         // there's not risk of double payout, so long as rollOverattester is only called once per epoch
         // this should be guaranteed by the implementation, but we may want to create a withdrawal mapping to ensure this
-        _payAttester(address(this), attester, custodian, unstakeAmount);
+        if (unstakeAmount > 0) {
+            _payAttesterFromExternalDirectly(address(this), attester, custodian, unstakeAmount);
+        }
 
         emit AttesterEpochRolledOver(
             attester,
@@ -541,7 +543,7 @@ contract MovementStaking is
                 ),
                 Math.min(amounts[i], refundAmounts[i])
             );
-            _payAttester(
+            _payAttesterWithSelector(
                 address(this), // this contract is paying the attester, it should always have enough balance
                 attesters[i],
                 custodians[i],
@@ -566,34 +568,26 @@ contract MovementStaking is
         }
     }
 
-    /// @notice Custodian pays an attester
-    // TODO these multiple if statements are a bit confusing at best. 
-    // TODO This should be refactored and more individual functions created.
-    // TODO e.g. _payAttesterFromContract, _payAttesterFromCustodian, _payAttesterFromToken
-    function _payAttester(
+    /// @notice Routes attester payment to appropriate function based on conditions
+    /// @param from The address initiating the payment (this contract or external)
+    /// @param attester The address receiving the payment
+    /// @param custodian The custodian token address (or base token if direct payment)
+    /// @param amount The amount to pay
+    function _payAttesterWithSelector(
         address from,
         address attester,
         address custodian,
         uint256 amount
     ) internal {
-        console.log("[payAttester] From:", from);
-        console.log("[payAttester] Attester:", attester);
-        console.log("[payAttester] Custodian:", custodian);
-        console.log("[payAttester] Amount:", amount);
-        console.log("[payAttester] Token address:", address(token));
-        console.log("[payAttester] Address of this:", address(this));
+        console.log("[payAttesterWithSelector] ");
         if (from == address(this)) {
             // this contract is paying the attester
-            console.log("[payAttester] From = contract");
             if (address(token) == custodian) {
-                // if there isn't a custodian...
-                token.transfer(attester, amount); // just transfer the token
+                // if there isn't a custodian, just transfer the base token
+                _payAttesterFromContractDirectly(from, attester, custodian, amount);
             } else {
-                // approve the custodian to spend the base token
-                token.approve(custodian, amount);
-
-                // purchase the custodial token for the attester
-                ICustodianToken(custodian).buyCustodialToken(attester, amount);
+                // approve the custodian to spend the base token and purchase custodial token
+                _payAttesterFromContractViaCustodian(from, attester, custodian, amount);
             }
         } else {
             // This can be used by the domain to pay the attester, but it's just as convenient for the domain to reward the attester directly.
@@ -601,39 +595,76 @@ contract MovementStaking is
 
             // somebody else is trying to pay the attester, e.g., the domain
             if (address(token) == custodian) {
-                // if there isn't a custodian...
-                console.log("[payAttester] From = address(token)");
-                // make an if statement to check if there is enough balance
-                console.log("[payAttester] Balance of token:", token.balanceOf(from));
-                console.log("[payAttester] Amount:", amount);
-                if (token.balanceOf(from) < amount) {
-                    console.log("[payAttester] insuffienct balance");
-                    console.log("[payAttester] Balance of token:", token.balanceOf(from));
-                    console.log("[payAttester] Amount:", amount);
-                }
-                token.transferFrom(from, attester, amount); // just transfer the token
-                console.log("[payAttester] Successfully transferred from:", from);
+                // if there isn't a custodian, transfer from the sender
+                _payAttesterFromExternalDirectly(from, attester, custodian, amount);
             } else {
-                // purchase the custodial token for the attester
-                ICustodianToken(custodian).buyCustodialTokenFrom(
-                    from,
-                    attester,
-                    amount
-                );
+                // purchase the custodial token for the attester from sender
+                _payAttesterFromExternalViaCustodian(from, attester, custodian, amount);
             }
         }
     }
 
-    /// @notice Custodian rewards an attester
+    /// @notice Contract pays attester directly with base token
+    // if there isn't a custodian, just transfer the base token
+    function _payAttesterFromContractDirectly(address from, address attester, address custodian, uint256 amount) internal {
+        console.log("[payAttesterFromContractDirectly] attester:", attester);
+        console.log("[payAttesterFromContractDirectly] custodian:", custodian);
+        console.log("[payAttesterFromContractDirectly] amount:", amount);
+        require(from == address(this), "Only contract can call directly 1");
+        require(address(token) == custodian, "Must use base token");
+        token.transfer(attester, amount);
+    }
+
+    /// @notice Contract pays attester through custodian token
+    function _payAttesterFromContractViaCustodian(address from, address attester, address custodian, uint256 amount) internal {
+        console.log("[payAttesterFromContractViaCustodian] attester:", attester);
+        console.log("[payAttesterFromContractViaCustodian] custodian:", custodian);
+        console.log("[payAttesterFromContractViaCustodian] amount:", amount);
+        require(from == address(this), "Only contract can call directly 2");
+        require(address(token) != custodian, "Must use custodian token");
+        token.approve(custodian, amount);
+        ICustodianToken(custodian).buyCustodialToken(attester, amount);
+    }
+
+    /// @notice External account pays attester directly with base token
+    // somebody else is trying to pay the attester, e.g., the domain
+    // This can be used by the domain to pay the attester, but it's just as convenient for the domain to reward the attester directly.
+    // This is, currently, there is no added benefit of issuing a reward through this contract--other than Riccardian clarity.
+    function _payAttesterFromExternalDirectly(address from, address attester, address custodian, uint256 amount) internal {
+        console.log("[payAttesterFromExternalDirectly] from:", from);
+        console.log("[payAttesterFromExternalDirectly] attester:", attester);
+        console.log("[payAttesterFromExternalDirectly] custodian:", custodian);
+        console.log("[payAttesterFromExternalDirectly] amount:", amount);
+        require(msg.sender != address(this), "Only external calls");
+        require(address(token) == custodian, "Must use base token");
+        uint256 balanceBefore = token.balanceOf(attester);
+        token.transferFrom(from, attester, amount);
+        uint256 balanceAfter = token.balanceOf(attester);
+        console.log("[payAttesterFromExternalDirectly] balanceBefore:", balanceBefore);
+        console.log("[payAttesterFromExternalDirectly] balanceAfter:", balanceAfter);
+    }
+
+    /// @notice External account pays attester through custodian token
+    function _payAttesterFromExternalViaCustodian(address from, address attester, address custodian, uint256 amount) internal {
+        console.log("[payAttesterFromExternalViaCustodian] from:", from);
+        console.log("[payAttesterFromExternalViaCustodian] attester:", attester);
+        console.log("[payAttesterFromExternalViaCustodian] custodian:", custodian);
+        console.log("[payAttesterFromExternalViaCustodian] amount:", amount);
+        require(msg.sender != address(this), "Only external calls");
+        require(address(token) != custodian, "Must use custodian token");
+        ICustodianToken(custodian).buyCustodialTokenFrom(from, attester, amount);
+    }
+
+    /// @notice Domain rewards an attester
     /// @param attester The attester to reward
     /// @param amount The amount to reward
-    /// @param custodian The custodian of the token from which to reward the attester
-    function reward(
+    /// @param custodian The custodian of the token from which to reward the attester, here it is the domain
+    function rewardFromDomain(
         address attester,
         uint256 amount,
-        address custodian
+        address custodian // here it is the domain
     ) public nonReentrant {
-        _payAttester(msg.sender, attester, custodian, amount);
+        _payAttesterFromExternalDirectly(msg.sender, attester, custodian, amount);
     }
 
     /// @notice An array of custodians reward an array of attesters
@@ -647,7 +678,7 @@ contract MovementStaking is
     ) public nonReentrant {
         // note: you may want to apply this directly to the attester's stake if the Domain sets an automatic restake policy
         for (uint256 i = 0; i < attesters.length; i++) {
-            _payAttester(msg.sender, attesters[i], custodians[i], amounts[i]);
+            _payAttesterFromExternalDirectly(msg.sender, attesters[i], custodians[i], amounts[i]);
         }
     }
 

--- a/protocol-units/settlement/mcr/contracts/src/staking/interfaces/IMovementStaking.sol
+++ b/protocol-units/settlement/mcr/contracts/src/staking/interfaces/IMovementStaking.sol
@@ -100,7 +100,7 @@ interface IMovementStaking {
     function getStakedAttestersForAcceptingEpoch(address domain) external view returns (address[] memory);
     function computeAllStakeForAcceptingEpoch(address attester) external view returns (uint256);
 
-    function reward(address attester, uint256 amount, address custodian) external;
+    function rewardFromDomain(address attester, uint256 amount, address custodian) external;
     function rewardArray(address[] calldata attesters, uint256[] calldata amounts, address[] calldata custodians) external;
 
     function getEpochDuration(address domain) external view returns (uint256);

--- a/protocol-units/settlement/mcr/contracts/src/staking/interfaces/IMovementStaking.sol
+++ b/protocol-units/settlement/mcr/contracts/src/staking/interfaces/IMovementStaking.sol
@@ -100,8 +100,8 @@ interface IMovementStaking {
     function getStakedAttestersForAcceptingEpoch(address domain) external view returns (address[] memory);
     function computeAllStakeForAcceptingEpoch(address attester) external view returns (uint256);
 
-    /// @notice Gets the epoch duration for a given domain
-    /// @param domain The domain to get the epoch duration for
-    /// @return The epoch duration in seconds
+    function reward(address attester, uint256 amount, address custodian) external;
+    function rewardArray(address[] calldata attesters, uint256[] calldata amounts, address[] calldata custodians) external;
+
     function getEpochDuration(address domain) external view returns (uint256);
 }

--- a/protocol-units/settlement/mcr/contracts/test/settlement/MCR.sol
+++ b/protocol-units/settlement/mcr/contracts/test/settlement/MCR.sol
@@ -786,10 +786,6 @@ contract MCRTest is Test, IMCR {
     function testAcceptorRewards() public {
         (address alice, address bob, ) = setupGenesisWithThreeAttesters(1, 1, 0);
         assertEq(mcr.getAcceptor(), bob, "Bob should be the acceptor");
-        
-        // TODO why do we need to whitelist the address?
-        // staking.whitelistAddress(alice);
-        // staking.whitelistAddress(bob);
 
         // make superBlock commitments
         MCRStorage.SuperBlockCommitment memory initCommitment = newHonestCommitment(1);
@@ -821,7 +817,6 @@ contract MCRTest is Test, IMCR {
         vm.prank(bob);
         mcr.postconfirmSuperBlocksAndRollover();
         assertEq(mcr.getLastPostconfirmedSuperBlockHeight(), 2);
-
     }
 
 

--- a/protocol-units/settlement/mcr/contracts/test/settlement/MCR.sol
+++ b/protocol-units/settlement/mcr/contracts/test/settlement/MCR.sol
@@ -865,12 +865,17 @@ contract MCRTest is Test, IMCR {
     function testRewardPoints() public {
         // Setup with Alice having supermajority-enabling stake
         (address alice, address bob, address carol) = setupGenesisWithThreeAttesters(2, 1, 1);
+        console.log("Alice is:", alice);
+        console.log("Bob is:", bob);
+        console.log("Carol is:", carol);
 
         // Mint tokens to MCR contract for rewards
         moveToken.mint(address(mcr), 100); // MCR needs tokens to pay rewards
         console.log("Minted tokens to staking contract");
         assertEq(moveToken.balanceOf(address(mcr)), 100, "MCR contract should have 100 tokens");
+
         // MCR needs to approve staking contract to spend its tokens
+        // TODO check this is necessary (comment and uncomment)
         vm.prank(address(mcr));
         moveToken.approve(address(staking), type(uint256).max);
 
@@ -963,9 +968,6 @@ contract MCRTest is Test, IMCR {
         assertEq(mcr.attesterRewardPoints(mcr.getAcceptingEpoch(), alice), 0, "Alice's points should be cleared");
         assertEq(mcr.attesterRewardPoints(mcr.getAcceptingEpoch(), bob), 0, "Bob's points should be cleared");
         assertEq(mcr.attesterRewardPoints(mcr.getAcceptingEpoch(), carol), 0, "Carol's points should be cleared");
-        assertEq(moveToken.balanceOf(alice), aliceInitialBalance, "Alice reward not yet paid out.");
-        assertEq(moveToken.balanceOf(bob), bobInitialBalance, "Bob reward not yet paid out.");
-        assertEq(moveToken.balanceOf(carol), carolInitialBalance, "Carol reward not yet paid out.");
         console.log("Reward distribution complete");
         console.log("A/B/C balances:", moveToken.balanceOf(alice), moveToken.balanceOf(bob), moveToken.balanceOf(carol));
         console.log("A/B/C stakes:", 
@@ -974,11 +976,10 @@ contract MCRTest is Test, IMCR {
             mcr.getStakeForAcceptingEpoch(address(moveToken), carol)
         );
 
-        vm.warp(block.timestamp + epochDuration);
-        vm.prank(alice);
-        mcr.postconfirmSuperBlocksAndRollover();
-        assertEq(mcr.getAcceptingEpoch(), 3, "Should be in epoch 3");
-
+        console.log("Alice initial balance:", aliceInitialBalance);
+        console.log("Alice stake:", mcr.getStakeForAcceptingEpoch(address(moveToken), alice));
+        console.log("Alice reward:", mcr.getStakeForAcceptingEpoch(address(moveToken), alice) * 2);
+        console.log("Alice final balance:", moveToken.balanceOf(alice));
         assertEq(moveToken.balanceOf(alice), aliceInitialBalance + mcr.getStakeForAcceptingEpoch(address(moveToken), alice) * 2, "Alice reward not correct.");
         assertEq(moveToken.balanceOf(bob), bobInitialBalance + mcr.getStakeForAcceptingEpoch(address(moveToken), bob), "Bob reward not correct.");
         assertEq(moveToken.balanceOf(carol), carolInitialBalance + mcr.getStakeForAcceptingEpoch(address(moveToken), carol), "Carol reward not correct.");
@@ -991,11 +992,11 @@ contract MCRTest is Test, IMCR {
         // Setup with Alice having supermajority-enabling stake
         address alice = setupGenesisWithOneAttester(1);
         console.log("Alice is:", alice);
+        assertEq(moveToken.balanceOf(alice), 0, "Alice should have 0 tokens");
         // Mint tokens to MCR contract for rewards
         moveToken.mint(address(mcr), 100); // MCR needs tokens to pay rewards
         console.log("Minted tokens to staking contract");
         assertEq(moveToken.balanceOf(address(mcr)), 100, "MCR contract should have 100 tokens");
-        
         // MCR needs to approve staking contract to spend its tokens
         vm.prank(address(mcr));
         moveToken.approve(address(staking), type(uint256).max);

--- a/protocol-units/settlement/mcr/contracts/test/staking/MovementStaking.t.sol
+++ b/protocol-units/settlement/mcr/contracts/test/staking/MovementStaking.t.sol
@@ -356,6 +356,48 @@ contract MovementStakingTest is Test {
                 1000
             )
         );
-        staking.reward(attesters, amounts, custodians);
+        staking.rewardArray(attesters, amounts, custodians);
     }
+
+    function testRewardSingleAttester() public {
+        // Register a domain
+        address domain = address(this);
+        address[] memory custodians = new address[](1);
+        custodians[0] = address(moveToken);
+        staking.registerDomain(7200 seconds, custodians);
+        // Setup domain to pay rewards
+        // moveToken.mint(domain, 100);  // Domain has already funds
+        moveToken.approve(address(staking), 100);  // Domain approves staking
+
+        
+        // Alice stakes 1000 tokens
+        address payable alice = payable(vm.addr(2));
+        staking.whitelistAddress(alice);
+        moveToken.mint(alice, 1000);
+        vm.prank(alice);
+        moveToken.approve(address(staking), 1000);
+        vm.prank(alice);
+        staking.stake(domain, moveToken, 1000);
+        
+        // Assertions on stakes and balances
+        assertEq(moveToken.balanceOf(alice), 0, "Alice should have 0 tokens");
+        assertEq(moveToken.balanceOf(address(staking)), 1000, "Staking contract should have 1000 tokens");
+        assertEq(staking.getCustodianStake(domain, 0, address(moveToken)), 1000, "Custodian stake should be 1000");
+        assertEq(staking.getStake(domain, 0, address(moveToken), alice), 1000, "Alice stake should be 1000");
+                
+        // Reward alice
+        console.log("This is moveToken:", address(moveToken));
+        console.log("This is staking:", address(staking));
+        console.log("This is alice:", alice);
+        console.log("This is domain:", domain);
+        vm.prank(domain);  // Domain calls reward
+        staking.reward(alice, 100, address(moveToken));
+        
+        // Verify reward was received
+        assertEq(moveToken.balanceOf(alice), 100, "Alice should have received 100 tokens");
+    }
+
 }
+
+
+

--- a/protocol-units/settlement/mcr/contracts/test/staking/MovementStaking.t.sol
+++ b/protocol-units/settlement/mcr/contracts/test/staking/MovementStaking.t.sol
@@ -391,7 +391,7 @@ contract MovementStakingTest is Test {
         console.log("This is alice:", alice);
         console.log("This is domain:", domain);
         vm.prank(domain);  // Domain calls reward
-        staking.reward(alice, 100, address(moveToken));
+        staking.rewardFromDomain(alice, 100, address(moveToken));
         
         // Verify reward was received
         assertEq(moveToken.balanceOf(alice), 100, "Alice should have received 100 tokens");


### PR DESCRIPTION
# Summary

Rewards for the Attesters as long as they attested before the postconfirmation

# Changelog

- adds reward functionality, specifically updates `rollOverEpoch`
- split payAttester into specialized functions
- adds tests
  - testRewardSingleAttester
  - setupGenesisWithOneAttester
  - testRewardPoints
  - testPostconfirmationRewards

# Testing

`forge test` ok

# Outstanding issues

- postconfirmation should be delayed compared to first honest commit