### PR TITLE
feat: Add traits for Storage and Celestia client

### DIFF
--- a/protocol-units/da-sequencer/node/src/celestia/mod.rs
+++ b/protocol-units/da-sequencer/node/src/celestia/mod.rs
@@ -2,10 +2,46 @@ use crate::block::BlockHeight;
 use crate::block::SequencerBlockDigest;
 use crate::celestia::blob::Blob;
 use crate::error::DaSequencerError;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::mpsc::Sender;
 use url::Url;
 
 mod blob;
+
+/// Functions to implement to save block digest in an external DA like Celestia
+pub trait DaSequencerExternDaClient {
+	/// Create the Celestia client and all async process to manage celestia access.
+	fn new(
+		connection_url: Url,
+		notifier: Sender<CelestiaNotifier>,
+	) -> Pin<Box<dyn Future<Output = Self> + Send>>;
+
+	/// send the given block to Celestia.
+	/// The block is not immediatly sent but aggergated in a blob
+	/// Until the client can send it to celestia.
+	async fn send_block(
+		&self,
+		block: &SequencerBlockDigest,
+	) -> Pin<Box<dyn Future<Output = std::result::Result<(), DaSequencerError>> + Send>>;
+
+	/// Get the blob from celestia at the given height.
+	async fn get_blob_at_height(&self) -> Pin<Box<dyn Future<Output = Blob> + Send>>;
+
+	/// Bootstrap the Celestia client to recovert from missing block.
+	/// In case of crash for example, block sent to Celestia can be behind the block created by the network.
+	/// The role of this function is to recovert this missing block to all block of the network are sent to celestia.
+	/// The basic algorythm is start from 'last_sent_block_height' to 'current_block_height' and request using the notifier channel
+	/// The missing block. Not sure last_notified_celestia_height is useful.
+	/// During this boostrap new block are sent to the client.
+	/// These block should be buffered until the boostrap is done then sent after in order.
+	async fn bootstrap(
+		&self,
+		current_block_height: BlockHeight,
+		last_sent_block_height: BlockHeight,
+		last_notified_celestia_height: CelestiaHeight,
+	) -> Pin<Box<dyn Future<Output = std::result::Result<(), DaSequencerError>> + Send>>;
+}
 
 #[derive(Clone, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct CelestiaHeight(u64);

--- a/protocol-units/da-sequencer/node/src/storage/mod.rs
+++ b/protocol-units/da-sequencer/node/src/storage/mod.rs
@@ -6,6 +6,45 @@ use crate::block::SequencerBlockDigest;
 use crate::celestia::CelestiaHeight;
 use crate::error::DaSequencerError;
 
+pub trait DaSequencerStorage {
+	/// Save all batch's Tx in the pending Tx table. The batch's Tx has been verified and validated.
+	fn write_batch(&self, batch: DaBatch<FullnodeTx>) -> std::result::Result<(), DaSequencerError>;
+
+	/// Return, if exists, the Block at the given height.
+	fn get_block_at_height(
+		&self,
+		height: BlockHeight,
+	) -> std::result::Result<Option<SequencerBlock>, DaSequencerError>;
+
+	/// Return, if exists, the Block with specified sequencer id.
+	fn get_block_with_digest(
+		&self,
+		id: SequencerBlockDigest,
+	) -> std::result::Result<Option<SequencerBlock>, DaSequencerError>;
+
+	/// Produce next block with pending Tx.
+	/// Generate the new height.
+	/// Aggregate all pending Tx until the block is filled.
+	/// A block is filled if no more Tx are pending or it's size is more than the max size.
+	/// All pending Tx added to the block are removed from the pending Tx table.
+	/// Save the block for this height
+	/// Return the block.
+	fn produce_next_block(&self) -> std::result::Result<Option<SequencerBlock>, DaSequencerError>;
+
+	/// Return, if exists, the Celestia height for given block height.
+	fn get_celestia_height_for_block(
+		&self,
+		heigh: BlockHeight,
+	) -> std::result::Result<Option<CelestiaHeight>, DaSequencerError>;
+
+	/// Set the Celestia height for a given block height.
+	fn set_block_celestia_height(
+		&self,
+		block_heigh: BlockHeight,
+		celestia_heigh: CelestiaHeight,
+	) -> std::result::Result<(), DaSequencerError>;
+}
+
 pub struct Storage {}
 
 impl Storage {


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

<!--
Add your summary text here. 
 -->
Define trait for the Storage and Celestia client to allow to Mock them for the test.
It provides on the trait definition. Implementation will be done in future PR.

# Changelog
 * Add `DaSequencerStorage` trait
 * Add `DaSequencerExternDaClient` trait
 
<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->