### PR TITLE
chore: remove #1110 from main 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 - - -
+## [0.3.3](https://github.com/movementlabsxyz/movement/compare/1cec33a2df0510c6e789998d7e0dd2d5ee49893b..0.3.3) - 2025-03-14
+#### Bug Fixes
+- **(da-light-node)** graceful return on unimlemented (#1112) - ([0d2e7d1](https://github.com/movementlabsxyz/movement/commit/0d2e7d185551be8df62e300ed32ff0ddfd0fa273)) - Mikhail Zabaluev
+- Memseq Degradation (#1111) - ([1cec33a](https://github.com/movementlabsxyz/movement/commit/1cec33a2df0510c6e789998d7e0dd2d5ee49893b)) - Liam Monninger
+#### Tests
+- load-soak-basic bardock (#1108) - ([1265444](https://github.com/movementlabsxyz/movement/commit/126544476332e18abbdecd0eb131d9d515e78a92)) - Richard Melkonian
+
+- - -
+
 ## [0.3.2](https://github.com/movementlabsxyz/movement/compare/19d6bad30f58c7647c05c95e763229d05c3c9713..0.3.2) - 2025-03-14
 #### Bug Fixes
 - quick fixes for DA sequencer (#1110) - ([19d6bad](https://github.com/movementlabsxyz/movement/commit/19d6bad30f58c7647c05c95e763229d05c3c9713)) - Mikhail Zabaluev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11992,6 +11992,7 @@ dependencies = [
  "hyper 1.5.0",
  "k256",
  "maptos-dof-execution",
+ "maptos-execution-util",
  "maptos-opt-executor",
  "mcr-settlement-client",
  "mcr-settlement-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-account-whitelist"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-framework-biarritz-rc1-release"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-framework-elsa-release"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1947,7 +1947,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-framework-elsa-to-biarritz-rc1-migration"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aptos-framework-biarritz-rc1-release",
  "aptos-sdk",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-framework-head-release"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -1970,7 +1970,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-framework-known-release"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-framework-release-script-release"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-framework-set-feature-flags-release"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-framework-upgrade-gas-release"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -5419,7 +5419,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-config"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5435,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-grpc"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "buildtime",
  "prost 0.13.3",
@@ -5446,7 +5446,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-indexer-db"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-integration-tests"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-service"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "alloy",
  "alloy-network",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-setup"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "alloy",
  "alloy-primitives 0.7.7",
@@ -5578,7 +5578,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-util"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "buildtime"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "buildtime-helpers",
@@ -5625,7 +5625,7 @@ dependencies = [
 
 [[package]]
 name = "buildtime-helpers"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -5634,7 +5634,7 @@ dependencies = [
 
 [[package]]
 name = "buildtime-macros"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "buildtime-helpers",
  "quote",
@@ -6181,7 +6181,7 @@ dependencies = [
 
 [[package]]
 name = "commander"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "futures",
@@ -7291,7 +7291,7 @@ checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
 
 [[package]]
 name = "dot-movement"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "movement-types",
@@ -7863,7 +7863,7 @@ dependencies = [
 
 [[package]]
 name = "flocks"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "futures",
@@ -8262,7 +8262,7 @@ dependencies = [
 
 [[package]]
 name = "godfig"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8807,7 +8807,7 @@ checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "howzit"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -8828,7 +8828,7 @@ dependencies = [
 
 [[package]]
 name = "hsm-demo"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9872,7 +9872,7 @@ dependencies = [
 
 [[package]]
 name = "latest-aptos-framework-migration"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-account-whitelist",
@@ -10322,7 +10322,7 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "maptos-dof-execution"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -10356,7 +10356,7 @@ dependencies = [
 
 [[package]]
 name = "maptos-execution-util"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-account-whitelist",
@@ -10379,7 +10379,7 @@ dependencies = [
 
 [[package]]
 name = "maptos-fin-view"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -10400,7 +10400,7 @@ dependencies = [
 
 [[package]]
 name = "maptos-framework-release-util"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -10419,7 +10419,7 @@ dependencies = [
 
 [[package]]
 name = "maptos-opt-executor"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-account-whitelist",
@@ -10515,7 +10515,7 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "mcr-settlement-client"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -10549,7 +10549,7 @@ dependencies = [
 
 [[package]]
 name = "mcr-settlement-config"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "alloy",
  "anyhow",
@@ -10561,7 +10561,7 @@ dependencies = [
 
 [[package]]
 name = "mcr-settlement-manager"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10577,7 +10577,7 @@ dependencies = [
 
 [[package]]
 name = "mcr-settlement-runner"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "alloy-primitives 0.7.7",
  "anyhow",
@@ -10597,7 +10597,7 @@ dependencies = [
 
 [[package]]
 name = "mcr-settlement-setup"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "alloy",
  "alloy-network",
@@ -10648,7 +10648,7 @@ dependencies = [
 
 [[package]]
 name = "mempool-util"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "movement-types",
@@ -10657,7 +10657,7 @@ dependencies = [
 
 [[package]]
 name = "memseq"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "dot-movement",
@@ -10677,7 +10677,7 @@ dependencies = [
 
 [[package]]
 name = "memseq-util"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "dot-movement",
@@ -11334,7 +11334,7 @@ dependencies = [
 
 [[package]]
 name = "move-rocks"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "bcs 0.1.6 (git+https://github.com/movementlabsxyz/bcs.git?rev=bc16d2d39cabafaabd76173dd1b04b2aa170cf0c)",
@@ -11590,7 +11590,7 @@ dependencies = [
 
 [[package]]
 name = "movement-algs"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",
@@ -11600,7 +11600,7 @@ dependencies = [
 
 [[package]]
 name = "movement-celestia-da-light-node"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -11643,7 +11643,7 @@ dependencies = [
 
 [[package]]
 name = "movement-celestia-da-light-node-runners"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "commander",
@@ -11664,7 +11664,7 @@ dependencies = [
 
 [[package]]
 name = "movement-client"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -11706,7 +11706,7 @@ dependencies = [
 
 [[package]]
 name = "movement-collections"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "uuid",
@@ -11714,7 +11714,7 @@ dependencies = [
 
 [[package]]
 name = "movement-config"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-sdk",
@@ -11742,7 +11742,7 @@ dependencies = [
 
 [[package]]
 name = "movement-da-light-node-celestia"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -11760,7 +11760,7 @@ dependencies = [
 
 [[package]]
 name = "movement-da-light-node-client"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "bytes 1.8.0",
@@ -11775,7 +11775,7 @@ dependencies = [
 
 [[package]]
 name = "movement-da-light-node-da"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -11792,7 +11792,7 @@ dependencies = [
 
 [[package]]
 name = "movement-da-light-node-digest-store"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -11809,7 +11809,7 @@ dependencies = [
 
 [[package]]
 name = "movement-da-light-node-prevalidator"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -11835,7 +11835,7 @@ dependencies = [
 
 [[package]]
 name = "movement-da-light-node-proto"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "buildtime",
  "prost 0.13.3",
@@ -11845,7 +11845,7 @@ dependencies = [
 
 [[package]]
 name = "movement-da-light-node-setup"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -11869,14 +11869,14 @@ dependencies = [
 
 [[package]]
 name = "movement-da-light-node-signer"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "movement-signer",
 ]
 
 [[package]]
 name = "movement-da-light-node-tests"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "ecdsa 0.16.9",
@@ -11890,7 +11890,7 @@ dependencies = [
 
 [[package]]
 name = "movement-da-light-node-verifier"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -11916,7 +11916,7 @@ dependencies = [
 
 [[package]]
 name = "movement-da-util"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "alloy",
  "anyhow",
@@ -11974,7 +11974,7 @@ dependencies = [
 
 [[package]]
 name = "movement-full-node"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "alloy-signer",
  "anyhow",
@@ -12021,7 +12021,7 @@ dependencies = [
 
 [[package]]
 name = "movement-full-node-setup"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-sdk",
@@ -12052,7 +12052,7 @@ dependencies = [
 
 [[package]]
 name = "movement-indexer-service"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "clap 4.5.21",
@@ -12074,7 +12074,7 @@ dependencies = [
 
 [[package]]
 name = "movement-rest"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -12086,7 +12086,7 @@ dependencies = [
 
 [[package]]
 name = "movement-signer"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12100,7 +12100,7 @@ dependencies = [
 
 [[package]]
 name = "movement-signer-aws-kms"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "alloy-signer",
  "anyhow",
@@ -12118,7 +12118,7 @@ dependencies = [
 
 [[package]]
 name = "movement-signer-hashicorp-vault"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12133,7 +12133,7 @@ dependencies = [
 
 [[package]]
 name = "movement-signer-loader"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12149,7 +12149,7 @@ dependencies = [
 
 [[package]]
 name = "movement-signer-local"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12166,7 +12166,7 @@ dependencies = [
 
 [[package]]
 name = "movement-signer-test"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -12199,7 +12199,7 @@ dependencies = [
 
 [[package]]
 name = "movement-signing-aptos"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -12226,7 +12226,7 @@ dependencies = [
 
 [[package]]
 name = "movement-signing-eth"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -12241,7 +12241,7 @@ dependencies = [
 
 [[package]]
 name = "movement-tracing"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "tracing-appender",
  "tracing-subscriber 0.3.18",
@@ -12249,7 +12249,7 @@ dependencies = [
 
 [[package]]
 name = "movement-types"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -12264,7 +12264,7 @@ dependencies = [
 
 [[package]]
 name = "movement-util"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-sdk",
@@ -12868,7 +12868,7 @@ dependencies = [
 
 [[package]]
 name = "parent-aptos-framework-migration"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "aptos-account-whitelist",
@@ -15480,7 +15480,7 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "sequencing-util"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "movement-types",
@@ -16369,7 +16369,7 @@ dependencies = [
 
 [[package]]
 name = "syncador"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -16397,7 +16397,7 @@ dependencies = [
 
 [[package]]
 name = "syncup"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -18107,7 +18107,7 @@ dependencies = [
 
 [[package]]
 name = "whitelist"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "prost 0.13.3",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Movement Labs"]

--- a/networks/movement/movement-client/Cargo.toml
+++ b/networks/movement/movement-client/Cargo.toml
@@ -19,6 +19,10 @@ name = "movement-tests-e2e-basic-alice-bob"
 path = "src/bin/e2e/basic_alice_bob.rs"
 
 [[bin]]
+name = "bardock-tests-load-soak-basic"
+path = "src/bin/e2e/bardock_alice_bob.rs"
+
+[[bin]]
 name = "movement-tests-e2e-simple-interaction"
 path = "src/bin/e2e/simple_interaction.rs"
 

--- a/networks/movement/movement-client/src/bin/e2e/bardock_alice_bob.rs
+++ b/networks/movement/movement-client/src/bin/e2e/bardock_alice_bob.rs
@@ -1,0 +1,196 @@
+use anyhow::{Context, Result};
+use aptos_sdk::{
+	coin_client::CoinClient,
+	rest_client::{Client, FaucetClient},
+	types::LocalAccount,
+};
+use movement_client::load_soak_testing::{
+	execute_test, init_test, ExecutionConfig, Scenario, TestKind,
+};
+use once_cell::sync::Lazy;
+use std::sync::Arc;
+use std::{str::FromStr, time::Duration};
+use tokio::time::sleep;
+use url::Url;
+
+fn main() {
+	let mut config = ExecutionConfig::default();
+
+	// Set some params for the load test, drive some requests
+	config.kind = TestKind::Soak {
+		min_scenarios: 20,
+		max_scenarios: 20,
+		duration: std::time::Duration::from_secs(600), // 10 minutes
+		number_cycle: 1,
+	};
+
+	config.number_scenario_per_client = 20; // 20Client Requests
+
+	// Init the Test before execution
+	if let Err(err) = init_test(&config) {
+		println!("Test init fail ; {err}",);
+	}
+
+	// Execute the test.
+	let result = execute_test(config, Arc::new(create_scenario));
+	tracing::info!("End Test with result {result:?}",);
+}
+
+// Scenario constructor function use by the Test runtime to create new scenarios.
+fn create_scenario(id: usize) -> Box<dyn Scenario> {
+	Box::new(BasicScenario { id })
+}
+
+pub struct BasicScenario {
+	id: usize,
+}
+
+impl BasicScenario {
+	pub fn new(id: usize) -> Self {
+		BasicScenario { id }
+	}
+}
+
+static SUZUKA_CONFIG: Lazy<movement_config::Config> = Lazy::new(|| {
+	let dot_movement = dot_movement::DotMovement::try_from_env().unwrap();
+	let config = dot_movement.try_get_config_from_json::<movement_config::Config>().unwrap();
+	config
+});
+
+static NODE_URL: Lazy<Url> = Lazy::new(|| {
+	let node_connection_address = SUZUKA_CONFIG
+		.execution_config
+		.maptos_config
+		.client
+		.maptos_rest_connection_hostname
+		.clone();
+	let node_connection_port = SUZUKA_CONFIG
+		.execution_config
+		.maptos_config
+		.client
+		.maptos_rest_connection_port
+		.clone();
+
+	let node_connection_url =
+		format!("https://{}:{}", node_connection_address, node_connection_port);
+
+	Url::from_str(node_connection_url.as_str()).unwrap()
+});
+
+static FAUCET_URL: Lazy<Url> = Lazy::new(|| {
+	//The Bardock Faucet Listen URL
+	Url::from_str("https://faucet.testnet.bardock.movementnetwork.xyz").unwrap()
+});
+
+#[async_trait::async_trait]
+impl Scenario for BasicScenario {
+	async fn run(self: Box<Self>) -> Result<()> {
+		// Sleep for 7 seconds before each Scenario run to not get Rate Limited
+		sleep(Duration::from_secs(5)).await;
+
+		let rest_client = Client::new(NODE_URL.clone());
+		let faucet_client = FaucetClient::new(FAUCET_URL.clone(), NODE_URL.clone());
+		let coin_client = CoinClient::new(&rest_client);
+
+		// Create two accounts locally, Alice and Bob.
+		let mut alice = LocalAccount::generate(&mut rand::rngs::OsRng);
+		let bob = LocalAccount::generate(&mut rand::rngs::OsRng); // <:!:section_2
+
+		// Print account addresses.
+		tracing::info!(
+			"Scenario:{}\n=== Addresses ===\nAlice: {}\nBob: {}",
+			self.id,
+			alice.address().to_hex_literal(),
+			bob.address().to_hex_literal()
+		);
+
+		tracing::info!("{} Before alice fund", self.id);
+		self.log_exec_info(&format!("{} Before alice fund", self.id));
+		// Create the accounts on chain, but only fund Alice.
+		faucet_client.fund(alice.address(), 100_000_000).await?;
+		tracing::info!("{} Before Bod create_account", self.id);
+		self.log_exec_info(&format!("{} Before Bod create_account", self.id));
+		faucet_client.create_account(bob.address()).await?;
+		tracing::info!("{} After Bod create_account", self.id);
+		self.log_exec_info(&format!("{} After Bod create_account", self.id));
+
+		// Have Alice send Bob some coins.
+		let txn_hash = coin_client
+			.transfer(&mut alice, bob.address(), 1_000, None)
+			.await
+			.context("Failed to submit transaction to transfer coins")?;
+		rest_client
+			.wait_for_transaction(&txn_hash)
+			.await
+			.context("Failed when waiting for the transfer transaction")?;
+
+		// Print intermediate balances.
+		tracing::info!(
+			"Scenario:{}\n=== Intermediate Balances ===\nAlice: {:?}\nBob: {:?}",
+			self.id,
+			coin_client
+				.get_account_balance(&alice.address())
+				.await
+				.context("Failed to get Alice's account balance the second time")?,
+			coin_client
+				.get_account_balance(&bob.address())
+				.await
+				.context("Failed to get Bob's account balance the second time")?
+		);
+
+		self.log_exec_info(&format!("Scenario:{} ended", self.id));
+
+		// Have Alice send Bob some coins.
+		let txn_hash = coin_client
+			.transfer(&mut alice, bob.address(), 1_000, None)
+			.await
+			.context("Failed to submit transaction to transfer coins")?;
+		tracing::info!("Alice Transfer To Bob tx_hash: {:?}", txn_hash);
+		rest_client
+			.wait_for_transaction(&txn_hash)
+			.await
+			.context("Failed when waiting for the transfer transaction")?;
+
+		// Print intermediate balances.
+		tracing::info!(
+			"Scenario:{}\n=== Intermediate Balances ===\n Alice: {:?}\n Bob: {:?}",
+			self.id,
+			coin_client
+				.get_account_balance(&alice.address())
+				.await
+				.context("Failed to get Alice's account balance the second time")?,
+			coin_client
+				.get_account_balance(&bob.address())
+				.await
+				.context("Failed to get Bob's account balance the second time")?
+		);
+
+		// Have Alice send Bob some more coins.
+		let txn_hash = coin_client
+			.transfer(&mut alice, bob.address(), 1_000, None)
+			.await
+			.context("Failed to submit transaction to transfer coins")?; // <:!:section_5
+		tracing::info!("Alice Transfer To Bob tx_hash: {:?}", txn_hash);
+		// :!:>section_6
+		rest_client
+			.wait_for_transaction(&txn_hash)
+			.await
+			.context("Failed when waiting for the transfer transaction")?; // <:!:section_6
+
+		// Print final balances.
+		tracing::info!(
+			"Scenario:{}\n=== Final Balances ===\n Alice: {:?}\n Bob: {:?}",
+			self.id,
+			coin_client
+				.get_account_balance(&alice.address())
+				.await
+				.context("Failed to get Alice's account balance the second time")?,
+			coin_client
+				.get_account_balance(&bob.address())
+				.await
+				.context("Failed to get Bob's account balance the second time")?
+		);
+
+		Ok(())
+	}
+}

--- a/networks/movement/movement-full-node/Cargo.toml
+++ b/networks/movement/movement-full-node/Cargo.toml
@@ -16,6 +16,7 @@ maptos-dof-execution = { workspace = true }
 prost = { workspace = true }
 movement-da-light-node-proto = { workspace = true, features = ["client"] }
 movement-da-util = { workspace = true }
+maptos-execution-util = { workspace = true }
 mcr-settlement-client = { workspace = true, features = ["eth"] }
 mcr-settlement-manager = { workspace = true }
 serde_json = { workspace = true }

--- a/networks/movement/movement-full-node/src/node/partial.rs
+++ b/networks/movement/movement-full-node/src/node/partial.rs
@@ -63,8 +63,7 @@ where
 		let transaction_ingress_task = tasks::transaction_ingress::Task::new(
 			transaction_receiver,
 			self.light_node_client,
-			// FIXME: why are the struct member names so tautological?
-			self.config.celestia_da_light_node.celestia_da_light_node_config,
+			self.config.execution_config.maptos_config,
 		);
 
 		let (

--- a/networks/movement/movement-full-node/src/node/tasks/transaction_ingress.rs
+++ b/networks/movement/movement-full-node/src/node/tasks/transaction_ingress.rs
@@ -1,9 +1,9 @@
 //! Task to process incoming transactions and write to DA
 
 use maptos_dof_execution::SignedTransaction;
+use maptos_execution_util::config::Config as MaptosConfig;
 use movement_da_light_node_client::MovementDaLightNodeClient;
 use movement_da_light_node_proto::{BatchWriteRequest, BlobWrite};
-use movement_da_util::config::Config as LightNodeConfig;
 
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
@@ -18,16 +18,16 @@ const LOGGING_UID: AtomicU64 = AtomicU64::new(0);
 pub struct Task {
 	transaction_receiver: mpsc::Receiver<(u64, SignedTransaction)>,
 	da_light_node_client: MovementDaLightNodeClient,
-	da_light_node_config: LightNodeConfig,
+	maptos_config: MaptosConfig,
 }
 
 impl Task {
 	pub(crate) fn new(
 		transaction_receiver: mpsc::Receiver<(u64, SignedTransaction)>,
 		da_light_node_client: MovementDaLightNodeClient,
-		da_light_node_config: LightNodeConfig,
+		maptos_config: MaptosConfig,
 	) -> Self {
-		Task { transaction_receiver, da_light_node_client, da_light_node_config }
+		Task { transaction_receiver, da_light_node_client, maptos_config }
 	}
 
 	pub async fn run(mut self) -> anyhow::Result<()> {
@@ -43,7 +43,7 @@ impl Task {
 
 		// limit the total time batching transactions
 		let start = Instant::now();
-		let (_, half_building_time) = self.da_light_node_config.block_building_parameters();
+		let half_building_time = self.maptos_config.load_shedding.batch_production_time;
 
 		let mut transactions = Vec::new();
 

--- a/protocol-units/da/movement/protocol/light-node/src/passthrough.rs
+++ b/protocol-units/da/movement/protocol/light-node/src/passthrough.rs
@@ -198,7 +198,7 @@ where
 		&self,
 		_request: tonic::Request<StreamReadLatestRequest>,
 	) -> std::result::Result<tonic::Response<Self::StreamReadLatestStream>, tonic::Status> {
-		unimplemented!()
+		Err(tonic::Status::unimplemented(""))
 	}
 	/// Server streaming response type for the StreamWriteCelestiaBlob method.
 	type StreamWriteBlobStream = std::pin::Pin<
@@ -209,21 +209,21 @@ where
 		&self,
 		_request: tonic::Request<tonic::Streaming<StreamWriteBlobRequest>>,
 	) -> std::result::Result<tonic::Response<Self::StreamWriteBlobStream>, tonic::Status> {
-		unimplemented!()
+		Err(tonic::Status::unimplemented(""))
 	}
 	/// Read blobs at a specified height.
 	async fn read_at_height(
 		&self,
 		_request: tonic::Request<ReadAtHeightRequest>,
 	) -> std::result::Result<tonic::Response<ReadAtHeightResponse>, tonic::Status> {
-		unimplemented!()
+		Err(tonic::Status::unimplemented(""))
 	}
 	/// Batch read and write operations for efficiency.
 	async fn batch_read(
 		&self,
 		_request: tonic::Request<BatchReadRequest>,
 	) -> std::result::Result<tonic::Response<BatchReadResponse>, tonic::Status> {
-		unimplemented!()
+		Err(tonic::Status::unimplemented(""))
 	}
 
 	/// Batch write blobs.

--- a/protocol-units/da/movement/protocol/light-node/src/sequencer.rs
+++ b/protocol-units/da/movement/protocol/light-node/src/sequencer.rs
@@ -173,6 +173,17 @@ where
 		Ok(())
 	}
 
+	/// Collapses the back-pressured blocks into a single block and submits it.
+	///
+	/// todo: mark not pub once this is actually used
+	pub async fn submit_collapsed_blocks(&self, blocks: Vec<Block>) -> Result<(), anyhow::Error> {
+		let block = Block::collapse(blocks);
+		let data: InnerSignedBlobV1Data<C> = block.try_into()?;
+		let blob = data.try_to_sign(&self.pass_through.signer).await?;
+		self.pass_through.da.submit_blob(blob.into()).await?;
+		Ok(())
+	}
+
 	/// Reads blobs from the receiver until the building time is exceeded
 	async fn read_blocks(
 		&self,

--- a/protocol-units/da/movement/protocol/light-node/src/sequencer.rs
+++ b/protocol-units/da/movement/protocol/light-node/src/sequencer.rs
@@ -173,17 +173,6 @@ where
 		Ok(())
 	}
 
-	/// Collapses the back-pressured blocks into a single block and submits it.
-	///
-	/// todo: mark not pub once this is actually used
-	pub async fn submit_collapsed_blocks(&self, blocks: Vec<Block>) -> Result<(), anyhow::Error> {
-		let block = Block::collapse(blocks);
-		let data: InnerSignedBlobV1Data<C> = block.try_into()?;
-		let blob = data.try_to_sign(&self.pass_through.signer).await?;
-		self.pass_through.da.submit_blob(blob.into()).await?;
-		Ok(())
-	}
-
 	/// Reads blobs from the receiver until the building time is exceeded
 	async fn read_blocks(
 		&self,

--- a/protocol-units/da/movement/protocol/light-node/src/sequencer.rs
+++ b/protocol-units/da/movement/protocol/light-node/src/sequencer.rs
@@ -365,8 +365,9 @@ where
 		&self,
 		_request: tonic::Request<tonic::Streaming<grpc::StreamWriteBlobRequest>>,
 	) -> std::result::Result<tonic::Response<Self::StreamWriteBlobStream>, tonic::Status> {
-		unimplemented!("stream_write_blob")
+		Err(tonic::Status::unimplemented(""))
 	}
+
 	/// Read blobs at a specified height.
 	async fn read_at_height(
 		&self,

--- a/protocol-units/execution/maptos/util/src/config/common.rs
+++ b/protocol-units/execution/maptos/util/src/config/common.rs
@@ -201,6 +201,8 @@ env_default!(
 	HashValue::sha3_256_of(b"maptos").to_hex()
 );
 
+env_default!(default_batch_production_time, "MAPTOS_BATCH_PRODUCTION_TIME_MS", u64, 2000);
+
 env_default!(default_max_transactions_in_flight, "MAPTOS_MAX_TRANSACTIONS_IN_FLIGHT", u64);
 
 env_default!(default_sequence_number_ttl_ms, "MAPTOS_SEQUENCE_NUMBER_TTL_MS", u64, 1000 * 60 * 3);

--- a/protocol-units/execution/maptos/util/src/config/load_shedding.rs
+++ b/protocol-units/execution/maptos/util/src/config/load_shedding.rs
@@ -1,6 +1,6 @@
 //! Configuration for load-shedding limits.
 
-use super::common::default_max_transactions_in_flight;
+use super::common::{default_batch_production_time, default_max_transactions_in_flight};
 
 use serde::{Deserialize, Serialize};
 
@@ -10,10 +10,16 @@ pub struct Config {
 	/// before new transactions are rejected.
 	#[serde(default = "default_max_transactions_in_flight")]
 	pub max_transactions_in_flight: Option<u64>,
+	/// Time between 2 batch production.
+	#[serde(default = "default_batch_production_time")]
+	pub batch_production_time: u64,
 }
 
 impl Default for Config {
 	fn default() -> Self {
-		Self { max_transactions_in_flight: default_max_transactions_in_flight() }
+		Self {
+			max_transactions_in_flight: default_max_transactions_in_flight(),
+			batch_production_time: default_batch_production_time(),
+		}
 	}
 }

--- a/protocol-units/sequencing/memseq/util/src/lib.rs
+++ b/protocol-units/sequencing/memseq/util/src/lib.rs
@@ -23,7 +23,7 @@ pub struct Config {
 	pub memseq_max_block_size: u32,
 }
 
-env_default!(default_memseq_build_time, "MEMSEQ_BUILD_TIME", u64, 1000);
+env_default!(default_memseq_build_time, "MEMSEQ_BUILD_TIME", u64, 500);
 
 env_default!(default_memseq_max_block_size, "MEMSEQ_MAX_BLOCK_SIZE", u32, 2048);
 


### PR DESCRIPTION
# Summary
We may want to have this functionality, but it wasn't thoroughly e2e tested and the parallelism caused a bottleneck at DA block production rate. 

For now this removes that feature from main and we can reopen the #1110 PR

This PR removed commit `1cec33a2df0510c6e789998d7e0dd2d5ee49893b` using the interactive rebase method from main. Doing so re-commits all the changes after that PR hence the diff.

# Changelog
Removes the logic added 

# Testing
cargo checks and builds

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->