### PR TITLE
refactor[da-sequencer]: introduce block provider trait in celestia

### DIFF
--- a/protocol-units/da-sequencer/node/src/celestia/mod.rs
+++ b/protocol-units/da-sequencer/node/src/celestia/mod.rs
@@ -88,6 +88,7 @@ pub trait BlockProvider {
 	) -> impl Future<Output = Result<SequencerBlock, DaSequencerError>> + Send;
 }
 
+#[derive(Clone)]
 pub struct ChannelBlockProvider {
 	notifier: mpsc::Sender<ExternalDaNotification>,
 }

--- a/protocol-units/da-sequencer/node/src/error.rs
+++ b/protocol-units/da-sequencer/node/src/error.rs
@@ -23,8 +23,10 @@ pub enum DaSequencerError {
 	DeserializationFailure,
 	#[error("Signature was invalid")]
 	InvalidSignature,
-    #[error("Error during bootstrapping the external DA: {0}")]
-    ExternalDaBootstrap(String),
-    #[error("Error during requesting a block: {0}")]
-    BlockRetrieval(String),
+	#[error("Error during bootstrapping the external DA: {0}")]
+	ExternalDaBootstrap(String),
+	#[error("Error during requesting a block: {0}")]
+	BlockRetrieval(String),
+	#[error("Error during channel messaging: {0}")]
+	ChannelError(String),
 }


### PR DESCRIPTION
# Summary
- #1158 
- **Categories**: `protocol-units`, `da-sequencer`

# Changelog

- Add a new `trait BlockProvider` in the Celestia module.
- Implement the trait for `ChannelBlockProvider` which uses a notifier `Sender` to send `ExternalDaNotification`s. 
- Refactor the `CelestiaExternalDa` to use the new trait instead of the notifier `Sender`.

# Testing

[TBD]

# Outstanding issues
