### PR TITLE
feat: add submit_batch cmd to full node exe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12007,6 +12007,7 @@ dependencies = [
  "movement-tracing",
  "movement-types",
  "prost 0.13.3",
+ "rand 0.7.3",
  "rocksdb",
  "serde_json",
  "sha2 0.10.8",

--- a/networks/movement/movement-full-node/Cargo.toml
+++ b/networks/movement/movement-full-node/Cargo.toml
@@ -54,6 +54,8 @@ k256 = { workspace = true }
 alloy-signer = { workspace = true }
 chrono = { workspace = true }
 maptos-opt-executor = { workspace = true }
+rand = { workspace = true }
+
 
 [features]
 default = []

--- a/networks/movement/movement-full-node/src/da/mod.rs
+++ b/networks/movement/movement-full-node/src/da/mod.rs
@@ -1,4 +1,5 @@
-pub mod stream_blocks;
+mod stream_blocks;
+mod submit_batch;
 
 use clap::Subcommand;
 
@@ -6,12 +7,14 @@ use clap::Subcommand;
 #[clap(rename_all = "kebab-case", about = "Commands for intereacting with the DA")]
 pub enum Da {
 	StreamBlocks(stream_blocks::StreamBlocks),
+	SubmitBatch(submit_batch::SubmitBatch),
 }
 
 impl Da {
 	pub async fn execute(&self) -> Result<(), anyhow::Error> {
 		match self {
 			Da::StreamBlocks(stream_blocks) => stream_blocks.execute().await,
+			Da::SubmitBatch(submit_batch) => submit_batch.execute().await,
 		}
 	}
 }

--- a/networks/movement/movement-full-node/src/da/submit_batch.rs
+++ b/networks/movement/movement-full-node/src/da/submit_batch.rs
@@ -1,0 +1,74 @@
+use crate::common_args::MovementArgs;
+use anyhow::Context;
+use aptos_sdk::types::account_address::AccountAddress;
+use aptos_sdk::types::transaction::TransactionPayload;
+use aptos_sdk::{
+	move_types::{identifier::Identifier, language_storage::ModuleId},
+	transaction_builder::TransactionBuilder,
+	types::{transaction::EntryFunction, LocalAccount},
+};
+use clap::Parser;
+use movement_da_light_node_client::MovementDaLightNodeClient;
+use movement_da_light_node_proto::BatchWriteRequest;
+use movement_da_light_node_proto::BlobWrite;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+use tracing::info;
+
+#[derive(Debug, Parser, Clone)]
+#[clap(rename_all = "kebab-case", about = "Streams the DA blocks")]
+pub struct SubmitBatch {
+	#[clap(flatten)]
+	pub movement_args: MovementArgs,
+	pub light_node_url: String,
+}
+
+impl SubmitBatch {
+	pub async fn execute(&self) -> Result<(), anyhow::Error> {
+		// Get the config
+		let dot_movement = self.movement_args.dot_movement()?;
+		let config = dot_movement.try_get_config_from_json::<movement_config::Config>()?;
+
+		let mut da_client = MovementDaLightNodeClient::try_http2(self.light_node_url.as_str())
+			.await
+			.context("Failed to connect to light node")?;
+
+		let alice = LocalAccount::generate(&mut rand::rngs::OsRng);
+		let bob = LocalAccount::generate(&mut rand::rngs::OsRng);
+		// Create a raw transaction from Alice to Bob.
+		let transaction_builder = TransactionBuilder::new(
+			TransactionPayload::EntryFunction(EntryFunction::new(
+				ModuleId::new(AccountAddress::from_str_strict("0x1")?, Identifier::new("coin")?),
+				Identifier::new("transfer")?,
+				vec![],
+				vec![],
+			)),
+			SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() + 20,
+			config.execution_config.maptos_config.chain.maptos_chain_id.clone(),
+		)
+		.sender(alice.address())
+		.sequence_number(alice.sequence_number())
+		.max_gas_amount(5_000)
+		.gas_unit_price(100);
+
+		// Sign the Tx by bob to be invalid. Just test the submit_batch don't want to be executed.
+		let signed_transaction = bob.sign_with_transaction_builder(transaction_builder);
+		let mut transactions = vec![];
+		let serialized_aptos_transaction = bcs::to_bytes(&signed_transaction)?;
+		let movement_transaction = movement_types::transaction::Transaction::new(
+			serialized_aptos_transaction,
+			0,
+			signed_transaction.sequence_number(),
+		);
+		let serialized_transaction = serde_json::to_vec(&movement_transaction)?;
+		transactions.push(BlobWrite { data: serialized_transaction });
+		let batch_write = BatchWriteRequest { blobs: transactions };
+
+		// write the batch to the DA
+		let batch_write_reponse = da_client.batch_write(batch_write).await?;
+
+		info!("Batch submitted with response: {batch_write_reponse:?}");
+
+		Ok(())
+	}
+}


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

Add the command `submit_batch` to `movement-full-node` exe to test the batch submission connection.

The batch contains a badly signed Tx so it is rejected. 
<!--
Add your summary text here. 
 -->

# Changelog
- Add submit_batch cmd to test the submit_batch connection.
<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->
To test start a full node:
```
CELESTIA_LOG_LEVEL=FATAL nix develop --extra-experimental-features nix-command --extra-experimental-features flakes --command bash  -c "just movement-full-node native build.celestia-local --keep-tui"
```
then execute the new command on the local full node:
```
cargo build -p movement-full-node
target/debug/movement-full-node da submit_batch http://localhost:30730
```
# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->