### PR TITLE
Memseq Degradation

### DIFF
--- a/protocol-units/sequencing/memseq/sequencer/src/lib.rs
+++ b/protocol-units/sequencing/memseq/sequencer/src/lib.rs
@@ -539,3 +539,5 @@ pub mod test {
 		}
 	}
 }
+
+pub mod degradation_tests {}

--- a/util/movement-types/src/block.rs
+++ b/util/movement-types/src/block.rs
@@ -224,3 +224,30 @@ pub enum BlockCommitmentEvent {
 	Accepted(BlockCommitment),
 	Rejected { height: u64, reason: BlockCommitmentRejectionReason },
 }
+
+pub mod test {
+
+	#[test]
+	fn test_collapse_blocks() {
+		// check transactions are deduplicated
+		let block1 = super::Block::test();
+		let block2 = super::Block::test();
+
+		let collapsed_block = super::Block::collapse(vec![block1.clone(), block2]);
+
+		// assert transactions equals test transactions
+		let test = super::Block::test();
+		assert_eq!(collapsed_block.transactions().count(), 1);
+		assert_eq!(collapsed_block.transactions().next(), test.transactions().next());
+
+		// check transactions are preserved
+		// construct a different block
+		let mut diff_block1 = super::Block::test();
+		let new_transaction = super::Transaction::new(vec![4, 5, 6], 0, 0);
+		diff_block1.add_transaction(new_transaction.clone());
+		let collapsed = super::Block::collapse(vec![block1, diff_block1]);
+		assert_eq!(collapsed.transactions().count(), 2);
+		assert_eq!(collapsed.transactions().next(), Some(&new_transaction));
+		assert_eq!(collapsed.transactions().nth(1), test.transactions().next());
+	}
+}

--- a/util/movement-types/src/block.rs
+++ b/util/movement-types/src/block.rs
@@ -106,6 +106,23 @@ impl Block {
 	pub fn add_transaction(&mut self, transaction: Transaction) {
 		self.transactions.insert(transaction);
 	}
+
+	pub fn collapse(blocks: Vec<Block>) -> Block {
+		let mut transactions = BTreeSet::new();
+		let parent = if let Some(first_block) = blocks.first() {
+			first_block.parent
+		} else {
+			Id::genesis_block()
+		};
+
+		for block in blocks {
+			for transaction in block.transactions {
+				transactions.insert(transaction);
+			}
+		}
+
+		Block::new(BlockMetadata::BlockMetadata, parent, transactions)
+	}
 }
 
 #[derive(


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**: `protocol-units`

Submits Celestia blobs in parallel. This resolves backpressuring and works in the context where you rely on Celestia for ordering. When Celestia is no longer used for ordering, e.g., WAL-Celestia, you will need to return to some kind of sequential submission to make sure these match. 

Also adds `submit_collapsed_block` to replace submission in parallel with submission of single batched block. This works under both ordering and non-ordering regimes of Celestia given submissions over the in-process channel are read and processed in order. 

# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->