### PR TITLE
fix(docker): celestia-light-node fixes

### DIFF
--- a/docker/compose/movement-full-node/docker-compose.celestia-mainnet.yml
+++ b/docker/compose/movement-full-node/docker-compose.celestia-mainnet.yml
@@ -26,7 +26,9 @@ services:
     container_name: celestia-light-node
     command: |
       celestia light start
-        --core.ip rpc.celestia.pops.one
+        --core.ip consensus.celestia.mainnet.movementinfra.xyz
+        --core.port 9090
+        --rpc.addr 0.0.0.0
         --p2p.network celestia
         --node.store /.movement/celestia/movement/.celestia-light
         --keyring.backend test
@@ -35,6 +37,8 @@ services:
     environment:
       - NODE_TYPE=light
       - P2P_NETWORK=celestia
+      - NODE_STORE=/.movement/celestia/movement/.celestia-light
+    user: root:root
     volumes:
       - ${DOT_MOVEMENT_PATH}/celestia:/.movement/celestia
     ports:
@@ -43,5 +47,5 @@ services:
       setup:
         condition: service_healthy
     healthcheck:
-      test: "celestia node info"
+      test: "nc -zv 0.0.0.0 26658"
     restart: on-failure:3


### PR DESCRIPTION
# Summary
- **Categories**: `scripts`.

* Point to the consensus node in the infra.
* Specify the listen address for the RPC.
* Pass the `NODE_STORE` environment variable so that the endpoint calls init on the store.
* Improve the health check to check the service port with nc.
