### PR TITLE
fix: deduplicate execute_block tracing spans

### DIFF
--- a/networks/movement/movement-full-node/src/node/tasks/execute_settle.rs
+++ b/networks/movement/movement-full-node/src/node/tasks/execute_settle.rs
@@ -146,7 +146,7 @@ where
 
 		// get the transactions
 		let transactions_count = block.transactions().len();
-		let span = info_span!(target: "movement_timing", "execute_block", id = ?block_id);
+		let span = info_span!(target: "movement_timing", "execute_block", block_id = %block.id());
 		let commitment =
 			self.execute_block_with_retries(block, block_timestamp).instrument(span).await?;
 
@@ -222,62 +222,52 @@ where
 		let block_id = block.id();
 		let block_hash = HashValue::from_slice(block_id)?;
 
-		let span = info_span!(
-			target: "movement_timing",
-			"execute_block",
-			%block_id,
-		);
+		// get the transactions
+		let mut block_transactions = Vec::new();
+		let block_metadata = self.executor.build_block_metadata(
+			HashValue::sha3_256_of(block_id.as_bytes().as_slice()),
+			block_timestamp,
+		)?;
+		let block_metadata_transaction =
+			SignatureVerifiedTransaction::Valid(Transaction::BlockMetadata(block_metadata));
+		block_transactions.push(block_metadata_transaction);
 
-		async move {
-			// get the transactions
-			let mut block_transactions = Vec::new();
-			let block_metadata = self.executor.build_block_metadata(
-				HashValue::sha3_256_of(block_id.as_bytes().as_slice()),
-				block_timestamp,
-			)?;
-			let block_metadata_transaction =
-				SignatureVerifiedTransaction::Valid(Transaction::BlockMetadata(block_metadata));
-			block_transactions.push(block_metadata_transaction);
+		for transaction in block.transactions() {
+			let signed_transaction: SignedTransaction = bcs::from_bytes(transaction.data())?;
 
-			for transaction in block.transactions() {
-				let signed_transaction: SignedTransaction = bcs::from_bytes(transaction.data())?;
-
-				// check if the transaction has already been executed to prevent replays
-				if self
-					.executor
-					.has_executed_transaction_opt(signed_transaction.committed_hash())?
-				{
-					continue;
-				}
-
-				info!(
-					target: "movement_timing",
-					tx_hash = %signed_transaction.committed_hash(),
-					sender = %signed_transaction.sender(),
-					sequence_number = signed_transaction.sequence_number(),
-					"execute_transaction",
-				);
-
-				let signature_verified_transaction = SignatureVerifiedTransaction::Valid(
-					Transaction::UserTransaction(signed_transaction),
-				);
-				block_transactions.push(signature_verified_transaction);
+			// check if the transaction has already been executed to prevent replays
+			if self
+				.executor
+				.has_executed_transaction_opt(signed_transaction.committed_hash())?
+			{
+				continue;
 			}
 
-			// form the executable transactions vec
-			let block = ExecutableTransactions::Unsharded(block_transactions);
+			info!(
+				target: "movement_timing",
+				tx_hash = %signed_transaction.committed_hash(),
+				sender = %signed_transaction.sender(),
+				sequence_number = signed_transaction.sequence_number(),
+				"execute_transaction",
+			);
 
-			// form the executable block and execute it
-			let executable_block = ExecutableBlock::new(block_hash, block);
-			let block_id = executable_block.block_id;
-			let commitment = self.executor.execute_block_opt(executable_block).await?;
-
-			info!("Executed block: {}", block_id);
-
-			Ok(commitment)
+			let signature_verified_transaction = SignatureVerifiedTransaction::Valid(
+				Transaction::UserTransaction(signed_transaction),
+			);
+			block_transactions.push(signature_verified_transaction);
 		}
-		.instrument(span)
-		.await
+
+		// form the executable transactions vec
+		let block = ExecutableTransactions::Unsharded(block_transactions);
+
+		// form the executable block and execute it
+		let executable_block = ExecutableBlock::new(block_hash, block);
+		let block_id = executable_block.block_id;
+		let commitment = self.executor.execute_block_opt(executable_block).await?;
+
+		info!("Executed block: {}", block_id);
+
+		Ok(commitment)
 	}
 
 	async fn process_commitment_event(


### PR DESCRIPTION
# Summary
- **Categories**: `networks`.

Remove a duplicate "execute_block" tracing span and ensure the remaining span shows a nice hex-encoded block_id value.