### PR TITLE
HTTP2 Connection Should be Used for DA Tool

### DIFF
--- a/networks/movement/movement-full-node/src/da/stream_blocks/mod.rs
+++ b/networks/movement/movement-full-node/src/da/stream_blocks/mod.rs
@@ -19,7 +19,8 @@ impl StreamBlocks {
 	pub async fn execute(&self) -> Result<(), anyhow::Error> {
 		// Get the config
 
-		let mut client = MovementDaLightNodeClient::try_http1(self.light_node_url.as_str())
+		let mut client = MovementDaLightNodeClient::try_http2(self.light_node_url.as_str())
+			.await
 			.context("Failed to connect to light node")?;
 
 		let mut blocks_from_da = client


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**: `protocol-units`

The DA tool should use `http2` not `http1`.

# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

```
./target/debug/movement-full-node da stream-blocks https://m1-da-light-node.mainnet.movementnetwork.xyz/ 4315164
2025-03-05T23:05:45.654626Z  INFO movement_full_node::da::stream_blocks: streaming blocks from DA
2025-03-05T23:05:45.655956Z  INFO movement_full_node::da::stream_blocks: Receive heartbeat blob
2025-03-05T23:05:46.917033Z  INFO movement_full_node::da::stream_blocks: Receive PassedThroughBlob blob
2025-03-05T23:05:46.917858Z  INFO movement_full_node::da::stream_blocks: Block ID: bfbd27af2c32a36b4fb96bbe489598189974fa5aaf121086a89e4ffe70489015, Block Timestamp: 2025-03-05T23:05:34.458688Z, DA Height: 4315166
```

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->