### PR TITLE
fix: quick fixes for DA sequencer

### DIFF
--- a/protocol-units/da/movement/protocol/light-node/src/sequencer.rs
+++ b/protocol-units/da/movement/protocol/light-node/src/sequencer.rs
@@ -255,6 +255,8 @@ where
 		}
 	}
 
+	// FIXME: this does not work correctly, see details in move-rocks
+	#[allow(dead_code)]
 	async fn run_gc(&self) -> Result<(), anyhow::Error> {
 		loop {
 			self.memseq.gc().await?;
@@ -268,7 +270,7 @@ where
 			match futures::try_join!(
 				self.run_block_builder(sender.clone()),
 				self.run_block_publisher(&mut receiver),
-				self.run_gc(),
+				// self.run_gc(),
 			) {
 				Ok(_) => {
 					info!("block proposer completed");

--- a/protocol-units/mempool/move-rocks/src/lib.rs
+++ b/protocol-units/mempool/move-rocks/src/lib.rs
@@ -267,6 +267,9 @@ impl MempoolTransactionOperations for RocksdbMempool {
 			match iter.next() {
 				None => return Ok(None), // No transactions to pop
 				Some(res) => {
+					// Drop the database reader early
+					drop(iter);
+
 					let (key, value) = res?;
 					let transaction: MempoolTransaction = bcs::from_bytes(&value)?;
 

--- a/protocol-units/mempool/move-rocks/src/lib.rs
+++ b/protocol-units/mempool/move-rocks/src/lib.rs
@@ -36,6 +36,8 @@ fn construct_mempool_transaction_key(transaction: &MempoolTransaction) -> Result
 }
 
 fn construct_timestamp_threshold_key(timestamp_threshold: u64) -> Result<String, Error> {
+	// FIXME: this is wrong since the application priority buckets were introduced
+	// in construct_mempool_transaction_key above.
 	let mut key = String::with_capacity(32 + 1);
 	key.write_fmt(format_args!("{:032}:", timestamp_threshold))
 		.map_err(|_| Error::msg("Error writing timestamp threshold key"))?;

--- a/protocol-units/mempool/move-rocks/src/lib.rs
+++ b/protocol-units/mempool/move-rocks/src/lib.rs
@@ -347,7 +347,7 @@ impl MempoolTransactionOperations for RocksdbMempool {
 			let mut transaction_count = 0;
 			let mut batch = WriteBatch::default();
 
-			if let Some(res) = iter.next() {
+			while let Some(res) = iter.next() {
 				let (key, value) = res?;
 				let transaction: MempoolTransaction = bcs::from_bytes(&value)?;
 

--- a/protocol-units/sequencing/memseq/sequencer/src/lib.rs
+++ b/protocol-units/sequencing/memseq/sequencer/src/lib.rs
@@ -6,16 +6,16 @@ pub use movement_types::{
 };
 pub use sequencing_util::Sequencer;
 
-use tokio::sync::RwLock;
+use tokio::sync::{Notify, RwLock};
+use tokio::time::Instant;
 use tracing::{debug, info};
 
 use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// The `Memseq` module is responsible for managing a mempool and sequencing transactions into blocks.
-#[derive(Clone)]
 pub struct Memseq<T: MempoolTransactionOperations> {
 	/// The mempool to get transactions from.
 	mempool: T,
@@ -25,6 +25,8 @@ pub struct Memseq<T: MempoolTransactionOperations> {
 	pub parent_block: Arc<RwLock<block::Id>>,
 	// this value should not be changed after initialization
 	building_time_ms: u64,
+	// The notifier used to wake up the block building routine
+	changed: Notify,
 }
 
 impl<T: MempoolTransactionOperations> Memseq<T> {
@@ -34,7 +36,7 @@ impl<T: MempoolTransactionOperations> Memseq<T> {
 		parent_block: Arc<RwLock<block::Id>>,
 		building_time_ms: u64,
 	) -> Self {
-		Self { mempool, block_size, parent_block, building_time_ms }
+		Self { mempool, block_size, parent_block, building_time_ms, changed: Notify::new() }
 	}
 
 	pub fn with_block_size(mut self, block_size: u32) -> Self {
@@ -89,11 +91,13 @@ impl Memseq<RocksdbMempool> {
 impl<T: MempoolTransactionOperations> Sequencer for Memseq<T> {
 	async fn publish_many(&self, transactions: Vec<Transaction>) -> Result<(), anyhow::Error> {
 		self.mempool.add_transactions(transactions).await?;
+		self.changed.notify_waiters();
 		Ok(())
 	}
 
 	async fn publish(&self, transaction: Transaction) -> Result<(), anyhow::Error> {
 		self.mempool.add_transaction(transaction).await?;
+		self.changed.notify_waiters();
 		Ok(())
 	}
 
@@ -102,6 +106,7 @@ impl<T: MempoolTransactionOperations> Sequencer for Memseq<T> {
 		let mut transactions = Vec::with_capacity(self.block_size as usize);
 
 		let now = Instant::now();
+		let build_deadline = now + Duration::from_millis(self.building_time_ms);
 
 		loop {
 			let current_block_size = transactions.len() as u32;
@@ -113,10 +118,7 @@ impl<T: MempoolTransactionOperations> Sequencer for Memseq<T> {
 			let mut transactions_to_add = self.mempool.pop_transactions(remaining as usize).await?;
 			transactions.append(&mut transactions_to_add);
 
-			// sleep to yield to other tasks and wait for more transactions
-			tokio::task::yield_now().await;
-
-			if now.elapsed().as_millis() as u64 > self.building_time_ms {
+			if let Err(_) = tokio::time::timeout_at(build_deadline, self.changed.notified()).await {
 				break;
 			}
 		}


### PR DESCRIPTION
Sundry fixes to address the observed performance:

- Disable GC in rocksdb-mempool, which does not work correctly.
- Rework a busy loop in memseq.
- Code change to remove contention in rocksdb-mempool.
