### PR TITLE
feat: gRPC client heartbeat detection and alert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11559,6 +11559,7 @@ dependencies = [
  "movement-signer",
  "movement-signer-loader",
  "thiserror 1.0.69",
+ "tokio",
  "tokio-stream",
  "tonic 0.12.3",
  "tonic-web",

--- a/protocol-units/da-sequencer/client/Cargo.toml
+++ b/protocol-units/da-sequencer/client/Cargo.toml
@@ -23,6 +23,7 @@ tracing = { workspace = true }
 movement-signer = { workspace = true }
 movement-signer-loader = { workspace = true }
 url = { workspace = true }
+tokio = { workspace = true }
 tokio-stream = { workspace = true }
 futures = { workspace = true }
 async-stream = { workspace = true }

--- a/protocol-units/da-sequencer/config/src/lib.rs
+++ b/protocol-units/da-sequencer/config/src/lib.rs
@@ -22,8 +22,8 @@ pub struct DaSequencerConfig {
 	#[serde(default = "default_block_production_interval_millisec")]
 	pub block_production_interval_millisec: u64,
 
-        #[serde(default = "default_stream_heartbeat_interval_sec")]
-        pub stream_heartbeat_interval_sec: u64,
+	#[serde(default = "default_stream_heartbeat_interval_sec")]
+	pub stream_heartbeat_interval_sec: u64,
 
 	#[serde(default = "default_whitelist_relative_path")]
 	pub whitelist_relative_path: String,
@@ -52,12 +52,12 @@ env_default!(
 );
 
 impl Default for DaSequencerConfig {
-        fn default() -> Self {
-                Self {
-                        grpc_listen_address: default_grpc_listen_address(),
-                        block_production_interval_millisec: default_block_production_interval_millisec(),
-                        stream_heartbeat_interval_sec: default_stream_heartbeat_interval_sec(),
-                        whitelist_relative_path: default_whitelist_relative_path(),
-                }
-        }
+	fn default() -> Self {
+		Self {
+			grpc_listen_address: default_grpc_listen_address(),
+			block_production_interval_millisec: default_block_production_interval_millisec(),
+			stream_heartbeat_interval_sec: default_stream_heartbeat_interval_sec(),
+			whitelist_relative_path: default_whitelist_relative_path(),
+		}
+	}
 }

--- a/protocol-units/da-sequencer/node/src/tests/client.rs
+++ b/protocol-units/da-sequencer/node/src/tests/client.rs
@@ -46,7 +46,7 @@ async fn test_should_write_batch() {
 	let _ = tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
 
 	let connection_url = Url::parse(&format!("http://127.0.0.1:{}", grpc_address.port())).unwrap();
-	let mut client = GrpcDaSequencerClient::try_connect(&connection_url.clone())
+	let mut client = GrpcDaSequencerClient::try_connect(&connection_url.clone(), None, 10)
 		.await
 		.expect("gRPC client connection failed.");
 
@@ -54,7 +54,7 @@ async fn test_should_write_batch() {
 
 	//verify the block produced contains the batch.
 	//Register to block stream
-	let mut client = GrpcDaSequencerClient::try_connect(&connection_url)
+	let mut client = GrpcDaSequencerClient::try_connect(&connection_url.clone(), None, 10)
 		.await
 		.expect("gRPC client connection failed.");
 
@@ -111,7 +111,7 @@ async fn test_write_batch_gprc_main_loop_failed_validate_batch() {
 
 	//send the bacth using the grpc client
 	let connection_url = Url::parse(&format!("http://127.0.0.1:{}", grpc_address.port())).unwrap();
-	let mut client = GrpcDaSequencerClient::try_connect(&connection_url)
+	let mut client = GrpcDaSequencerClient::try_connect(&connection_url.clone(), None, 10)
 		.await
 		.expect("gRPC client connection failed.");
 
@@ -123,7 +123,7 @@ async fn test_write_batch_gprc_main_loop_failed_validate_batch() {
 
 	//TODO verify no block has been produced.
 	//Register to block stream
-	let mut client = GrpcDaSequencerClient::try_connect(&connection_url)
+	let mut client = GrpcDaSequencerClient::try_connect(&connection_url.clone(), None, 10)
 		.await
 		.expect("gRPC client connection failed.");
 
@@ -174,7 +174,7 @@ async fn test_produce_block_and_stream() {
 
 	//Register to block stream
 	let connection_url = Url::parse(&format!("http://127.0.0.1:{}", grpc_address.port())).unwrap();
-	let mut client = GrpcDaSequencerClient::try_connect(&connection_url)
+	let mut client = GrpcDaSequencerClient::try_connect(&connection_url.clone(), None, 10)
 		.await
 		.expect("gRPC client connection failed.");
 
@@ -208,7 +208,7 @@ async fn test_produce_block_and_stream() {
 	mock_wait_and_get_next_block(&mut block_stream, 3).await;
 
 	//create a new client and see if it steam all blocks.
-	let mut client2 = GrpcDaSequencerClient::try_connect(&connection_url)
+	let mut client2 = GrpcDaSequencerClient::try_connect(&connection_url.clone(), None, 10)
 		.await
 		.expect("gRPC client connection failed.");
 	let mut block_stream2 = client2
@@ -264,7 +264,7 @@ async fn test_grpc_client_should_write_one_batch_with_a_correct_whitelist() {
 	let _ = tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
 
 	let connection_url = Url::parse(&format!("http://{}", grpc_address)).unwrap();
-	let mut client = GrpcDaSequencerClient::try_connect(&connection_url)
+	let mut client = GrpcDaSequencerClient::try_connect(&connection_url.clone(), None, 10)
 		.await
 		.expect("Failed to connect");
 
@@ -320,7 +320,7 @@ async fn test_grpc_client_should_write_one_batch_with_an_empty_whitelist() {
 	let serialized = serialize_full_node_batch(verifying_key, signature, batch_bytes);
 
 	let connection_url = Url::parse(&format!("http://{}", grpc_address)).unwrap();
-	let mut client = GrpcDaSequencerClient::try_connect(&connection_url)
+	let mut client = GrpcDaSequencerClient::try_connect(&connection_url.clone(), None, 10)
 		.await
 		.expect("gRPC client connection failed");
 
@@ -369,7 +369,7 @@ async fn test_grpc_client_should_write_one_batch_with_a_wrong_verifying_key_in_w
 	let serialized = serialize_full_node_batch(verifying_key, signature, batch_bytes);
 
 	let connection_url = Url::parse(&format!("http://{}", grpc_address)).unwrap();
-	let mut client = GrpcDaSequencerClient::try_connect(&connection_url)
+	let mut client = GrpcDaSequencerClient::try_connect(&connection_url.clone(), None, 10)
 		.await
 		.expect("gRPC client connection failed");
 
@@ -415,10 +415,9 @@ async fn test_write_batch_grpc_main_loop_bad_signature() {
 	let serialized = serialize_full_node_batch(verifying_key, signature, batch_bytes);
 
 	let connection_url = Url::parse(&format!("http://{}", grpc_address)).unwrap();
-	let mut client = GrpcDaSequencerClient::try_connect(&connection_url)
+	let mut client = GrpcDaSequencerClient::try_connect(&connection_url.clone(), None, 10)
 		.await
 		.expect("gRPC client connection failed");
-
 	let request = BatchWriteRequest { data: serialized };
 	let res = client.batch_write(request).await.expect("Failed to send the batch.");
 	tracing::info!("{res:?}");
@@ -435,7 +434,6 @@ async fn test_missed_grpc_heartbeat_twice_triggers_alert() {
 	let (request_tx, request_rx) = mpsc::channel(100);
 
 	let mut config = DaSequencerConfig::default();
-	config.stream_heartbeat_interval_sec = 1; // short interval for test
 
 	let signing_key = generate_signing_key();
 	let verifying_key = signing_key.verifying_key();
@@ -447,16 +445,15 @@ async fn test_missed_grpc_heartbeat_twice_triggers_alert() {
 	let storage_mock = StorageMock::new();
 	let celestia_mock = CelestiaMock::new();
 	let stream_heartbeat_interval_sec = config.stream_heartbeat_interval_sec;
+	config.stream_heartbeat_interval_sec = 1; // short interval for test
 	let loop_task = tokio::spawn(run(config, request_rx, storage_mock, celestia_mock));
 
 	tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
-
-	let url = Url::parse(&format!("http://{}", grpc_address)).unwrap();
-	let mut client = GrpcDaSequencerClient::try_connect(&url).await.expect("Failed to connect");
-
+	let connection_url = Url::parse(&format!("http://{}", grpc_address)).unwrap();
 	let (alert_tx, mut alert_rx) = unbounded_channel();
-	client.set_heartbeat_alert_channel(alert_tx);
-	client.stream_heartbeat_interval_sec = stream_heartbeat_interval_sec;
+	let mut client = GrpcDaSequencerClient::try_connect(&connection_url, Some(alert_tx), 1)
+		.await
+		.expect("Failed to connect");
 
 	let mut stream = client
 		.stream_read_from_height(StreamReadFromHeightRequest { height: 0 })
@@ -483,7 +480,6 @@ async fn test_missed_grpc_heartbeat_once_does_not_trigger_alert() {
 	let (request_tx, request_rx) = mpsc::channel(100);
 
 	let mut config = DaSequencerConfig::default();
-	config.stream_heartbeat_interval_sec = 1;
 
 	let signing_key = generate_signing_key();
 	let verifying_key = signing_key.verifying_key();
@@ -494,18 +490,17 @@ async fn test_missed_grpc_heartbeat_once_does_not_trigger_alert() {
 
 	let storage_mock = StorageMock::new();
 	let celestia_mock = CelestiaMock::new();
+	config.stream_heartbeat_interval_sec = 1; // short interval for test
 	let stream_heartbeat_interval_sec = config.stream_heartbeat_interval_sec;
 	let loop_task = tokio::spawn(run(config, request_rx, storage_mock, celestia_mock));
 
 	tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
 
-	let url = Url::parse(&format!("http://{}", grpc_address)).unwrap();
-	let mut client = GrpcDaSequencerClient::try_connect(&url).await.expect("Failed to connect");
-
+	let connection_url = Url::parse(&format!("http://{}", grpc_address)).unwrap();
 	let (alert_tx, mut alert_rx) = unbounded_channel();
-	client.set_heartbeat_alert_channel(alert_tx);
-	client.stream_heartbeat_interval_sec = stream_heartbeat_interval_sec;
-
+	let mut client = GrpcDaSequencerClient::try_connect(&connection_url, Some(alert_tx), 1)
+		.await
+		.expect("Failed to connect");
 	let mut stream = client
 		.stream_read_from_height(StreamReadFromHeightRequest { height: 0 })
 		.await

--- a/protocol-units/da-sequencer/node/src/tests/client.rs
+++ b/protocol-units/da-sequencer/node/src/tests/client.rs
@@ -426,3 +426,102 @@ async fn test_write_batch_grpc_main_loop_bad_signature() {
 
 	tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
 }
+
+#[tokio::test]
+async fn test_missed_grpc_heartbeat_twice_triggers_alert() {
+	use tokio::sync::mpsc::unbounded_channel;
+	use tokio_stream::StreamExt;
+
+	let (request_tx, request_rx) = mpsc::channel(100);
+
+	let mut config = DaSequencerConfig::default();
+	config.stream_heartbeat_interval_sec = 1; // short interval for test
+
+	let signing_key = generate_signing_key();
+	let verifying_key = signing_key.verifying_key();
+	let whitelist = make_test_whitelist(vec![verifying_key.clone()]);
+
+	let grpc_address = "0.0.0.0:30799".parse::<SocketAddr>().expect("Bad address");
+	let grpc_task = tokio::spawn(run_server(grpc_address, request_tx, whitelist));
+
+	let storage_mock = StorageMock::new();
+	let celestia_mock = CelestiaMock::new();
+	let stream_heartbeat_interval_sec = config.stream_heartbeat_interval_sec;
+	let loop_task = tokio::spawn(run(config, request_rx, storage_mock, celestia_mock));
+
+	tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+
+	let url = Url::parse(&format!("http://{}", grpc_address)).unwrap();
+	let mut client = GrpcDaSequencerClient::try_connect(&url).await.expect("Failed to connect");
+
+	let (alert_tx, mut alert_rx) = unbounded_channel();
+	client.set_heartbeat_alert_channel(alert_tx);
+	client.stream_heartbeat_interval_sec = stream_heartbeat_interval_sec;
+
+	let mut stream = client
+		.stream_read_from_height(StreamReadFromHeightRequest { height: 0 })
+		.await
+		.expect("Failed to start stream");
+
+	// drop the stream to simulate missed heartbeats
+	drop(stream);
+
+	// Wait a little more than 2 intervals (2s + buffer)
+	tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+
+	assert!(alert_rx.try_recv().is_ok(), "Expected heartbeat alert after two missed heartbeats");
+
+	grpc_task.abort();
+	loop_task.abort();
+}
+
+#[tokio::test]
+async fn test_missed_grpc_heartbeat_once_does_not_trigger_alert() {
+	use tokio::sync::mpsc::unbounded_channel;
+	use tokio_stream::StreamExt;
+
+	let (request_tx, request_rx) = mpsc::channel(100);
+
+	let mut config = DaSequencerConfig::default();
+	config.stream_heartbeat_interval_sec = 1;
+
+	let signing_key = generate_signing_key();
+	let verifying_key = signing_key.verifying_key();
+	let whitelist = make_test_whitelist(vec![verifying_key.clone()]);
+
+	let grpc_address = "0.0.0.0:30800".parse::<SocketAddr>().expect("Bad address");
+	let grpc_task = tokio::spawn(run_server(grpc_address, request_tx, whitelist));
+
+	let storage_mock = StorageMock::new();
+	let celestia_mock = CelestiaMock::new();
+	let stream_heartbeat_interval_sec = config.stream_heartbeat_interval_sec;
+	let loop_task = tokio::spawn(run(config, request_rx, storage_mock, celestia_mock));
+
+	tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+
+	let url = Url::parse(&format!("http://{}", grpc_address)).unwrap();
+	let mut client = GrpcDaSequencerClient::try_connect(&url).await.expect("Failed to connect");
+
+	let (alert_tx, mut alert_rx) = unbounded_channel();
+	client.set_heartbeat_alert_channel(alert_tx);
+	client.stream_heartbeat_interval_sec = stream_heartbeat_interval_sec;
+
+	let mut stream = client
+		.stream_read_from_height(StreamReadFromHeightRequest { height: 0 })
+		.await
+		.expect("Failed to start stream");
+
+	// Drop the stream to simulate a single missed heartbeat
+	drop(stream);
+
+	// Wait slightly longer than 1 interval but less than 2
+	tokio::time::sleep(tokio::time::Duration::from_millis(1500)).await;
+
+	assert!(
+		alert_rx.try_recv().is_err(),
+		"Did not expect heartbeat alert after one missed heartbeat"
+	);
+
+	grpc_task.abort();
+	loop_task.abort();
+}


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- Addresses part of issue #1169 

# Changelog
- Update `GrpcDaSequencerClient` struct and impl with heartbeat alert transmission channel and heartbeat interval for configurability
- Update `stream_read_from_height` to check for two missed heartbeats and send an alert
- Add two tests of the alert system
- Currently the stream does not stop when the alert happens.

# Testing

Individual tests:
- `cargo test test_missed_grpc_heartbeat_twice_triggers_alert -lib -p movement-da-sequencer-node`
- `cargo test test_missed_grpc_heartbeat_once_does_not_trigger_alert -lib -p movement-da-sequencer-node`

Or run all crate tests:
- `cargo test -p movement-da-sequencer-node`

# Outstanding issues
- How should `stream_read_from_height` handle if the alert happens?