### PR TITLE
da-sequencer: Connect grpc write_batch to the storage.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11559,6 +11559,7 @@ dependencies = [
 name = "movement-da-sequencer-config"
 version = "0.3.4"
 dependencies = [
+ "dot-movement",
  "ed25519-dalek 2.1.1",
  "godfig",
  "hex",
@@ -11579,8 +11580,10 @@ dependencies = [
  "aptos-sdk",
  "bcs 0.1.6 (git+https://github.com/movementlabsxyz/bcs.git?rev=bc16d2d39cabafaabd76173dd1b04b2aa170cf0c)",
  "chrono",
+ "dot-movement",
  "ed25519-dalek 2.1.1",
  "futures",
+ "godfig",
  "hex",
  "movement-da-sequencer-client",
  "movement-da-sequencer-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11580,6 +11580,7 @@ dependencies = [
  "bcs 0.1.6 (git+https://github.com/movementlabsxyz/bcs.git?rev=bc16d2d39cabafaabd76173dd1b04b2aa170cf0c)",
  "chrono",
  "ed25519-dalek 2.1.1",
+ "futures",
  "hex",
  "movement-da-sequencer-client",
  "movement-da-sequencer-config",

--- a/protocol-units/da-sequencer/client/Cargo.toml
+++ b/protocol-units/da-sequencer/client/Cargo.toml
@@ -22,4 +22,4 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 
 [lints]
-workspace = true
+#workspace = true

--- a/protocol-units/da-sequencer/client/src/lib.rs
+++ b/protocol-units/da-sequencer/client/src/lib.rs
@@ -1,5 +1,5 @@
-use ed25519_dalek::{SigningKey, Signature};
 use ed25519_dalek::Signer;
+use ed25519_dalek::{Signature, SigningKey};
 use movement_da_sequencer_proto::da_sequencer_node_service_client::DaSequencerNodeServiceClient;
 use std::time::Duration;
 use tonic::transport::{Channel, ClientTlsConfig};
@@ -14,7 +14,7 @@ pub struct DaSequencerClient {
 
 impl DaSequencerClient {
 	/// Creates an http2 connection to the Da Sequencer node service.
-	pub async fn try_connect(&self, connection_string: &str) -> Result<Self, anyhow::Error> {
+	pub async fn try_connect(connection_string: &str) -> Result<Self, anyhow::Error> {
 		for _ in 0..5 {
 			match DaSequencerClient::connect(connection_string).await {
 				Ok(client) => return Ok(DaSequencerClient { client }),
@@ -52,11 +52,12 @@ impl DaSequencerClient {
 		let response = self.client.batch_write(request).await?;
 		Ok(response.into_inner())
 	}
-	
+
 	/// Connects to a da sequencer node service using the given connection string.
 	async fn connect(
 		connection_string: &str,
 	) -> Result<DaSequencerNodeServiceClient<tonic::transport::Channel>, anyhow::Error> {
+		tracing::info!("Grpc client connect using :{connection_string}");
 		let endpoint = Channel::from_shared(connection_string.to_string())?;
 
 		// Dynamically configure TLS based on the scheme (http or https)
@@ -76,5 +77,5 @@ impl DaSequencerClient {
 }
 
 pub fn sign_batch(batch_data: &[u8], signing_key: &SigningKey) -> Signature {
-        signing_key.sign(batch_data)
+	signing_key.sign(batch_data)
 }

--- a/protocol-units/da-sequencer/config/Cargo.toml
+++ b/protocol-units/da-sequencer/config/Cargo.toml
@@ -18,6 +18,7 @@ ed25519-dalek = { workspace = true }
 rand = { workspace = true }
 tracing = { workspace = true }
 hex = { workspace = true }
+dot-movement = { workspace = true }
 
 [lints]
 workspace = true

--- a/protocol-units/da-sequencer/config/src/lib.rs
+++ b/protocol-units/da-sequencer/config/src/lib.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use tracing::info;
 
-pub const DASEQUENCER_CONF_FOLDER: &str = "da-sequencer";
+pub const DA_SEQUENCER_DIR: &str = "da-sequencer";
 
 fn default_signing_key() -> SigningKey {
         let mut bytes = [0u8; 32];

--- a/protocol-units/da-sequencer/config/src/lib.rs
+++ b/protocol-units/da-sequencer/config/src/lib.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use tracing::info;
 
+pub const DASEQUENCER_CONF_FOLDER: &str = "da-sequencer";
+
 fn default_signing_key() -> SigningKey {
         let mut bytes = [0u8; 32];
         OsRng.fill_bytes(&mut bytes);
@@ -20,6 +22,13 @@ fn default_signing_key() -> SigningKey {
 
         signing_key
 }
+
+pub fn get_config_path(dot_movement: &dot_movement::DotMovement) -> std::path::PathBuf {
+        let mut pathbuff = std::path::PathBuf::from(dot_movement.get_path());
+        pathbuff.push(DASEQUENCER_CONF_FOLDER);
+        pathbuff
+}
+
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DaSequencerConfig {

--- a/protocol-units/da-sequencer/config/src/lib.rs
+++ b/protocol-units/da-sequencer/config/src/lib.rs
@@ -25,7 +25,7 @@ fn default_signing_key() -> SigningKey {
 
 pub fn get_config_path(dot_movement: &dot_movement::DotMovement) -> std::path::PathBuf {
         let mut pathbuff = std::path::PathBuf::from(dot_movement.get_path());
-        pathbuff.push(DASEQUENCER_CONF_FOLDER);
+        pathbuff.push(DA_SEQUENCER_DIR);
         pathbuff
 }
 
@@ -34,6 +34,10 @@ pub fn get_config_path(dot_movement: &dot_movement::DotMovement) -> std::path::P
 pub struct DaSequencerConfig {
         #[serde(default = "default_movement_da_sequencer_listen_address")]
         pub movement_da_sequencer_listen_address: SocketAddr,
+
+        #[serde(default = "default_movement_da_sequencer_block_production_interval_millisec")]
+        pub movement_da_sequencer_block_production_interval_millisec: u64,
+
 
         #[serde(skip_deserializing, skip_serializing, default = "default_signing_key")]
         pub signing_key: SigningKey,
@@ -48,10 +52,18 @@ env_default!(
                 .expect("Bad da sequencer listener address.")
 );
 
+env_default!(
+        default_movement_da_sequencer_block_production_interval_millisec,
+        "MOVEMENT_DA_BLOCK_PRODUCTION_INTERVAL_MILLISEC",
+        u64,
+        500
+);
+
 impl Default for DaSequencerConfig {
         fn default() -> Self {
                 Self {
                         movement_da_sequencer_listen_address: default_movement_da_sequencer_listen_address(),
+                        movement_da_sequencer_block_production_interval_millisec: default_movement_da_sequencer_block_production_interval_millisec(),
                         signing_key: default_signing_key(),
                 }
         }

--- a/protocol-units/da-sequencer/node/Cargo.toml
+++ b/protocol-units/da-sequencer/node/Cargo.toml
@@ -30,6 +30,7 @@ tonic-reflection = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
+futures = { workspace = true }
 
 movement-da-sequencer-client = { workspace = true }
 movement-da-sequencer-config = { workspace = true }

--- a/protocol-units/da-sequencer/node/Cargo.toml
+++ b/protocol-units/da-sequencer/node/Cargo.toml
@@ -31,6 +31,8 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 futures = { workspace = true }
+dot-movement = { workspace = true }
+godfig = { workspace = true }
 
 movement-da-sequencer-client = { workspace = true }
 movement-da-sequencer-config = { workspace = true }

--- a/protocol-units/da-sequencer/node/src/batch.rs
+++ b/protocol-units/da-sequencer/node/src/batch.rs
@@ -1,12 +1,10 @@
-use aptos_sdk::crypto::hash::CryptoHash;
-use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use crate::error::DaSequencerError;
+use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use bcs;
-use ed25519_dalek::{Signature, Signer, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use movement_types::transaction::Transaction;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
-use movement_da_sequencer_config::DaSequencerConfig;
 
 #[derive(Debug)]
 pub struct RawData {
@@ -52,29 +50,24 @@ where
 {
 	/// Creates a test-only `DaBatch` with a real signature over the given data.
 	/// Only usable in tests.
-        pub fn test_only_new(data: D) -> Self
-        where
-                D: Serialize,
-        {
-                use rand::rngs::OsRng;
-        
-                let mut rng = OsRng;
-                let config = DaSequencerConfig::default();
-                let private_key = config.signing_key;
-                let public_key = private_key.verifying_key();
-        
-                let serialized = bcs::to_bytes(&data).unwrap(); // only fails if serialization is broken
-        
-                let signature = private_key.sign(&serialized);
-                let timestamp = chrono::Utc::now().timestamp_micros() as u64;
-        
-                Self {
-                        data,
-                        signature,
-                        signer: public_key,
-                        timestamp,
-                }
-        }
+	pub fn test_only_new(data: D) -> Self
+	where
+		D: Serialize,
+	{
+		use rand::rngs::OsRng;
+
+		let mut rng = OsRng;
+		let config = DaSequencerConfig::default();
+		let private_key = config.signing_key;
+		let public_key = private_key.verifying_key();
+
+		let serialized = bcs::to_bytes(&data).unwrap(); // only fails if serialization is broken
+
+		let signature = private_key.sign(&serialized);
+		let timestamp = chrono::Utc::now().timestamp_micros() as u64;
+
+		Self { data, signature, signer: public_key, timestamp }
+	}
 }
 
 pub fn serialize_full_node_batch(
@@ -100,91 +93,88 @@ pub fn deserialize_full_node_batch(
 	let signature_bytes: [u8; 64] = sign_deserialized.try_into()?;
 
 	let public_key = VerifyingKey::try_from(pub_key_bytes.as_slice())
-                .map_err(|_| DaSequencerError::DeserializationFailure)?;
-        let signature = Signature::try_from(signature_bytes.as_slice())
-                .map_err(|_| DaSequencerError::DeserializationFailure)?;
+		.map_err(|_| DaSequencerError::DeserializationFailure)?;
+	let signature = Signature::try_from(signature_bytes.as_slice())
+		.map_err(|_| DaSequencerError::DeserializationFailure)?;
 
 	let data: Vec<u8> = vec_deserialized.to_vec();
 	Ok((public_key, signature, data))
 }
 
 pub fn validate_batch(
-        new_batch: DaBatch<RawData>,
+	new_batch: DaBatch<RawData>,
 ) -> Result<DaBatch<FullNodeTxs>, DaSequencerError> {
-        verify_batch_signature(&new_batch.data.data, &new_batch.signature, &new_batch.signer)?;
+	verify_batch_signature(&new_batch.data.data, &new_batch.signature, &new_batch.signer)?;
 
-        let txs: FullNodeTxs = bcs::from_bytes(&new_batch.data.data)
-                .map_err(|_| DaSequencerError::DeserializationFailure)?;
+	let txs: FullNodeTxs = bcs::from_bytes(&new_batch.data.data)
+		.map_err(|_| DaSequencerError::DeserializationFailure)?;
 
-        Ok(DaBatch {
-                data: txs,
-                signature: new_batch.signature,
-                signer: new_batch.signer,
-                timestamp: new_batch.timestamp,
-        })
+	Ok(DaBatch {
+		data: txs,
+		signature: new_batch.signature,
+		signer: new_batch.signer,
+		timestamp: new_batch.timestamp,
+	})
 }
 
 pub fn verify_batch_signature(
-        batch_data: &[u8],
-        signature: &Signature,
-        public_key: &VerifyingKey,
+	batch_data: &[u8],
+	signature: &Signature,
+	public_key: &VerifyingKey,
 ) -> Result<(), DaSequencerError> {
-        public_key
-                .verify(batch_data, signature)
-                .map_err(|_| DaSequencerError::InvalidSignature)
+	public_key
+		.verify(batch_data, signature)
+		.map_err(|_| DaSequencerError::InvalidSignature)
 }
 
 #[cfg(test)]
 mod tests {
-        use super::*;
-        use movement_da_sequencer_client::sign_batch;
-        use movement_da_sequencer_config::DaSequencerConfig;
-        use tracing_subscriber;
+	use super::*;
+	use movement_da_sequencer_client::sign_batch;
+	use movement_da_sequencer_config::DaSequencerConfig;
+	use tracing_subscriber;
 
-        #[test]
-        fn test_sign_and_validate_batch() {
-                let _ = tracing_subscriber::fmt()
-                        .with_max_level(tracing::Level::INFO)
-                        .with_test_writer()
-                        .try_init();
-        
-                let config = DaSequencerConfig::default();
-                let signing_key = config.signing_key;
-                let verifying_key = signing_key.verifying_key();
-        
-                // Create transactions and batch
-                let txs = FullNodeTxs(vec![
-                        Transaction::new(b"hello".to_vec(), 0, 1),
-                        Transaction::new(b"world".to_vec(), 0, 2),
-                ]);
-        
-                let batch_bytes = bcs::to_bytes(&txs).expect("Serialization failed");
-                let signature = sign_batch(&batch_bytes, &signing_key);
-        
-                // Serialize full node batch into raw bytes
-                let serialized = serialize_full_node_batch(
-                        verifying_key,
-                        signature.clone(),
-                        batch_bytes.clone(),
-                );
-        
-                // Deserialize it back
-                let (deserialized_key, deserialized_sig, deserialized_data) =
-                        deserialize_full_node_batch(serialized).expect("Deserialization failed");
-        
-                // Recreate the raw batch from deserialized data
-                let raw_batch = DaBatch {
-                        data: RawData { data: deserialized_data },
-                        signature: deserialized_sig,
-                        signer: deserialized_key,
-                        timestamp: chrono::Utc::now().timestamp_micros() as u64,
-                };
-        
-                // Validate the batch
-                let validated = validate_batch(raw_batch).expect("Batch should validate");
-        
-                // Check it worked
-                assert_eq!(validated.data.0.len(), 2);
-                assert_eq!(validated.data.0, txs.0);
-        }
+	#[test]
+	fn test_sign_and_validate_batch() {
+		let _ = tracing_subscriber::fmt()
+			.with_max_level(tracing::Level::INFO)
+			.with_test_writer()
+			.try_init();
+
+		let config = DaSequencerConfig::default();
+		let signing_key = config.signing_key;
+		let verifying_key = signing_key.verifying_key();
+
+		// Create transactions and batch
+		let txs = FullNodeTxs(vec![
+			Transaction::new(b"hello".to_vec(), 0, 1),
+			Transaction::new(b"world".to_vec(), 0, 2),
+		]);
+
+		let batch_bytes = bcs::to_bytes(&txs).expect("Serialization failed");
+		let signature = sign_batch(&batch_bytes, &signing_key);
+
+		// Serialize full node batch into raw bytes
+		let serialized =
+			serialize_full_node_batch(verifying_key, signature.clone(), batch_bytes.clone());
+
+		// Deserialize it back
+		let (deserialized_key, deserialized_sig, deserialized_data) =
+			deserialize_full_node_batch(serialized).expect("Deserialization failed");
+
+		// Recreate the raw batch from deserialized data
+		let raw_batch = DaBatch {
+			data: RawData { data: deserialized_data },
+			signature: deserialized_sig,
+			signer: deserialized_key,
+			timestamp: chrono::Utc::now().timestamp_micros() as u64,
+		};
+
+		// Validate the batch
+		let validated = validate_batch(raw_batch).expect("Batch should validate");
+
+		// Check it worked
+		assert_eq!(validated.data.0.len(), 2);
+		assert_eq!(validated.data.0, txs.0);
+	}
 }

--- a/protocol-units/da-sequencer/node/src/celestia/mod.rs
+++ b/protocol-units/da-sequencer/node/src/celestia/mod.rs
@@ -10,23 +10,17 @@ use url::Url;
 mod blob;
 
 /// Functions to implement to save block digest in an external DA like Celestia
-pub trait DaSequencerExternDaClient {
-	/// Create the Celestia client and all async process to manage celestia access.
-	fn new(
-		connection_url: Url,
-		notifier: Sender<CelestiaNotifier>,
-	) -> Pin<Box<dyn Future<Output = Self> + Send>>;
-
+pub trait DaSequencerExternDaClient: Clone {
 	/// send the given block to Celestia.
 	/// The block is not immediatly sent but aggergated in a blob
 	/// Until the client can send it to celestia.
-	async fn send_block(
+	fn send_block(
 		&self,
 		block: &SequencerBlockDigest,
-	) -> Pin<Box<dyn Future<Output = std::result::Result<(), DaSequencerError>> + Send>>;
+	) -> impl Future<Output = std::result::Result<(), DaSequencerError>> + Send;
 
 	/// Get the blob from celestia at the given height.
-	async fn get_blob_at_height(&self) -> Pin<Box<dyn Future<Output = Blob> + Send>>;
+	fn get_blob_at_height(&self) -> Pin<Box<dyn Future<Output = Blob> + Send>>;
 
 	/// Bootstrap the Celestia client to recovert from missing block.
 	/// In case of crash for example, block sent to Celestia can be behind the block created by the network.
@@ -35,12 +29,12 @@ pub trait DaSequencerExternDaClient {
 	/// The missing block. Not sure last_notified_celestia_height is useful.
 	/// During this boostrap new block are sent to the client.
 	/// These block should be buffered until the boostrap is done then sent after in order.
-	async fn bootstrap(
+	fn bootstrap(
 		&self,
 		current_block_height: BlockHeight,
 		last_sent_block_height: BlockHeight,
 		last_notified_celestia_height: CelestiaHeight,
-	) -> Pin<Box<dyn Future<Output = std::result::Result<(), DaSequencerError>> + Send>>;
+	) -> impl Future<Output = std::result::Result<(), DaSequencerError>> + Send;
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/protocol-units/da-sequencer/node/src/celestia/mod.rs
+++ b/protocol-units/da-sequencer/node/src/celestia/mod.rs
@@ -20,7 +20,9 @@ pub trait DaSequencerExternDaClient: Clone {
 	) -> impl Future<Output = std::result::Result<(), DaSequencerError>> + Send;
 
 	/// Get the blob from celestia at the given height.
-	fn get_blob_at_height(&self) -> Pin<Box<dyn Future<Output = Blob> + Send>>;
+	fn get_blob_at_height(
+		&self,
+	) -> impl Future<Output = Result<Option<Blob>, DaSequencerError>> + Send;
 
 	/// Bootstrap the Celestia client to recovert from missing block.
 	/// In case of crash for example, block sent to Celestia can be behind the block created by the network.
@@ -73,7 +75,7 @@ impl CelestiaClient {
 	}
 
 	/// Get the blob from celestia at the given height.
-	pub async fn get_blob_at_height(&self) -> Blob {
+	pub async fn get_blob_at_height(&self) -> Result<Option<Blob>, DaSequencerError> {
 		todo!()
 	}
 

--- a/protocol-units/da-sequencer/node/src/celestia/mod.rs
+++ b/protocol-units/da-sequencer/node/src/celestia/mod.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 use std::sync::mpsc::Sender;
 use url::Url;
 
-mod blob;
+pub mod blob;
 
 /// Functions to implement to save block digest in an external DA like Celestia
 pub trait DaSequencerExternDaClient: Clone {

--- a/protocol-units/da-sequencer/node/src/celestia/mod.rs
+++ b/protocol-units/da-sequencer/node/src/celestia/mod.rs
@@ -3,7 +3,6 @@ use crate::block::SequencerBlockDigest;
 use crate::celestia::blob::Blob;
 use crate::error::DaSequencerError;
 use std::future::Future;
-use std::pin::Pin;
 use std::sync::mpsc::Sender;
 use url::Url;
 
@@ -17,7 +16,7 @@ pub trait DaSequencerExternDaClient: Clone {
 	fn send_block(
 		&self,
 		block: &SequencerBlockDigest,
-	) -> impl Future<Output = std::result::Result<(), DaSequencerError>> + Send;
+	) -> impl Future<Output = Result<(), DaSequencerError>> + Send;
 
 	/// Get the blob from celestia at the given height.
 	fn get_blob_at_height(
@@ -67,10 +66,7 @@ impl CelestiaClient {
 	/// send the given block to Celestia.
 	/// The block is not immediatly sent but aggergated in a blob
 	/// Until the client can send it to celestia.
-	pub async fn send_block(
-		&self,
-		block: &SequencerBlockDigest,
-	) -> std::result::Result<(), DaSequencerError> {
+	pub async fn send_block(&self, block: &SequencerBlockDigest) -> Result<(), DaSequencerError> {
 		todo!()
 	}
 
@@ -91,7 +87,7 @@ impl CelestiaClient {
 		current_block_height: BlockHeight,
 		last_sent_block_height: BlockHeight,
 		last_notified_celestia_height: CelestiaHeight,
-	) -> std::result::Result<(), DaSequencerError> {
+	) -> Result<(), DaSequencerError> {
 		todo!()
 	}
 }

--- a/protocol-units/da-sequencer/node/src/celestia/mod.rs
+++ b/protocol-units/da-sequencer/node/src/celestia/mod.rs
@@ -36,7 +36,7 @@ pub trait DaSequencerExternDaClient: Clone {
 		current_block_height: BlockHeight,
 		last_sent_block_height: BlockHeight,
 		last_notified_celestia_height: CelestiaHeight,
-	) -> impl Future<Output = std::result::Result<(), DaSequencerError>> + Send;
+	) -> impl Future<Output = Result<(), DaSequencerError>> + Send;
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/protocol-units/da-sequencer/node/src/error.rs
+++ b/protocol-units/da-sequencer/node/src/error.rs
@@ -17,10 +17,10 @@ pub enum DaSequencerError {
 	BatchSerializationError(#[from] std::array::TryFromSliceError),
 	#[error("Key or signature are badly formated: {0}")]
 	BadKeyOrSign(#[from] aptos_sdk::crypto::CryptoMaterialError),
-        #[error("Failed to serialize FullnodeTx batch")]
-        SerializationFailure,
-        #[error("Failed to deserialize FullnodeTx batch")]
-        DeserializationFailure,
-        #[error("Signature was invalid")]
-        InvalidSignature,
+	#[error("Failed to serialize FullnodeTx batch")]
+	SerializationFailure,
+	#[error("Failed to deserialize FullnodeTx batch")]
+	DeserializationFailure,
+	#[error("Signature was invalid")]
+	InvalidSignature,
 }

--- a/protocol-units/da-sequencer/node/src/lib.rs
+++ b/protocol-units/da-sequencer/node/src/lib.rs
@@ -13,8 +13,10 @@ pub mod batch;
 mod block;
 mod celestia;
 pub mod error;
-mod server;
+pub mod server;
 mod storage;
+#[cfg(test)]
+mod tests;
 
 /// Run Da sequencing loop.
 /// This function only return in case of error that indicate a crash of the node.

--- a/protocol-units/da-sequencer/node/src/lib.rs
+++ b/protocol-units/da-sequencer/node/src/lib.rs
@@ -20,17 +20,19 @@ mod tests;
 
 /// Run Da sequencing loop.
 /// This function only return in case of error that indicate a crash of the node.
-pub async fn run<DA, S>(
+pub async fn run<D, S>(
 	config: DaSequencerConfig,
 	mut request_rx: mpsc::Receiver<GrpcRequests>,
 	storage: S,
-	celestia: DA,
+	celestia: D,
 ) -> Result<(), DaSequencerError>
 where
-	DA: DaSequencerExternDaClient + Send + 'static,
+	D: DaSequencerExternDaClient + Send + 'static,
 	S: DaSequencerStorage + Send + 'static,
 {
-	let mut produce_block_interval = tokio::time::interval(tokio::time::Duration::from_millis(500)); //todo put interval value in the config.
+	let mut produce_block_interval = tokio::time::interval(tokio::time::Duration::from_millis(
+		config.movement_da_sequencer_block_production_interval_millisec,
+	)); //todo put interval value in the config.
 	let mut spawn_result_futures = FuturesUnordered::new();
 	let mut produce_block_jh = None;
 
@@ -111,7 +113,7 @@ where
 	}
 }
 
-// manage the optional future for block production.
+/// manage the optional future for block production.
 async fn conditional_block_producing(
 	fut: Option<&mut JoinHandle<Result<Option<SequencerBlock>, DaSequencerError>>>,
 ) -> Option<SequencerBlock> {

--- a/protocol-units/da-sequencer/node/src/lib.rs
+++ b/protocol-units/da-sequencer/node/src/lib.rs
@@ -25,7 +25,7 @@ pub async fn run<DA, S>(
 	mut request_rx: mpsc::Receiver<GrpcRequests>,
 	storage: S,
 	celestia: DA,
-) -> std::result::Result<(), DaSequencerError>
+) -> Result<(), DaSequencerError>
 where
 	DA: DaSequencerExternDaClient + Send + 'static,
 	S: DaSequencerStorage + Send + 'static,

--- a/protocol-units/da-sequencer/node/src/lib.rs
+++ b/protocol-units/da-sequencer/node/src/lib.rs
@@ -1,8 +1,13 @@
+use crate::block::SequencerBlock;
+use crate::celestia::DaSequencerExternDaClient;
 use crate::error::DaSequencerError;
 use crate::server::GrpcRequests;
-use crate::storage::Storage;
+use crate::storage::DaSequencerStorage;
+use futures::stream::FuturesUnordered;
 use movement_da_sequencer_config::DaSequencerConfig;
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_stream::StreamExt;
 
 pub mod batch;
 mod block;
@@ -13,28 +18,118 @@ mod storage;
 
 /// Run Da sequencing loop.
 /// This function only return in case of error that indicate a crash of the node.
-pub async fn run(
+pub async fn run<DA, S>(
 	config: DaSequencerConfig,
 	mut request_rx: mpsc::Receiver<GrpcRequests>,
-) -> std::result::Result<(), DaSequencerError> {
+	storage: S,
+	celestia: DA,
+) -> std::result::Result<(), DaSequencerError>
+where
+	DA: DaSequencerExternDaClient + Send + 'static,
+	S: DaSequencerStorage + Send + 'static,
+{
 	let mut produce_block_interval = tokio::time::interval(tokio::time::Duration::from_millis(500)); //todo put interval value in the config.
+	let mut spawn_result_futures = FuturesUnordered::new();
+	let mut produce_block_jh = None;
+
 	loop {
 		tokio::select! {
+			// Manage grpc request.
 			Some(grpc_request) = request_rx.recv() => {
 				match grpc_request {
 					GrpcRequests::StartBlockStream { callback } => todo!(),
-					GrpcRequests::GetBlockHeight { block_height, callback } => todo!(),
+					GrpcRequests::GetBlockHeight { block_height, callback } => {
+						let get_block_jh = tokio::task::spawn_blocking({
+							let storage = storage.clone();
+							move || {storage.get_block_at_height(block_height)}
+						});
+						tokio::spawn(async move {
+							let result = get_block_jh.await;
+							//manage result
+							let to_send = match result {
+								Err(err) => {
+									tracing::error!("spawn_blocking task failed: {err}");
+									None
+								}
+								Ok(Err(err)) => {
+									tracing::error!("Storage get_block_at_height return an error: {err}");
+									None
+
+								}
+								Ok(Ok(block)) => block,
+							};
+
+							let _ = callback.send(to_send);
+						});
+					},
 					GrpcRequests::WriteBatch(batch) => {
 						//send batch to the storage.
+						let write_batch_jh = tokio::task::spawn_blocking({
+							let storage = storage.clone();
+							move || {storage.write_batch(batch)}
+						});
+						spawn_result_futures.push(write_batch_jh);
 					},
 
 				}
 			}
+			// Every tick product a new block.
 			_ = produce_block_interval.tick() => {
-				//produce one block
+				// Produce only one block at a time.
+				// If some is already in production, wait next tick.
+				if produce_block_jh.is_none() {
+					let produce_block_batch_jh = tokio::task::spawn_blocking({
+						let storage = storage.clone();
+						move || {storage.produce_next_block()}
+					});
+					produce_block_jh = Some(produce_block_batch_jh);
+				}
+			}
 
-				//propagate the new block.
+			//propagate the new block.
+			Some(block) = conditional_block_producing(produce_block_jh.as_mut()) => {
+				let block_digest = block.get_block_digest();
+				// Send the block to all registered follower
+
+				//send the block to Celestia.
+				let celestia_send_jh = tokio::spawn({
+					let celestia = celestia.clone();
+					async move {celestia.send_block(&block_digest).await}
+				});
+				spawn_result_futures.push(celestia_send_jh);
+			}
+
+			Some(Ok(res)) = spawn_result_futures.next() =>  {
+				// just log for now, add more logic later.
+				if let Err(err) = res {
+					tracing::error!("Error during future execution:{err}");
+				}
 			}
 		}
+	}
+}
+
+// manage the optional future for block production.
+async fn conditional_block_producing(
+	fut: Option<&mut JoinHandle<Result<Option<SequencerBlock>, DaSequencerError>>>,
+) -> Option<SequencerBlock> {
+	match fut {
+		Some(fut) => {
+			let res = fut.await;
+			match res {
+				Ok(Ok(Some(res))) => Some(res),
+				Ok(Ok(None)) => None,
+				Ok(Err(err)) => {
+					// for now log the error, TODO better error management.
+					tracing::error!("Error during Block producing:{err}");
+					None
+				}
+				Err(err) => {
+					tracing::error!("Block producing joinhandle failed to execute:{err}");
+					None
+				}
+			}
+		}
+		None => None,
 	}
 }

--- a/protocol-units/da-sequencer/node/src/main.rs
+++ b/protocol-units/da-sequencer/node/src/main.rs
@@ -1,9 +1,10 @@
 use godfig::{backend::config_file::ConfigFile, Godfig};
 use movement_da_sequencer_config::DaSequencerConfig;
+use std::error::Error;
 use tokio::sync::mpsc;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn Error>> {
 	use tracing_subscriber::EnvFilter;
 
 	tracing_subscriber::fmt()
@@ -28,7 +29,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	let (request_tx, request_rx) = mpsc::channel(100);
 	// Start gprc server
-	let grpc_address = dasequencer_config.movement_da_sequencer_listen_address;
+	let grpc_address = da_sequencer_config.movement_da_sequencer_listen_address;
 	let grpc_jh = tokio::spawn(async move {
 		movement_da_sequencer_node::server::run_server(grpc_address, request_tx).await
 	});

--- a/protocol-units/da-sequencer/node/src/main.rs
+++ b/protocol-units/da-sequencer/node/src/main.rs
@@ -1,0 +1,40 @@
+use godfig::{backend::config_file::ConfigFile, Godfig};
+use movement_da_sequencer_config::DaSequencerConfig;
+use tokio::sync::mpsc;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	use tracing_subscriber::EnvFilter;
+
+	tracing_subscriber::fmt()
+		.with_env_filter(
+			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+		)
+		.init();
+
+	tracing::info!("Start Bridge");
+
+	// Define da-sequencer config path
+	let mut dot_movement = dot_movement::DotMovement::try_from_env()?;
+	let pathbuff = movement_da_sequencer_config::get_config_path(&dot_movement);
+	dot_movement.set_path(pathbuff);
+
+	let config_file = dot_movement.try_get_or_create_config_file().await?;
+
+	// Get a matching godfig object
+	let godfig: Godfig<DaSequencerConfig, ConfigFile> =
+		Godfig::new(ConfigFile::new(config_file), vec![]);
+	let dasequencer_config: DaSequencerConfig = godfig.try_wait_for_ready().await?;
+
+	let (request_tx, request_rx) = mpsc::channel(100);
+	// Start gprc server
+	let grpc_address = dasequencer_config.movement_da_sequencer_listen_address;
+	let grpc_jh = tokio::spawn(async move {
+		movement_da_sequencer_node::server::run_server(grpc_address, request_tx).await
+	});
+
+	//Start the main loop
+	todo!();
+
+	Ok(())
+}

--- a/protocol-units/da-sequencer/node/src/main.rs
+++ b/protocol-units/da-sequencer/node/src/main.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	// Get a matching godfig object
 	let godfig: Godfig<DaSequencerConfig, ConfigFile> =
 		Godfig::new(ConfigFile::new(config_file), vec![]);
-	let dasequencer_config: DaSequencerConfig = godfig.try_wait_for_ready().await?;
+	let da_sequencer_config: DaSequencerConfig = godfig.try_wait_for_ready().await?;
 
 	let (request_tx, request_rx) = mpsc::channel(100);
 	// Start gprc server

--- a/protocol-units/da-sequencer/node/src/server.rs
+++ b/protocol-units/da-sequencer/node/src/server.rs
@@ -35,7 +35,7 @@ pub async fn run_server(
 #[derive(Debug)]
 pub enum GrpcRequests {
 	StartBlockStream { callback: oneshot::Sender<(BlockHeight, mpsc::Receiver<SequencerBlock>)> },
-	GetBlockHeight { block_height: BlockHeight, callback: oneshot::Sender<SequencerBlock> },
+	GetBlockHeight { block_height: BlockHeight, callback: oneshot::Sender<Option<SequencerBlock>> },
 	WriteBatch(DaBatch<FullNodeTxs>),
 }
 

--- a/protocol-units/da-sequencer/node/src/server.rs
+++ b/protocol-units/da-sequencer/node/src/server.rs
@@ -21,7 +21,7 @@ pub async fn run_server(
 		.register_encoded_file_descriptor_set(movement_da_sequencer_proto::FILE_DESCRIPTOR_SET)
 		.build_v1()?;
 
-	tracing::info!("Server start on: {}", address);
+	tracing::info!("Server started on: {}", address);
 	Server::builder()
 		.max_frame_size(1024 * 1024 * 16 - 1)
 		.accept_http1(true)

--- a/protocol-units/da-sequencer/node/src/server.rs
+++ b/protocol-units/da-sequencer/node/src/server.rs
@@ -16,11 +16,12 @@ pub async fn run_server(
 	address: SocketAddr,
 	request_tx: mpsc::Sender<GrpcRequests>,
 ) -> Result<(), anyhow::Error> {
+	tracing::info!("Server listening on: {}", address);
 	let reflection = tonic_reflection::server::Builder::configure()
 		.register_encoded_file_descriptor_set(movement_da_sequencer_proto::FILE_DESCRIPTOR_SET)
 		.build_v1()?;
 
-	tracing::info!("Server listening on: {}", address);
+	tracing::info!("Server start on: {}", address);
 	Server::builder()
 		.max_frame_size(1024 * 1024 * 16 - 1)
 		.accept_http1(true)

--- a/protocol-units/da-sequencer/node/src/storage/mod.rs
+++ b/protocol-units/da-sequencer/node/src/storage/mod.rs
@@ -5,10 +5,8 @@ use crate::{
 	error::DaSequencerError,
 };
 use bcs;
-use movement_types::block::{Block, BlockMetadata, Id};
-use movement_types::transaction::Transaction;
 use rocksdb::{ColumnFamilyDescriptor, Options, WriteBatch, DB};
-use std::{collections::BTreeSet, result::Result, sync::Arc};
+use std::{result::Result, sync::Arc};
 
 pub mod cf {
 	pub const PENDING_TRANSACTIONS: &str = "pending_transactions";
@@ -16,12 +14,12 @@ pub mod cf {
 	pub const BLOCKS_BY_DIGEST: &str = "blocks_by_digest";
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Storage {
 	db: Arc<DB>,
 }
 
-pub trait DaSequencerStorage {
+pub trait DaSequencerStorage: Clone {
 	/// Save all batch's Tx in the pending Tx table. The batch's Tx has been verified and validated.
 	fn write_batch(&self, batch: DaBatch<FullNodeTxs>)
 		-> std::result::Result<(), DaSequencerError>;
@@ -45,7 +43,7 @@ pub trait DaSequencerStorage {
 	/// All pending Tx added to the block are removed from the pending Tx table.
 	/// Save the block for this height
 	/// Return the block.
-	fn produce_next_block(&self) -> std::result::Result<Option<SequencerBlock>, DaSequencerError>;
+	fn produce_next_block(&self) -> Result<Option<SequencerBlock>, DaSequencerError>;
 
 	/// Return, if exists, the Celestia height for given block height.
 	fn get_celestia_height_for_block(

--- a/protocol-units/da-sequencer/node/src/tests/mock.rs
+++ b/protocol-units/da-sequencer/node/src/tests/mock.rs
@@ -10,7 +10,6 @@ use crate::DaSequencerStorage;
 use crate::SequencerBlock;
 use std::cell::RefCell;
 use std::future::Future;
-use std::pin::Pin;
 
 #[derive(Debug, Clone)]
 pub struct StorageMock {

--- a/protocol-units/da-sequencer/node/src/tests/mock.rs
+++ b/protocol-units/da-sequencer/node/src/tests/mock.rs
@@ -85,8 +85,11 @@ impl DaSequencerExternDaClient for CelestiaMock {
 		futures::future::ready(Ok(()))
 	}
 
-	fn get_blob_at_height(&self) -> Pin<Box<dyn Future<Output = Blob> + Send>> {
-		todo!();
+	fn get_blob_at_height(
+		&self,
+	) -> impl Future<Output = Result<Option<Blob>, DaSequencerError>> + Send {
+		//TODO return dummy error for now.
+		futures::future::ready(Err(DaSequencerError::DeserializationFailure))
 	}
 
 	fn bootstrap(

--- a/protocol-units/da-sequencer/node/src/tests/mock.rs
+++ b/protocol-units/da-sequencer/node/src/tests/mock.rs
@@ -1,0 +1,100 @@
+use crate::batch::DaBatch;
+use crate::batch::FullNodeTxs;
+use crate::block::BlockHeight;
+use crate::block::SequencerBlockDigest;
+use crate::celestia::blob::Blob;
+use crate::celestia::CelestiaHeight;
+use crate::DaSequencerError;
+use crate::DaSequencerExternDaClient;
+use crate::DaSequencerStorage;
+use crate::SequencerBlock;
+use std::cell::RefCell;
+use std::future::Future;
+use std::pin::Pin;
+
+#[derive(Debug, Clone)]
+pub struct StorageMock {
+	pub batches: RefCell<Vec<DaBatch<FullNodeTxs>>>,
+	pub current_height: u64,
+}
+
+impl StorageMock {
+	pub fn new() -> Self {
+		StorageMock { batches: RefCell::new(Vec::new()), current_height: 0 }
+	}
+}
+
+impl DaSequencerStorage for StorageMock {
+	fn write_batch(
+		&self,
+		batch: DaBatch<FullNodeTxs>,
+	) -> std::result::Result<(), DaSequencerError> {
+		tracing::info!("Mock: Storage, call write_batch");
+		self.batches.borrow_mut().push(batch);
+		Ok(())
+	}
+
+	fn get_block_at_height(
+		&self,
+		height: BlockHeight,
+	) -> std::result::Result<Option<SequencerBlock>, DaSequencerError> {
+		todo!();
+	}
+
+	fn get_block_with_digest(
+		&self,
+		id: SequencerBlockDigest,
+	) -> std::result::Result<Option<SequencerBlock>, DaSequencerError> {
+		todo!();
+	}
+
+	fn produce_next_block(&self) -> Result<Option<SequencerBlock>, DaSequencerError> {
+		Ok(None)
+	}
+
+	fn get_celestia_height_for_block(
+		&self,
+		heigh: BlockHeight,
+	) -> std::result::Result<Option<CelestiaHeight>, DaSequencerError> {
+		todo!();
+	}
+
+	fn set_block_celestia_height(
+		&self,
+		block_heigh: BlockHeight,
+		celestia_heigh: CelestiaHeight,
+	) -> std::result::Result<(), DaSequencerError> {
+		todo!();
+	}
+}
+
+#[derive(Debug, Clone)]
+pub struct CelestiaMock {}
+
+impl CelestiaMock {
+	pub fn new() -> Self {
+		CelestiaMock {}
+	}
+}
+
+impl DaSequencerExternDaClient for CelestiaMock {
+	fn send_block(
+		&self,
+		block: &SequencerBlockDigest,
+	) -> impl Future<Output = std::result::Result<(), DaSequencerError>> + Send {
+		futures::future::ready(Ok(()))
+	}
+
+	fn get_blob_at_height(&self) -> Pin<Box<dyn Future<Output = Blob> + Send>> {
+		todo!();
+	}
+
+	fn bootstrap(
+		&self,
+		current_block_height: BlockHeight,
+		last_sent_block_height: BlockHeight,
+		last_notified_celestia_height: CelestiaHeight,
+	) -> impl Future<Output = std::result::Result<(), DaSequencerError>> + Send {
+		futures::future::ready(Ok(()))
+	}
+}

--- a/protocol-units/da-sequencer/node/src/tests/mod.rs
+++ b/protocol-units/da-sequencer/node/src/tests/mod.rs
@@ -1,10 +1,10 @@
 use crate::batch::serialize_full_node_batch;
-use crate::batch::FullNodeTxs;
+use crate::batch::{FullNodeTxs, serialize_full_node_batch};
 use crate::run;
 use crate::server::run_server;
 use crate::tests::mock::CelestiaMock;
-use crate::tests::mock::StorageMock;
-use movement_da_sequencer_client::sign_batch;
+use crate::tests::mock::{StorageMock, CelestiaMock};
+use movement_da_sequencer_client::{sign_batch, DaSequencerClient};
 use movement_da_sequencer_client::DaSequencerClient;
 use movement_da_sequencer_config::DaSequencerConfig;
 use movement_da_sequencer_proto::BatchWriteRequest;
@@ -50,10 +50,10 @@ async fn test_write_batch_gprc_main_loop() {
 	let connection_string = format!("http://127.0.0.1:{}", grpc_address.port());
 	let mut client = DaSequencerClient::try_connect(&connection_string)
 		.await
-		.expect("Grpc CLient connection failed.");
+		.expect("gRPC client connection failed.");
 
 	let request = BatchWriteRequest { data: serialized };
-	let res = client.batch_write(request).await.expect("Fail to send the batch.");
+	let res = client.batch_write(request).await.expect("Failed to send the batch.");
 	tracing::info!("{res:?}",);
 	assert!(res.answer);
 

--- a/protocol-units/da-sequencer/node/src/tests/mod.rs
+++ b/protocol-units/da-sequencer/node/src/tests/mod.rs
@@ -1,0 +1,65 @@
+use crate::batch::serialize_full_node_batch;
+use crate::batch::FullNodeTxs;
+use crate::run;
+use crate::server::run_server;
+use crate::tests::mock::CelestiaMock;
+use crate::tests::mock::StorageMock;
+use movement_da_sequencer_client::sign_batch;
+use movement_da_sequencer_client::DaSequencerClient;
+use movement_da_sequencer_config::DaSequencerConfig;
+use movement_da_sequencer_proto::BatchWriteRequest;
+use movement_types::transaction::Transaction;
+use tokio::sync::mpsc;
+
+mod mock;
+
+#[tokio::test]
+async fn test_write_batch_gprc_main_loop() {
+	let (request_tx, request_rx) = mpsc::channel(100);
+
+	let config = DaSequencerConfig::default();
+	let signing_key = config.signing_key.clone();
+	let verifying_key = signing_key.verifying_key();
+
+	// Start gprc server
+	let grpc_address = config.movement_da_sequencer_listen_address;
+	let grpc_jh = tokio::spawn(async move { run_server(grpc_address, request_tx).await });
+
+	//start main loop
+	let storage_mock = StorageMock::new();
+	let celestia_mock = CelestiaMock::new();
+	let loop_jh = tokio::spawn(run(config, request_rx, storage_mock, celestia_mock));
+
+	//need to wait the server is started before connecting
+	let _ = tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+
+	let tx = Transaction::test_only_new(b"test data".to_vec(), 1, 123);
+	let tx_id = tx.id();
+
+	let txs = FullNodeTxs::new(vec![tx]);
+
+	//sign batch
+	let batch_bytes = bcs::to_bytes(&txs).expect("Serialization failed");
+	let signature = sign_batch(&batch_bytes, &signing_key);
+
+	// Serialize full node batch into raw bytes
+	let serialized =
+		serialize_full_node_batch(verifying_key, signature.clone(), batch_bytes.clone());
+
+	//send the bacth using the grpc client
+	let connection_string = format!("http://127.0.0.1:{}", grpc_address.port());
+	let mut client = DaSequencerClient::try_connect(&connection_string)
+		.await
+		.expect("Grpc CLient connection failed.");
+
+	let request = BatchWriteRequest { data: serialized };
+	let res = client.batch_write(request).await.expect("Fail to send the batch.");
+	tracing::info!("{res:?}",);
+	assert!(res.answer);
+
+	//TODO verify the block produced contains the batch.
+	// Wait the implementation of the stream of block.
+
+	//wait at least one block production
+	let _ = tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+}

--- a/protocol-units/da-sequencer/node/src/tests/mod.rs
+++ b/protocol-units/da-sequencer/node/src/tests/mod.rs
@@ -1,20 +1,18 @@
-use crate::batch::serialize_full_node_batch;
-use crate::batch::{FullNodeTxs, serialize_full_node_batch};
+use crate::batch::{serialize_full_node_batch, FullNodeTxs};
 use crate::run;
 use crate::server::run_server;
-use crate::tests::mock::CelestiaMock;
-use crate::tests::mock::{StorageMock, CelestiaMock};
+use crate::tests::mock::{CelestiaMock, StorageMock};
+use ed25519_dalek::Signature;
 use movement_da_sequencer_client::{sign_batch, DaSequencerClient};
-use movement_da_sequencer_client::DaSequencerClient;
 use movement_da_sequencer_config::DaSequencerConfig;
 use movement_da_sequencer_proto::BatchWriteRequest;
 use movement_types::transaction::Transaction;
 use tokio::sync::mpsc;
 
-mod mock;
+pub mod mock;
 
 #[tokio::test]
-async fn test_write_batch_gprc_main_loop() {
+async fn test_write_batch_gprc_main_loop_happy_path() {
 	let (request_tx, request_rx) = mpsc::channel(100);
 
 	let config = DaSequencerConfig::default();
@@ -34,7 +32,6 @@ async fn test_write_batch_gprc_main_loop() {
 	let _ = tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
 
 	let tx = Transaction::test_only_new(b"test data".to_vec(), 1, 123);
-	let tx_id = tx.id();
 
 	let txs = FullNodeTxs::new(vec![tx]);
 
@@ -58,6 +55,57 @@ async fn test_write_batch_gprc_main_loop() {
 	assert!(res.answer);
 
 	//TODO verify the block produced contains the batch.
+	// Wait the implementation of the stream of block.
+
+	//wait at least one block production
+	let _ = tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+}
+
+#[tokio::test]
+async fn test_write_batch_gprc_main_loop_happy_path_unhappy_path() {
+	let (request_tx, request_rx) = mpsc::channel(100);
+
+	let config = DaSequencerConfig::default();
+	let signing_key = config.signing_key.clone();
+	let verifying_key = signing_key.verifying_key();
+
+	// Start gprc server
+	let grpc_address = config.movement_da_sequencer_listen_address;
+	let grpc_jh = tokio::spawn(async move { run_server(grpc_address, request_tx).await });
+
+	//start main loop
+	let storage_mock = StorageMock::new();
+	let celestia_mock = CelestiaMock::new();
+	let loop_jh = tokio::spawn(run(config, request_rx, storage_mock, celestia_mock));
+
+	//need to wait the server is started before connecting
+	let _ = tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+
+	let tx = Transaction::test_only_new(b"test data".to_vec(), 1, 123);
+
+	let txs = FullNodeTxs::new(vec![tx]);
+
+	let batch_bytes = bcs::to_bytes(&txs).expect("Serialization failed");
+	//define a dummy signature for the batch
+	let signature = Signature::from_bytes(&[0; 64]);
+
+	// Serialize full node batch into raw bytes
+	let serialized =
+		serialize_full_node_batch(verifying_key, signature.clone(), batch_bytes.clone());
+
+	//send the bacth using the grpc client
+	let connection_string = format!("http://127.0.0.1:{}", grpc_address.port());
+	let mut client = DaSequencerClient::try_connect(&connection_string)
+		.await
+		.expect("gRPC client connection failed.");
+
+	let request = BatchWriteRequest { data: serialized };
+	let res = client.batch_write(request).await.expect("Failed to send the batch.");
+	tracing::info!("{res:?}",);
+	//return false because of the signature.
+	assert!(!res.answer);
+
+	//TODO verify no block has been produced.
 	// Wait the implementation of the stream of block.
 
 	//wait at least one block production


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.
- 
Implementation of the issue #1135. Connect write_batch to the da storage.
Start implementing the mainloop.
Add Storage and Celestia mock.
<!--
Add your summary text here. 
 -->

# Changelog
 * Call storage's write_batch
 * Start implementing the main loop
 * Update Celestia and storage trait.
 *  Create Storage and Celestia mock
 * Add a submit_batch test
 * Start main.rs impl.
<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing
To start the submit_batch test run
```
RUST_LOG=info cargo test -p movement-da-sequencer-node test_write_batch_gprc_main_loop
```
<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->