### PR TITLE
fix(da-sequencer): style improvements for sequencer proto

### DIFF
--- a/networks/movement/movement-full-node/src/node/tasks/execute_settle.rs
+++ b/networks/movement/movement-full-node/src/node/tasks/execute_settle.rs
@@ -10,7 +10,7 @@ use mcr_settlement_manager::{CommitmentEventStream, McrSettlementManagerOperatio
 use movement_config::execution_extension;
 use movement_da_sequencer_client::DaSequencerClient;
 use movement_da_sequencer_client::GrpcDaSequencerClient;
-use movement_da_sequencer_proto::Block;
+use movement_da_sequencer_proto::Blockv1;
 use movement_da_sequencer_proto::StreamReadFromHeightRequest;
 use movement_types::block::{Block, BlockCommitment, BlockCommitmentEvent};
 use tokio::select;
@@ -92,7 +92,7 @@ where
 		Ok(())
 	}
 
-	async fn process_block_from_da(&mut self, da_block: Block) -> anyhow::Result<()> {
+	async fn process_block_from_da(&mut self, da_block: Blockv1) -> anyhow::Result<()> {
 		let block_timestamp = chrono::Utc::now().timestamp_micros() as u64;
 
 		info!(

--- a/networks/movement/movement-full-node/src/node/tasks/execute_settle.rs
+++ b/networks/movement/movement-full-node/src/node/tasks/execute_settle.rs
@@ -10,7 +10,7 @@ use mcr_settlement_manager::{CommitmentEventStream, McrSettlementManagerOperatio
 use movement_config::execution_extension;
 use movement_da_sequencer_client::DaSequencerClient;
 use movement_da_sequencer_client::GrpcDaSequencerClient;
-use movement_da_sequencer_proto::Blockv1;
+use movement_da_sequencer_proto::Block;
 use movement_da_sequencer_proto::StreamReadFromHeightRequest;
 use movement_types::block::{Block, BlockCommitment, BlockCommitmentEvent};
 use tokio::select;
@@ -92,7 +92,7 @@ where
 		Ok(())
 	}
 
-	async fn process_block_from_da(&mut self, da_block: Blockv1) -> anyhow::Result<()> {
+	async fn process_block_from_da(&mut self, da_block: Block) -> anyhow::Result<()> {
 		let block_timestamp = chrono::Utc::now().timestamp_micros() as u64;
 
 		info!(

--- a/networks/movement/movement-full-node/src/node/tasks/execute_settle.rs
+++ b/networks/movement/movement-full-node/src/node/tasks/execute_settle.rs
@@ -10,7 +10,7 @@ use mcr_settlement_manager::{CommitmentEventStream, McrSettlementManagerOperatio
 use movement_config::execution_extension;
 use movement_da_sequencer_client::DaSequencerClient;
 use movement_da_sequencer_client::GrpcDaSequencerClient;
-use movement_da_sequencer_proto::Blockv1;
+use movement_da_sequencer_proto::BlockV1;
 use movement_da_sequencer_proto::StreamReadFromHeightRequest;
 use movement_types::block::{Block, BlockCommitment, BlockCommitmentEvent};
 use tokio::select;
@@ -92,7 +92,7 @@ where
 		Ok(())
 	}
 
-	async fn process_block_from_da(&mut self, da_block: Blockv1) -> anyhow::Result<()> {
+	async fn process_block_from_da(&mut self, da_block: BlockV1) -> anyhow::Result<()> {
 		let block_timestamp = chrono::Utc::now().timestamp_micros() as u64;
 
 		info!(

--- a/proto/movementlabs/protocol_units/da/sequencer/v1.proto
+++ b/proto/movementlabs/protocol_units/da/sequencer/v1.proto
@@ -14,7 +14,7 @@ service DaSequencerNodeService {
 }
 
 // Request and response messages
-message Blockv1 {
+message BlockV1 {
     bytes block_id = 1;
     bytes data = 2;
     uint64 height = 3;
@@ -23,7 +23,7 @@ message Blockv1 {
 message BlockResponse {
     oneof block_type {
       bool heartbeat = 1;
-      Blockv1 blockv1 = 2;
+      BlockV1 block_v1 = 2;
     }
 }
 

--- a/proto/movementlabs/protocol_units/da/sequencer/v1.proto
+++ b/proto/movementlabs/protocol_units/da/sequencer/v1.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package movementlabs.protocol_units.da.da_sequencer.v1_0_0;
+package movementlabs.protocol_units.da.sequencer.v1;
 
 
 service DaSequencerNodeService {

--- a/proto/movementlabs/protocol_units/da/sequencer/v1.proto
+++ b/proto/movementlabs/protocol_units/da/sequencer/v1.proto
@@ -14,7 +14,7 @@ service DaSequencerNodeService {
 }
 
 // Request and response messages
-message Block {
+message Blockv1 {
     bytes block_id = 1;
     bytes data = 2;
     uint64 height = 3;
@@ -23,7 +23,7 @@ message Block {
 message BlockResponse {
     oneof block_type {
       bool heartbeat = 1;
-      Block block = 2;
+      Blockv1 blockv1 = 2;
     }
 }
 

--- a/proto/movementlabs/protocol_units/da/sequencer/v1.proto
+++ b/proto/movementlabs/protocol_units/da/sequencer/v1.proto
@@ -14,7 +14,7 @@ service DaSequencerNodeService {
 }
 
 // Request and response messages
-message Blockv1 {
+message Block {
     bytes block_id = 1;
     bytes data = 2;
     uint64 height = 3;
@@ -23,7 +23,7 @@ message Blockv1 {
 message BlockResponse {
     oneof block_type {
       bool heartbeat = 1;
-      Blockv1 blockv1 = 2;
+      Block block = 2;
     }
 }
 

--- a/protocol-units/da-sequencer/client/src/lib.rs
+++ b/protocol-units/da-sequencer/client/src/lib.rs
@@ -3,7 +3,7 @@ use futures::stream;
 use movement_da_sequencer_proto::block_response;
 use movement_da_sequencer_proto::da_sequencer_node_service_client::DaSequencerNodeServiceClient;
 use movement_da_sequencer_proto::BatchWriteResponse;
-use movement_da_sequencer_proto::Blockv1;
+use movement_da_sequencer_proto::BlockV1;
 use movement_da_sequencer_proto::StreamReadFromHeightRequest;
 use movement_signer::{
 	cryptography::ed25519::{Ed25519, Signature},
@@ -24,7 +24,7 @@ pub enum ClientDaSequencerError {
 }
 
 pub type StreamReadBlockFromHeight =
-	std::pin::Pin<Box<dyn Stream<Item = Result<Blockv1, ClientDaSequencerError>> + Send + 'static>>;
+	std::pin::Pin<Box<dyn Stream<Item = Result<BlockV1, ClientDaSequencerError>> + Send + 'static>>;
 
 pub trait DaSequencerClient: Clone + Send {
 	/// Stream reads from a given height.
@@ -111,7 +111,7 @@ impl DaSequencerClient for GrpcDaSequencerClient {
 								Some(block_response::BlockType::Heartbeat(_)) => {
 									tracing::info!("Receive block stream Heartbeat");
 								}
-								Some(block_response::BlockType::Blockv1(block)) => yield block,
+								Some(block_response::BlockType::BlockV1(block)) => yield block,
 								None => todo!(),
 							}
 							None => todo!(),
@@ -199,7 +199,7 @@ impl DaSequencerClient for EmptyDaSequencerClient {
 		&mut self,
 		_request: movement_da_sequencer_proto::StreamReadFromHeightRequest,
 	) -> Result<StreamReadBlockFromHeight, ClientDaSequencerError> {
-		let never_ending_stream = stream::pending::<Result<Blockv1, ClientDaSequencerError>>();
+		let never_ending_stream = stream::pending::<Result<BlockV1, ClientDaSequencerError>>();
 
 		Ok(Box::pin(never_ending_stream))
 	}

--- a/protocol-units/da-sequencer/client/src/lib.rs
+++ b/protocol-units/da-sequencer/client/src/lib.rs
@@ -3,10 +3,11 @@ use futures::stream;
 use movement_da_sequencer_proto::block_response;
 use movement_da_sequencer_proto::da_sequencer_node_service_client::DaSequencerNodeServiceClient;
 use movement_da_sequencer_proto::BatchWriteResponse;
-use movement_da_sequencer_proto::Blockv1;
+use movement_da_sequencer_proto::Block;
 use movement_da_sequencer_proto::StreamReadFromHeightRequest;
 use movement_signer::{
 	cryptography::ed25519::{Ed25519, Signature},
+	cryptography::ToBytes,
 	Signing,
 };
 use movement_signer_loader::LoadedSigner;
@@ -24,7 +25,7 @@ pub enum ClientDaSequencerError {
 }
 
 pub type StreamReadBlockFromHeight =
-	std::pin::Pin<Box<dyn Stream<Item = Result<Blockv1, ClientDaSequencerError>> + Send + 'static>>;
+	std::pin::Pin<Box<dyn Stream<Item = Result<Block, ClientDaSequencerError>> + Send + 'static>>;
 
 pub trait DaSequencerClient: Clone + Send {
 	/// Stream reads from a given height.
@@ -111,7 +112,7 @@ impl DaSequencerClient for GrpcDaSequencerClient {
 								Some(block_response::BlockType::Heartbeat(_)) => {
 									tracing::info!("Receive block stream Heartbeat");
 								}
-								Some(block_response::BlockType::Blockv1(block)) => yield block,
+								Some(block_response::BlockType::Block(block)) => yield block,
 								None => todo!(),
 							}
 							None => todo!(),
@@ -199,7 +200,7 @@ impl DaSequencerClient for EmptyDaSequencerClient {
 		&mut self,
 		_request: movement_da_sequencer_proto::StreamReadFromHeightRequest,
 	) -> Result<StreamReadBlockFromHeight, ClientDaSequencerError> {
-		let never_ending_stream = stream::pending::<Result<Blockv1, ClientDaSequencerError>>();
+		let never_ending_stream = stream::pending::<Result<Block, ClientDaSequencerError>>();
 
 		Ok(Box::pin(never_ending_stream))
 	}

--- a/protocol-units/da-sequencer/client/src/lib.rs
+++ b/protocol-units/da-sequencer/client/src/lib.rs
@@ -3,11 +3,10 @@ use futures::stream;
 use movement_da_sequencer_proto::block_response;
 use movement_da_sequencer_proto::da_sequencer_node_service_client::DaSequencerNodeServiceClient;
 use movement_da_sequencer_proto::BatchWriteResponse;
-use movement_da_sequencer_proto::Block;
+use movement_da_sequencer_proto::Blockv1;
 use movement_da_sequencer_proto::StreamReadFromHeightRequest;
 use movement_signer::{
 	cryptography::ed25519::{Ed25519, Signature},
-	cryptography::ToBytes,
 	Signing,
 };
 use movement_signer_loader::LoadedSigner;
@@ -25,7 +24,7 @@ pub enum ClientDaSequencerError {
 }
 
 pub type StreamReadBlockFromHeight =
-	std::pin::Pin<Box<dyn Stream<Item = Result<Block, ClientDaSequencerError>> + Send + 'static>>;
+	std::pin::Pin<Box<dyn Stream<Item = Result<Blockv1, ClientDaSequencerError>> + Send + 'static>>;
 
 pub trait DaSequencerClient: Clone + Send {
 	/// Stream reads from a given height.
@@ -112,7 +111,7 @@ impl DaSequencerClient for GrpcDaSequencerClient {
 								Some(block_response::BlockType::Heartbeat(_)) => {
 									tracing::info!("Receive block stream Heartbeat");
 								}
-								Some(block_response::BlockType::Block(block)) => yield block,
+								Some(block_response::BlockType::Blockv1(block)) => yield block,
 								None => todo!(),
 							}
 							None => todo!(),
@@ -200,7 +199,7 @@ impl DaSequencerClient for EmptyDaSequencerClient {
 		&mut self,
 		_request: movement_da_sequencer_proto::StreamReadFromHeightRequest,
 	) -> Result<StreamReadBlockFromHeight, ClientDaSequencerError> {
-		let never_ending_stream = stream::pending::<Result<Block, ClientDaSequencerError>>();
+		let never_ending_stream = stream::pending::<Result<Blockv1, ClientDaSequencerError>>();
 
 		Ok(Box::pin(never_ending_stream))
 	}

--- a/protocol-units/da-sequencer/node/src/server.rs
+++ b/protocol-units/da-sequencer/node/src/server.rs
@@ -7,7 +7,7 @@ use movement_da_sequencer_proto::da_sequencer_node_service_server::{
 	DaSequencerNodeService, DaSequencerNodeServiceServer,
 };
 use movement_da_sequencer_proto::{
-	block_response::BlockType, BatchWriteRequest, BatchWriteResponse, Block, BlockResponse,
+	block_response::BlockType, BatchWriteRequest, BatchWriteResponse, BlockResponse, Blockv1,
 	ReadAtHeightRequest, ReadAtHeightResponse, StreamReadFromHeightRequest,
 	StreamReadFromHeightResponse,
 };
@@ -116,7 +116,7 @@ impl DaSequencerNodeService for DaSequencerNode {
 					};
 					current_block_height +=1;
 
-					let block = match block.as_ref().map(|block| block.try_into()) {
+					let blockv1 = match block.as_ref().map(|block| block.try_into()) {
 						None => continue,
 						Some(Ok(block)) => block,
 						Some(Err(err)) => {
@@ -125,7 +125,7 @@ impl DaSequencerNodeService for DaSequencerNode {
 
 						}
 					};
-					BlockResponse { block_type: Some(BlockType::Block(block)) }
+					BlockResponse { block_type: Some(BlockType::Blockv1(blockv1)) }
 
 				} else {
 					//send block in produced channel
@@ -153,7 +153,7 @@ impl DaSequencerNodeService for DaSequencerNode {
 							}
 							current_block_height = new_block.height.0;
 
-							let block = match new_block.try_into() {
+							let blockv1 = match new_block.try_into() {
 								Ok(b) => b,
 								Err(err) => {
 									tracing::warn!(error = %err, "Stream block: block serialization failed.");
@@ -161,7 +161,7 @@ impl DaSequencerNodeService for DaSequencerNode {
 
 								}
 							};
-							BlockResponse { block_type: Some(BlockType::Block(block)) }
+							BlockResponse { block_type: Some(BlockType::Blockv1(blockv1)) }
 						}
 					}
 
@@ -236,19 +236,19 @@ impl DaSequencerNodeService for DaSequencerNode {
 
 pub struct GrpcBatchData {}
 
-impl TryFrom<SequencerBlock> for Block {
+impl TryFrom<SequencerBlock> for Blockv1 {
 	type Error = DaSequencerError;
 
 	fn try_from(block: SequencerBlock) -> Result<Self, Self::Error> {
-		Block::try_from(&block)
+		Blockv1::try_from(&block)
 	}
 }
 
-impl TryFrom<&SequencerBlock> for Block {
+impl TryFrom<&SequencerBlock> for Blockv1 {
 	type Error = DaSequencerError;
 
 	fn try_from(block: &SequencerBlock) -> Result<Self, Self::Error> {
-		Ok(Block {
+		Ok(Blockv1 {
 			block_id: block.get_block_digest().id.to_vec(),
 			height: block.height.into(),
 			data: block.try_into()?,

--- a/protocol-units/da-sequencer/node/src/server.rs
+++ b/protocol-units/da-sequencer/node/src/server.rs
@@ -7,7 +7,7 @@ use movement_da_sequencer_proto::da_sequencer_node_service_server::{
 	DaSequencerNodeService, DaSequencerNodeServiceServer,
 };
 use movement_da_sequencer_proto::{
-	block_response::BlockType, BatchWriteRequest, BatchWriteResponse, BlockResponse, Blockv1,
+	block_response::BlockType, BatchWriteRequest, BatchWriteResponse, BlockResponse, BlockV1,
 	ReadAtHeightRequest, ReadAtHeightResponse, StreamReadFromHeightRequest,
 	StreamReadFromHeightResponse,
 };
@@ -125,7 +125,7 @@ impl DaSequencerNodeService for DaSequencerNode {
 
 						}
 					};
-					BlockResponse { block_type: Some(BlockType::Blockv1(blockv1)) }
+					BlockResponse { block_type: Some(BlockType::BlockV1(blockv1)) }
 
 				} else {
 					//send block in produced channel
@@ -161,7 +161,7 @@ impl DaSequencerNodeService for DaSequencerNode {
 
 								}
 							};
-							BlockResponse { block_type: Some(BlockType::Blockv1(blockv1)) }
+							BlockResponse { block_type: Some(BlockType::BlockV1(blockv1)) }
 						}
 					}
 
@@ -236,19 +236,19 @@ impl DaSequencerNodeService for DaSequencerNode {
 
 pub struct GrpcBatchData {}
 
-impl TryFrom<SequencerBlock> for Blockv1 {
+impl TryFrom<SequencerBlock> for BlockV1 {
 	type Error = DaSequencerError;
 
 	fn try_from(block: SequencerBlock) -> Result<Self, Self::Error> {
-		Blockv1::try_from(&block)
+		BlockV1::try_from(&block)
 	}
 }
 
-impl TryFrom<&SequencerBlock> for Blockv1 {
+impl TryFrom<&SequencerBlock> for BlockV1 {
 	type Error = DaSequencerError;
 
 	fn try_from(block: &SequencerBlock) -> Result<Self, Self::Error> {
-		Ok(Blockv1 {
+		Ok(BlockV1 {
 			block_id: block.get_block_digest().id.to_vec(),
 			height: block.height.into(),
 			data: block.try_into()?,

--- a/protocol-units/da-sequencer/proto/build.rs
+++ b/protocol-units/da-sequencer/proto/build.rs
@@ -1,1 +1,1 @@
-buildtime::proto_build_main!("movementlabs/protocol_units/da/da-sequencer/v1.0.0.proto");
+buildtime::proto_build_main!("movementlabs/protocol_units/da/sequencer/v1.proto");

--- a/protocol-units/da-sequencer/proto/src/lib.rs
+++ b/protocol-units/da-sequencer/proto/src/lib.rs
@@ -1,8 +1,8 @@
-pub mod v1_0_0 {
-	tonic::include_proto!("movementlabs.protocol_units.da.da_sequencer.v1_0_0"); // The string specified here
+pub mod v1 {
+	tonic::include_proto!("movementlabs.protocol_units.da.sequencer.v1"); // The string specified here
 	pub const FILE_DESCRIPTOR_SET: &[u8] =
 		tonic::include_file_descriptor_set!("movement-da-sequencer-proto-descriptor");
 }
 
 // Re-export the latest version at the crate root
-pub use v1_0_0::*;
+pub use v1::*;

--- a/protocol-units/execution/maptos/opt-executor/src/background/transaction_pipe.rs
+++ b/protocol-units/execution/maptos/opt-executor/src/background/transaction_pipe.rs
@@ -401,7 +401,7 @@ mod tests {
 	use movement_da_sequencer_client::ClientDaSequencerError;
 	use movement_da_sequencer_client::StreamReadBlockFromHeight;
 	use movement_da_sequencer_proto::BatchWriteResponse;
-	use movement_da_sequencer_proto::Block;
+	use movement_da_sequencer_proto::Blockv1;
 	use std::collections::BTreeSet;
 	use std::sync::Mutex;
 
@@ -453,7 +453,7 @@ mod tests {
 			&mut self,
 			_request: movement_da_sequencer_proto::StreamReadFromHeightRequest,
 		) -> Result<StreamReadBlockFromHeight, ClientDaSequencerError> {
-			let never_ending_stream = stream::pending::<Result<Block, ClientDaSequencerError>>();
+			let never_ending_stream = stream::pending::<Result<Blockv1, ClientDaSequencerError>>();
 
 			Ok(Box::pin(never_ending_stream))
 		}

--- a/protocol-units/execution/maptos/opt-executor/src/background/transaction_pipe.rs
+++ b/protocol-units/execution/maptos/opt-executor/src/background/transaction_pipe.rs
@@ -401,7 +401,7 @@ mod tests {
 	use movement_da_sequencer_client::ClientDaSequencerError;
 	use movement_da_sequencer_client::StreamReadBlockFromHeight;
 	use movement_da_sequencer_proto::BatchWriteResponse;
-	use movement_da_sequencer_proto::Blockv1;
+	use movement_da_sequencer_proto::Block;
 	use std::collections::BTreeSet;
 	use std::sync::Mutex;
 
@@ -453,7 +453,7 @@ mod tests {
 			&mut self,
 			_request: movement_da_sequencer_proto::StreamReadFromHeightRequest,
 		) -> Result<StreamReadBlockFromHeight, ClientDaSequencerError> {
-			let never_ending_stream = stream::pending::<Result<Blockv1, ClientDaSequencerError>>();
+			let never_ending_stream = stream::pending::<Result<Block, ClientDaSequencerError>>();
 
 			Ok(Box::pin(never_ending_stream))
 		}

--- a/protocol-units/execution/maptos/opt-executor/src/background/transaction_pipe.rs
+++ b/protocol-units/execution/maptos/opt-executor/src/background/transaction_pipe.rs
@@ -401,7 +401,7 @@ mod tests {
 	use movement_da_sequencer_client::ClientDaSequencerError;
 	use movement_da_sequencer_client::StreamReadBlockFromHeight;
 	use movement_da_sequencer_proto::BatchWriteResponse;
-	use movement_da_sequencer_proto::Blockv1;
+	use movement_da_sequencer_proto::BlockV1;
 	use std::collections::BTreeSet;
 	use std::sync::Mutex;
 
@@ -453,7 +453,7 @@ mod tests {
 			&mut self,
 			_request: movement_da_sequencer_proto::StreamReadFromHeightRequest,
 		) -> Result<StreamReadBlockFromHeight, ClientDaSequencerError> {
-			let never_ending_stream = stream::pending::<Result<Blockv1, ClientDaSequencerError>>();
+			let never_ending_stream = stream::pending::<Result<BlockV1, ClientDaSequencerError>>();
 
 			Ok(Box::pin(never_ending_stream))
 		}


### PR DESCRIPTION
Bring the sequencer proto file in conformance with common proto
evolution conventions.
No minor and patch versioning in package name is necessary: v1 will
evolve backward-compatibly until there's time for a v2.

Style nit: no da-da repetition in the package name and paths.
