### PR TITLE
[Follower] Correct DA client http2 connection

### DIFF
--- a/protocol-units/da/movement/protocol/client/Cargo.toml
+++ b/protocol-units/da/movement/protocol/client/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 movement-da-light-node-proto = { workspace = true, features = ["client"] }
-tonic = { workspace = true}
+tonic = { workspace = true, features = ["tls", "tls-webpki-roots"]}
 tonic-web = { workspace = true }
 hyper-util = { workspace = true }
 tower = { workspace = true }

--- a/protocol-units/da/movement/protocol/client/src/http2.rs
+++ b/protocol-units/da/movement/protocol/client/src/http2.rs
@@ -1,4 +1,6 @@
 use movement_da_light_node_proto::light_node_service_client::LightNodeServiceClient;
+use std::time::Duration;
+use tonic::transport::{Channel, ClientTlsConfig};
 
 #[derive(Debug, Clone)]
 pub struct Http2 {
@@ -8,7 +10,20 @@ pub struct Http2 {
 impl Http2 {
 	/// Connects to a light node service using the given connection string.
 	pub async fn connect(connection_string: &str) -> Result<Self, anyhow::Error> {
-		let client = LightNodeServiceClient::connect(connection_string.to_string()).await?;
+		let endpoint = Channel::from_shared(connection_string.to_string())?;
+
+		// Dynamically configure TLS based on the scheme (http or https)
+		let endpoint = if connection_string.starts_with("https://") {
+			endpoint
+				.tls_config(ClientTlsConfig::new().with_enabled_roots())?
+				.http2_keep_alive_interval(Duration::from_secs(10))
+		} else {
+			endpoint
+		};
+
+		let channel = endpoint.connect().await?;
+		let client = LightNodeServiceClient::new(channel);
+
 		Ok(Http2 { client })
 	}
 


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

<!--
Add your summary text here. 
 -->
The DA client htp2 connection code wasn't merge in main. Put it back.

# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->