### PR TITLE
feat[da-sequencer]: remove block height from the Celestia blob

### DIFF
--- a/protocol-units/da-sequencer/config/src/lib.rs
+++ b/protocol-units/da-sequencer/config/src/lib.rs
@@ -22,8 +22,8 @@ pub struct DaSequencerConfig {
 	#[serde(default = "default_block_production_interval_millisec")]
 	pub block_production_interval_millisec: u64,
 
-        #[serde(default = "default_stream_heartbeat_interval_sec")]
-        pub stream_heartbeat_interval_sec: u64,
+	#[serde(default = "default_stream_heartbeat_interval_sec")]
+	pub stream_heartbeat_interval_sec: u64,
 
 	#[serde(default = "default_whitelist_relative_path")]
 	pub whitelist_relative_path: String,
@@ -52,12 +52,12 @@ env_default!(
 );
 
 impl Default for DaSequencerConfig {
-        fn default() -> Self {
-                Self {
-                        grpc_listen_address: default_grpc_listen_address(),
-                        block_production_interval_millisec: default_block_production_interval_millisec(),
-                        stream_heartbeat_interval_sec: default_stream_heartbeat_interval_sec(),
-                        whitelist_relative_path: default_whitelist_relative_path(),
-                }
-        }
+	fn default() -> Self {
+		Self {
+			grpc_listen_address: default_grpc_listen_address(),
+			block_production_interval_millisec: default_block_production_interval_millisec(),
+			stream_heartbeat_interval_sec: default_stream_heartbeat_interval_sec(),
+			whitelist_relative_path: default_whitelist_relative_path(),
+		}
+	}
 }

--- a/protocol-units/da-sequencer/node/src/block.rs
+++ b/protocol-units/da-sequencer/node/src/block.rs
@@ -1,25 +1,10 @@
-use movement_types::block::{self, Block};
+use movement_types::block::{self, Block, Transactions};
 use serde::{Deserialize, Serialize};
 
 use crate::error::DaSequencerError;
 
 // TODO: use a sensible value for the max sequencer block size
 pub const MAX_SEQUENCER_BLOCK_SIZE: u64 = 1_000_000; // 1 MB
-
-#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct SequencerBlockDigest {
-	pub height: BlockHeight,
-	pub id: block::Id,
-}
-
-impl SequencerBlockDigest {
-	/// Size of a digest in bytes.
-	pub const DIGEST_SIZE: usize = 32;
-
-	pub fn new(height: BlockHeight, id: block::Id) -> Self {
-		SequencerBlockDigest { height, id }
-	}
-}
 
 #[derive(
 	Serialize, Deserialize, Clone, Copy, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord,
@@ -48,8 +33,8 @@ impl From<BlockHeight> for u64 {
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct SequencerBlock {
-	pub height: BlockHeight,
-	pub block: Block,
+	height: BlockHeight,
+	block: Block,
 }
 
 impl SequencerBlock {
@@ -59,8 +44,16 @@ impl SequencerBlock {
 		Ok(sb)
 	}
 
-	pub fn get_block_digest(&self) -> SequencerBlockDigest {
-		SequencerBlockDigest::new(self.height, self.block.id())
+	pub fn id(&self) -> block::Id {
+		self.block.id()
+	}
+
+	pub fn height(&self) -> BlockHeight {
+		self.height
+	}
+
+	pub fn transactions(&self) -> Transactions {
+		self.block.transactions()
 	}
 }
 

--- a/protocol-units/da-sequencer/node/src/celestia/blob.rs
+++ b/protocol-units/da-sequencer/node/src/celestia/blob.rs
@@ -4,9 +4,9 @@ use std::slice::Iter;
 
 /// The blob format that is stored in Celestia DA.
 #[derive(Clone, Default, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct CelestiaBlobData(Vec<block::Id>);
+pub struct CelestiaBlob(Vec<block::Id>);
 
-impl CelestiaBlobData {
+impl CelestiaBlob {
 	pub fn iter(&self) -> Iter<'_, block::Id> {
 		self.0.iter()
 	}
@@ -20,7 +20,7 @@ impl CelestiaBlobData {
 	}
 }
 
-impl IntoIterator for CelestiaBlobData {
+impl IntoIterator for CelestiaBlob {
 	type Item = block::Id;
 	type IntoIter = <Vec<block::Id> as IntoIterator>::IntoIter;
 
@@ -29,7 +29,7 @@ impl IntoIterator for CelestiaBlobData {
 	}
 }
 
-impl From<Vec<block::Id>> for CelestiaBlobData {
+impl From<Vec<block::Id>> for CelestiaBlob {
 	fn from(value: Vec<block::Id>) -> Self {
 		Self(value)
 	}

--- a/protocol-units/da-sequencer/node/src/celestia/blob.rs
+++ b/protocol-units/da-sequencer/node/src/celestia/blob.rs
@@ -1,29 +1,36 @@
-use crate::block::{BlockHeight, SequencerBlockDigest};
-use std::slice::Iter;
-
+use movement_types::block;
 use serde::{Deserialize, Serialize};
+use std::slice::Iter;
 
 /// The blob format that is stored in Celestia DA.
 #[derive(Clone, Default, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct CelestiaBlobData {
-	pub digests: Vec<SequencerBlockDigest>,
-}
+pub struct CelestiaBlobData(Vec<block::Id>);
 
 impl CelestiaBlobData {
-	pub fn iter(&self) -> Iter<'_, SequencerBlockDigest> {
-		self.digests.iter()
+	pub fn iter(&self) -> Iter<'_, block::Id> {
+		self.0.iter()
 	}
 
-	pub fn last_block_height(&self) -> Option<BlockHeight> {
-		self.digests.last().map(|b| b.height)
+	pub fn last_block_id(&self) -> Option<block::Id> {
+		self.0.last().copied()
+	}
+
+	pub fn to_vec(self) -> Vec<block::Id> {
+		self.0
 	}
 }
 
 impl IntoIterator for CelestiaBlobData {
-	type Item = SequencerBlockDigest;
-	type IntoIter = <Vec<SequencerBlockDigest> as IntoIterator>::IntoIter;
+	type Item = block::Id;
+	type IntoIter = <Vec<block::Id> as IntoIterator>::IntoIter;
 
 	fn into_iter(self) -> Self::IntoIter {
-		self.digests.into_iter()
+		self.0.into_iter()
+	}
+}
+
+impl From<Vec<block::Id>> for CelestiaBlobData {
+	fn from(value: Vec<block::Id>) -> Self {
+		Self(value)
 	}
 }

--- a/protocol-units/da-sequencer/node/src/celestia/client.rs
+++ b/protocol-units/da-sequencer/node/src/celestia/client.rs
@@ -1,7 +1,5 @@
 use super::submit::BlobSubmitter;
-use super::{
-	BlockSource, CelestiaBlobData, CelestiaClientOps, CelestiaHeight, ExternalDaNotification,
-};
+use super::{BlockSource, CelestiaBlob, CelestiaClientOps, CelestiaHeight, ExternalDaNotification};
 use crate::error::DaSequencerError;
 use celestia_rpc::Client as RpcClient;
 use celestia_types::nmt::Namespace;
@@ -54,7 +52,7 @@ impl CelestiaClientOps for CelestiaClient {
 	async fn get_blob_at_height(
 		&self,
 		_height: CelestiaHeight,
-	) -> Result<Option<CelestiaBlobData>, DaSequencerError> {
+	) -> Result<Option<CelestiaBlob>, DaSequencerError> {
 		todo!()
 	}
 

--- a/protocol-units/da-sequencer/node/src/celestia/client.rs
+++ b/protocol-units/da-sequencer/node/src/celestia/client.rs
@@ -11,15 +11,15 @@ use tokio::sync::mpsc;
 use url::Url;
 
 #[derive(Debug, thiserror::Error)]
-enum Error {
+pub enum Error {
 	#[error("Celestia RPC error: {}", .0)]
 	Rpc(#[from] celestia_rpc::Error),
 }
 
 #[derive(Clone)]
 pub struct CelestiaClient {
-	rpc_client: Arc<RpcClient>,
-	notifier: mpsc::Sender<ExternalDaNotification>,
+	_rpc_client: Arc<RpcClient>,
+	_notifier: mpsc::Sender<ExternalDaNotification>,
 	// The sender end of the channel for the background sender task.
 	id_sender: mpsc::Sender<(block::Id, BlockSource)>,
 }
@@ -42,7 +42,11 @@ impl CelestiaClient {
 			notifier.clone(),
 		);
 		tokio::spawn(blob_submitter.run());
-		Ok(CelestiaClient { rpc_client, notifier, id_sender: digest_sender })
+		Ok(CelestiaClient {
+			_rpc_client: rpc_client,
+			_notifier: notifier,
+			id_sender: digest_sender,
+		})
 	}
 }
 

--- a/protocol-units/da-sequencer/node/src/celestia/height.rs
+++ b/protocol-units/da-sequencer/node/src/celestia/height.rs
@@ -1,4 +1,3 @@
-use serde::Serializer;
 use std::{
 	fmt::{Display, Formatter},
 	ops::{Add, AddAssign, Sub},

--- a/protocol-units/da-sequencer/node/src/celestia/mod.rs
+++ b/protocol-units/da-sequencer/node/src/celestia/mod.rs
@@ -1,17 +1,18 @@
 pub mod blob;
-mod client;
-mod height;
-mod submit;
-
-use crate::block::{BlockHeight, SequencerBlock, SequencerBlockDigest};
-use crate::error::DaSequencerError;
-use tokio::sync::{mpsc, oneshot};
-
-use std::future::Future;
-use std::time::Duration;
+pub mod client;
+pub mod height;
+pub mod submit;
 
 pub use blob::CelestiaBlobData;
 pub use height::CelestiaHeight;
+
+use crate::{
+	block::{BlockHeight, SequencerBlock},
+	error::DaSequencerError,
+};
+use movement_types::block;
+use std::{future::Future, time::Duration};
+use tokio::sync::{mpsc, oneshot};
 
 /// Functions to implement to save block digest in an external DA like Celestia
 pub trait DaSequencerExternalDa {
@@ -20,7 +21,7 @@ pub trait DaSequencerExternalDa {
 	/// Until the client can send it to celestia.
 	fn send_block(
 		&self,
-		block: SequencerBlockDigest,
+		block_id: block::Id,
 	) -> impl Future<Output = Result<(), DaSequencerError>> + Send;
 
 	/// Get the blob from celestia at the given height.
@@ -46,8 +47,8 @@ pub trait DaSequencerExternalDa {
 /// Message, use to notify CelestiaClient activities.
 #[derive(Debug)]
 pub enum ExternalDaNotification {
-	/// Notify that the block at specified height has been commited on celestia network
-	BlockCommitted(BlockHeight, CelestiaHeight),
+	/// Notify that the block at specified height has been committed on celestia network
+	BlocksCommitted { block_ids: Vec<block::Id>, celestia_height: CelestiaHeight },
 	/// Ask to send the block at specified height to the Celestia client.
 	/// Use during bootstrap to request block that are missing on Celestia network.
 	RequestBlock { height: BlockHeight, callback: oneshot::Sender<Option<SequencerBlock>> },
@@ -69,21 +70,26 @@ pub trait CelestiaClientOps: Sync + Clone {
 
 	fn send_block(
 		&self,
-		block: SequencerBlockDigest,
+		block_id: block::Id,
 		source: BlockSource,
 	) -> impl Future<Output = Result<(), DaSequencerError>> + Send;
 }
 
 pub trait BlockOps: Sync + Clone {
-	fn notify_block_commited(
+	fn notify_blocks_committed(
 		&self,
-		block_height: BlockHeight,
+		block_ids: Vec<block::Id>,
 		celestia_height: CelestiaHeight,
 	) -> impl Future<Output = Result<(), DaSequencerError>> + Send;
 
-	fn request_block(
+	fn request_block_at_height(
 		&self,
 		height: BlockHeight,
+	) -> impl Future<Output = Result<SequencerBlock, DaSequencerError>> + Send;
+
+	fn request_block_with_id(
+		&self,
+		id: block::Id,
 	) -> impl Future<Output = Result<SequencerBlock, DaSequencerError>> + Send;
 }
 
@@ -106,16 +112,19 @@ impl BlockProvider {
 }
 
 impl BlockOps for BlockProvider {
-	async fn notify_block_commited(
+	async fn notify_blocks_committed(
 		&self,
-		block_height: BlockHeight,
+		block_ids: Vec<block::Id>,
 		celestia_height: CelestiaHeight,
 	) -> Result<(), DaSequencerError> {
-		self.notify(ExternalDaNotification::BlockCommitted(block_height, celestia_height))
+		self.notify(ExternalDaNotification::BlocksCommitted { block_ids, celestia_height })
 			.await
 	}
 
-	async fn request_block(&self, height: BlockHeight) -> Result<SequencerBlock, DaSequencerError> {
+	async fn request_block_at_height(
+		&self,
+		height: BlockHeight,
+	) -> Result<SequencerBlock, DaSequencerError> {
 		let (tx, rx) = oneshot::channel();
 		self.notify(ExternalDaNotification::RequestBlock { height, callback: tx })
 			.await?;
@@ -127,6 +136,13 @@ impl BlockOps for BlockProvider {
 			height
 		)))?;
 		Ok(block)
+	}
+
+	async fn request_block_with_id(
+		&self,
+		_id: block::Id,
+	) -> Result<SequencerBlock, DaSequencerError> {
+		todo!()
 	}
 }
 
@@ -158,8 +174,8 @@ impl<B: BlockOps, C: CelestiaClientOps> DaSequencerExternalDa for CelestiaExtern
 	/// Send the given block to Celestia.
 	/// The block is not immediately sent but aggregated in a blob
 	/// until the client can send it to celestia.
-	async fn send_block(&self, block: SequencerBlockDigest) -> Result<(), DaSequencerError> {
-		self.celestia_client.send_block(block, BlockSource::Input).await
+	async fn send_block(&self, block_id: block::Id) -> Result<(), DaSequencerError> {
+		self.celestia_client.send_block(block_id, BlockSource::Input).await
 	}
 
 	/// Get the blob from celestia at the given height.
@@ -191,36 +207,38 @@ impl<B: BlockOps, C: CelestiaClientOps> DaSequencerExternalDa for CelestiaExtern
 			None => 1, // No blobs have been sent to Celestia yet, sync from the start
 			Some(last_finalized_celestia_height) => {
 				let mut celestia_height = last_finalized_celestia_height;
-				let mut finalized_blob = self.get_blob_at_height(celestia_height).await?.ok_or(
-					DaSequencerError::ExternalDaBootstrap(format!(
+				let mut last_block_id = self
+					.get_blob_at_height(celestia_height)
+					.await?
+					.ok_or(DaSequencerError::ExternalDaBootstrap(format!(
 						"Celestia has no blob at last known finalized height {}",
 						celestia_height
-					)),
-				)?;
+					)))?
+					.last_block_id();
 
 				// Increase the Celestia height until the tip is reached
 				loop {
 					celestia_height += 1;
 					match self.get_blob_at_height(celestia_height).await? {
 						Some(blob) => {
+							last_block_id = blob.last_block_id();
+
 							// The blocks in this blob are not confirmed yet.
-							for block in blob.iter() {
-								self.block_provider
-									.notify_block_commited(block.height, celestia_height)
-									.await?;
-							}
-							finalized_blob = blob;
+							self.block_provider
+								.notify_blocks_committed(blob.to_vec(), celestia_height)
+								.await?;
 						}
 						None => break, // The tip is reached
 					}
 				}
-				let finalized_height: u64 = finalized_blob
-					.last_block_height()
-					.ok_or(DaSequencerError::ExternalDaBootstrap(format!(
+				let finalized_block_id =
+					last_block_id.ok_or(DaSequencerError::ExternalDaBootstrap(format!(
 						"Celestia's last finalized blob at height {} is empty",
 						celestia_height - 1
-					)))?
-					.into();
+					)))?;
+				let finalized_block =
+					self.block_provider.request_block_with_id(finalized_block_id).await?;
+				let finalized_height: u64 = finalized_block.height().into();
 
 				finalized_height + 1
 			}
@@ -228,9 +246,10 @@ impl<B: BlockOps, C: CelestiaClientOps> DaSequencerExternalDa for CelestiaExtern
 
 		// Send all missing blocks to Celestia up to the current block height
 		for height in height_from..=current_block_height.into() {
-			let block = self.block_provider.request_block(BlockHeight::from(height)).await?;
+			let sequencer_block =
+				self.block_provider.request_block_at_height(BlockHeight::from(height)).await?;
 			self.celestia_client
-				.send_block(block.get_block_digest(), BlockSource::Bootstrap)
+				.send_block(sequencer_block.id(), BlockSource::Bootstrap)
 				.await?;
 		}
 
@@ -241,30 +260,22 @@ impl<B: BlockOps, C: CelestiaClientOps> DaSequencerExternalDa for CelestiaExtern
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use movement_types::block::{Block, BlockMetadata, Id};
+	use movement_types::block::{self, Block, BlockMetadata};
 	use movement_types::transaction::Transaction;
 	use rand::Rng;
 	use std::collections::{BTreeSet, HashMap};
 	use std::sync::Arc;
 	use tokio::sync::RwLock;
 
-	fn digest(block: &Block, block_height: BlockHeight) -> SequencerBlockDigest {
-		SequencerBlockDigest::new(block_height, Id::new(*block.id().as_bytes()))
-	}
-
-	fn into_digests(blocks: &[Block]) -> Vec<SequencerBlockDigest> {
-		blocks
-			.iter()
-			.enumerate()
-			.map(|(height, block)| digest(block, BlockHeight::from(height as u64)))
-			.collect()
+	fn into_ids(blocks: &[Block]) -> Vec<block::Id> {
+		blocks.iter().map(|block| block.id()).collect()
 	}
 
 	#[derive(Clone, Default, Debug, Eq, PartialEq)]
 	enum CelestiaClientCalls {
 		#[default]
 		Noop,
-		SendBlock(SequencerBlockDigest, BlockSource),
+		SendBlock(block::Id, BlockSource),
 		GetBlobsAtHeight(CelestiaHeight),
 	}
 
@@ -272,20 +283,43 @@ mod tests {
 	enum BlockProviderCalls {
 		#[default]
 		Noop,
-		NotifyBlockCommited(BlockHeight, CelestiaHeight),
-		RequestBlock(BlockHeight),
+		NotifyBlocksCommitted(Vec<block::Id>, CelestiaHeight),
+		RequestBlockAtHeight(BlockHeight),
+		RequestBlockForId(block::Id),
+	}
+
+	trait Id {
+		fn id(&self) -> block::Id;
+	}
+
+	impl Id for Block {
+		fn id(&self) -> block::Id {
+			self.id()
+		}
+	}
+
+	impl Id for CelestiaBlobData {
+		fn id(&self) -> block::Id {
+			self.iter().next().copied().unwrap()
+		}
 	}
 
 	#[derive(Clone)]
-	struct StoreMockState<B: Clone, C> {
+	struct StoreMockState<B: Id + Clone, C> {
 		height: u64,
 		data: HashMap<u64, B>,
+		index: HashMap<block::Id, u64>,
 		calls: Vec<C>,
 	}
 
-	impl<B: Clone, C> StoreMockState<B, C> {
+	impl<B: Id + Clone, C> StoreMockState<B, C> {
 		fn new() -> Self {
-			Self { height: 0, data: Default::default(), calls: Default::default() }
+			Self {
+				height: 0,
+				data: Default::default(),
+				index: Default::default(),
+				calls: Default::default(),
+			}
 		}
 
 		fn get_height(&self) -> u64 {
@@ -293,12 +327,17 @@ mod tests {
 		}
 
 		fn add(&mut self, value: B) {
+			self.index.insert(value.id(), self.height);
 			self.data.insert(self.height, value);
 			self.height += 1;
 		}
 
 		fn get_at_height(&self, height: u64) -> Option<B> {
 			self.data.get(&height).cloned()
+		}
+
+		fn get_for_id(&self, id: &block::Id) -> Option<(u64, B)> {
+			self.index.get(id).and_then(|h| self.data.get(h).map(|b| (*h, b.clone())))
 		}
 
 		fn add_call(&mut self, call: C) {
@@ -310,7 +349,7 @@ mod tests {
 		}
 	}
 
-	impl<B: Clone, C> FromIterator<B> for StoreMockState<B, C> {
+	impl<B: Id + Clone, C> FromIterator<B> for StoreMockState<B, C> {
 		fn from_iter<T: IntoIterator<Item = B>>(iter: T) -> Self {
 			let mut state: StoreMockState<B, C> = StoreMockState::new();
 			for item in iter {
@@ -348,12 +387,12 @@ mod tests {
 
 		async fn send_block(
 			&self,
-			block: SequencerBlockDigest,
+			block_id: block::Id,
 			source: BlockSource,
 		) -> Result<(), DaSequencerError> {
 			let mut state = self.0.write().await;
-			state.add_call(CelestiaClientCalls::SendBlock(block.clone(), source));
-			state.add(CelestiaBlobData { digests: vec![block] });
+			state.add_call(CelestiaClientCalls::SendBlock(block_id, source));
+			state.add(CelestiaBlobData::from(vec![block_id]));
 			Ok(())
 		}
 	}
@@ -379,24 +418,34 @@ mod tests {
 	}
 
 	impl BlockOps for BlockProviderMock {
-		async fn notify_block_commited(
+		async fn notify_blocks_committed(
 			&self,
-			block_height: BlockHeight,
+			block_ids: Vec<block::Id>,
 			celestia_height: CelestiaHeight,
 		) -> Result<(), DaSequencerError> {
 			let mut state = self.0.write().await;
-			state.add_call(BlockProviderCalls::NotifyBlockCommited(block_height, celestia_height));
+			state.add_call(BlockProviderCalls::NotifyBlocksCommitted(block_ids, celestia_height));
 			Ok(())
 		}
 
-		async fn request_block(
+		async fn request_block_at_height(
 			&self,
 			height: BlockHeight,
 		) -> Result<SequencerBlock, DaSequencerError> {
 			let mut state = self.0.write().await;
-			state.add_call(BlockProviderCalls::RequestBlock(height));
+			state.add_call(BlockProviderCalls::RequestBlockAtHeight(height));
 			let block = state.get_at_height(height.into()).unwrap();
-			Ok(SequencerBlock { height, block })
+			Ok(SequencerBlock::try_new(height, block)?)
+		}
+
+		async fn request_block_with_id(
+			&self,
+			id: block::Id,
+		) -> Result<SequencerBlock, DaSequencerError> {
+			let mut state = self.0.write().await;
+			state.add_call(BlockProviderCalls::RequestBlockForId(id));
+			let (height, block) = state.get_for_id(&id).unwrap();
+			Ok(SequencerBlock::try_new(BlockHeight::from(height), block)?)
 		}
 	}
 
@@ -408,7 +457,7 @@ mod tests {
 		let mut rng = rand::thread_rng();
 		let mut blocks = Vec::with_capacity(count);
 		let genesis = Block::default();
-		let mut parent: Id = genesis.id();
+		let mut parent: block::Id = genesis.id();
 		blocks.push(genesis);
 
 		for _ in 0..count - 1 {
@@ -442,9 +491,9 @@ mod tests {
 	#[tokio::test]
 	async fn test_celestia_external_da_bootstrap_in_sync() {
 		let blocks = test_blocks(3);
-		let digests = into_digests(blocks.as_slice());
+		let ids = into_ids(blocks.as_slice());
 		let block_provider = BlockProviderMock::new(blocks);
-		let blobs = digests.iter().map(|d| CelestiaBlobData { digests: vec![d.clone()] }).collect();
+		let blobs = ids.iter().map(|id| CelestiaBlobData::from(vec![*id])).collect();
 		let celestia = CelestiaMock::new(blobs);
 		let da = CelestiaExternalDa::new(block_provider.clone(), celestia.clone());
 
@@ -459,15 +508,18 @@ mod tests {
 				CelestiaClientCalls::GetBlobsAtHeight(3.into()),
 			],
 		);
-		assert_eq!(block_provider.into_calls().await, vec![]);
+		assert_eq!(
+			block_provider.into_calls().await,
+			vec![BlockProviderCalls::RequestBlockForId(ids.get(2).copied().unwrap())]
+		);
 	}
 
 	#[tokio::test]
 	async fn test_celestia_external_da_bootstrap_missing_confirmations() {
 		let blocks = test_blocks(3);
-		let digests = into_digests(blocks.as_slice());
+		let ids = into_ids(blocks.as_slice());
 		let block_provider = BlockProviderMock::new(blocks);
-		let blobs = digests.iter().map(|d| CelestiaBlobData { digests: vec![d.clone()] }).collect();
+		let blobs = ids.iter().map(|id| CelestiaBlobData::from(vec![*id])).collect();
 		let celestia = CelestiaMock::new(blobs);
 		let da = CelestiaExternalDa::new(block_provider.clone(), celestia.clone());
 
@@ -487,8 +539,15 @@ mod tests {
 		assert_eq!(
 			block_provider.into_calls().await,
 			vec![
-				BlockProviderCalls::NotifyBlockCommited(1.into(), 1.into()),
-				BlockProviderCalls::NotifyBlockCommited(2.into(), 2.into()),
+				BlockProviderCalls::NotifyBlocksCommitted(
+					vec![ids.get(1).copied().unwrap()],
+					1.into()
+				),
+				BlockProviderCalls::NotifyBlocksCommitted(
+					vec![ids.get(2).copied().unwrap()],
+					2.into()
+				),
+				BlockProviderCalls::RequestBlockForId(ids.get(2).copied().unwrap()),
 			]
 		);
 	}
@@ -496,12 +555,12 @@ mod tests {
 	#[tokio::test]
 	async fn test_celestia_external_da_bootstrap_one_behind() {
 		let blocks = test_blocks(3);
-		let digests = into_digests(blocks.as_slice());
+		let ids = into_ids(blocks.as_slice());
 		let block_provider = BlockProviderMock::new(blocks);
-		let blobs = digests
+		let blobs = ids
 			.iter()
-			.take(digests.len() - 1)
-			.map(|d| CelestiaBlobData { digests: vec![d.clone()] })
+			.take(ids.len() - 1)
+			.map(|id| CelestiaBlobData::from(vec![*id]))
 			.collect();
 		let celestia = CelestiaMock::new(blobs);
 		let da = CelestiaExternalDa::new(block_provider.clone(), celestia.clone());
@@ -517,7 +576,7 @@ mod tests {
 				CelestiaClientCalls::GetBlobsAtHeight(1.into()),
 				CelestiaClientCalls::GetBlobsAtHeight(2.into()),
 				CelestiaClientCalls::SendBlock(
-					digests.get(2).cloned().unwrap(),
+					ids.get(2).copied().unwrap(),
 					BlockSource::Bootstrap
 				)
 			]
@@ -525,8 +584,12 @@ mod tests {
 		assert_eq!(
 			block_provider.into_calls().await,
 			vec![
-				BlockProviderCalls::NotifyBlockCommited(1.into(), 1.into()),
-				BlockProviderCalls::RequestBlock(2.into())
+				BlockProviderCalls::NotifyBlocksCommitted(
+					vec![ids.get(1).copied().unwrap()],
+					1.into()
+				),
+				BlockProviderCalls::RequestBlockForId(ids.get(1).copied().unwrap()),
+				BlockProviderCalls::RequestBlockAtHeight(2.into())
 			]
 		);
 	}
@@ -534,7 +597,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_celestia_external_da_bootstrap_from_genesis() {
 		let blocks = test_blocks(3);
-		let digests = into_digests(blocks.as_slice());
+		let ids = into_ids(blocks.as_slice());
 		let block_provider = BlockProviderMock::new(blocks);
 		let blobs = vec![];
 		let celestia = CelestiaMock::new(blobs);
@@ -548,11 +611,11 @@ mod tests {
 			celestia.into_calls().await,
 			vec![
 				CelestiaClientCalls::SendBlock(
-					digests.get(1).cloned().unwrap(),
+					ids.get(1).copied().unwrap(),
 					BlockSource::Bootstrap
 				),
 				CelestiaClientCalls::SendBlock(
-					digests.get(2).cloned().unwrap(),
+					ids.get(2).copied().unwrap(),
 					BlockSource::Bootstrap
 				)
 			]
@@ -560,8 +623,8 @@ mod tests {
 		assert_eq!(
 			block_provider.into_calls().await,
 			vec![
-				BlockProviderCalls::RequestBlock(1.into()),
-				BlockProviderCalls::RequestBlock(2.into()),
+				BlockProviderCalls::RequestBlockAtHeight(1.into()),
+				BlockProviderCalls::RequestBlockAtHeight(2.into()),
 			]
 		);
 	}

--- a/protocol-units/da-sequencer/node/src/celestia/submit.rs
+++ b/protocol-units/da-sequencer/node/src/celestia/submit.rs
@@ -1,7 +1,6 @@
 //! The blob submitter task.
 
 use super::{BlockSource, CelestiaBlobData, CelestiaHeight, ExternalDaNotification};
-use crate::block::BlockHeight;
 
 use anyhow::Context;
 use celestia_rpc::prelude::*;

--- a/protocol-units/da-sequencer/node/src/celestia/submit.rs
+++ b/protocol-units/da-sequencer/node/src/celestia/submit.rs
@@ -1,6 +1,6 @@
 //! The blob submitter task.
 
-use super::{BlockSource, CelestiaBlobData, CelestiaHeight, ExternalDaNotification};
+use super::{BlockSource, CelestiaBlob, CelestiaHeight, ExternalDaNotification};
 
 use anyhow::Context;
 use celestia_rpc::prelude::*;
@@ -111,7 +111,7 @@ async fn submit_blob(
 	namespace: Namespace,
 	ids: Vec<block::Id>,
 ) -> Result<(Vec<block::Id>, CelestiaHeight), anyhow::Error> {
-	let data = CelestiaBlobData::from(ids.clone());
+	let data = CelestiaBlob::from(ids.clone());
 	let serialized_data = bcs::to_bytes(&data)?;
 	let blob = Blob::new(namespace, serialized_data, AppVersion::V2)?;
 	let config = TxConfig::default();

--- a/protocol-units/da-sequencer/node/src/celestia/submit.rs
+++ b/protocol-units/da-sequencer/node/src/celestia/submit.rs
@@ -85,15 +85,16 @@ impl BlobSubmitter {
 							}
 							submit_request = None;
 						}
-						next = self.id_receiver.recv(), if total_data_size + block::ID_SIZE <= MAX_CELESTIA_BLOB_SIZE => {
+						next = self.id_receiver.recv(),
+								if total_data_size + block::Id::SIZE <= MAX_CELESTIA_BLOB_SIZE => {
 							match next {
 								None => break,
 								Some((id, BlockSource::Input)) => {
-									total_data_size += block::ID_SIZE;
+									total_data_size += block::Id::SIZE;
 									buffered_ids.push(id);
 								}
 								Some((id, BlockSource::Bootstrap)) => {
-									total_data_size += block::ID_SIZE;
+									total_data_size += block::Id::SIZE;
 									bootstrap_ids.push(id);
 								}
 							}

--- a/protocol-units/da-sequencer/node/src/lib.rs
+++ b/protocol-units/da-sequencer/node/src/lib.rs
@@ -113,16 +113,16 @@ where
 				produce_block = false;
 				match res {
 					Ok(Ok(Some(block))) => {
-						let block_digest = block.get_block_digest();
+						let block_id = block.id();
 						// Send the block to all registered follower
 						// For now send to the main loop because there are very few followers (<100).
-						tracing::info!(sender_len = %connected_grpc_sender.len(), block_height= %block.height.0, "New block produced, send to fullnodes.");
+						tracing::info!(sender_len = %connected_grpc_sender.len(), block_height= %block.height().0, "New block produced, send to fullnodes.");
 						stream_block_to_sender(&mut connected_grpc_sender, Some(block)).await;
 
 						//send the block to Celestia.
 						let celestia_send_jh = tokio::spawn({
 							let celestia = celestia.clone();
-							async move {celestia.send_block(block_digest).await}
+							async move {celestia.send_block(block_id).await}
 						});
 						spawn_result_futures.push(celestia_send_jh);
 					},

--- a/protocol-units/da-sequencer/node/src/lib.rs
+++ b/protocol-units/da-sequencer/node/src/lib.rs
@@ -10,13 +10,13 @@ use tokio::task::JoinHandle;
 use tokio_stream::StreamExt;
 
 pub mod batch;
-mod block;
-mod celestia;
+pub mod block;
+pub mod celestia;
 pub mod error;
 pub mod server;
-mod storage;
+pub mod storage;
 #[cfg(test)]
-mod tests;
+pub mod tests;
 pub mod whitelist;
 
 /// Run Da sequencing loop.

--- a/protocol-units/da-sequencer/node/src/main.rs
+++ b/protocol-units/da-sequencer/node/src/main.rs
@@ -3,10 +3,7 @@ use movement_da_sequencer_config::DaSequencerConfig;
 use movement_da_sequencer_node::server::run_server;
 use movement_da_sequencer_node::whitelist::Whitelist;
 use std::error::Error;
-use std::path::PathBuf;
-use std::sync::Arc;
 use tokio::sync::mpsc;
-use tokio::sync::RwLock;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -37,14 +34,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
 	whitelist_path.push(&da_sequencer_config.whitelist_relative_path);
 	let whitelist = Whitelist::from_file_and_spawn_reload_thread(whitelist_path)?;
 
-	let (request_tx, request_rx) = mpsc::channel(100);
+	let (request_tx, _request_rx) = mpsc::channel(100);
 	// Start gprc server
 	let grpc_address = da_sequencer_config.grpc_listen_address;
-	let grpc_jh =
+	let _grpc_jh =
 		tokio::spawn(async move { run_server(grpc_address, request_tx, whitelist).await });
 
 	//Start the main loop
 	todo!();
-
-	Ok(())
 }

--- a/protocol-units/da-sequencer/node/src/server.rs
+++ b/protocol-units/da-sequencer/node/src/server.rs
@@ -184,7 +184,7 @@ impl DaSequencerNodeService for DaSequencerNode {
 	async fn read_at_height(
 		&self,
 		_request: tonic::Request<ReadAtHeightRequest>,
-	) -> std::result::Result<tonic::Response<ReadAtHeightResponse>, tonic::Status> {
+	) -> Result<tonic::Response<ReadAtHeightResponse>, tonic::Status> {
 		Err(tonic::Status::unimplemented(""))
 	}
 

--- a/protocol-units/da-sequencer/node/src/storage/mod.rs
+++ b/protocol-units/da-sequencer/node/src/storage/mod.rs
@@ -10,7 +10,6 @@ use movement_types::{
 	transaction::Transaction,
 };
 use rocksdb::{ColumnFamilyDescriptor, Options, WriteBatch, DB};
-use std::ops::Deref;
 use std::{collections::BTreeSet, result::Result, sync::Arc};
 
 pub mod cf {
@@ -45,7 +44,7 @@ impl TxCompositeKey {
 	}
 
 	/// Decode a composite key from a byte slice.
-	fn decode(bytes: &[u8]) -> Result<Self, DaSequencerError> {
+	fn _decode(bytes: &[u8]) -> Result<Self, DaSequencerError> {
 		if bytes.len() != 44 {
 			return Err(DaSequencerError::StorageFormat("Invalid composite key length".into()));
 		}
@@ -145,10 +144,6 @@ impl Storage {
 		} else {
 			Ok(BlockHeight(1))
 		}
-	}
-
-	fn notify_block_celestia_sent(&self, _height: BlockHeight) -> Result<(), DaSequencerError> {
-		todo!();
 	}
 }
 

--- a/protocol-units/da-sequencer/node/src/tests/mock.rs
+++ b/protocol-units/da-sequencer/node/src/tests/mock.rs
@@ -10,12 +10,12 @@ use movement_da_sequencer_client::{
 };
 use movement_da_sequencer_proto::BatchWriteRequest;
 use movement_signer::cryptography::ed25519::Signature as SigningSignature;
-use movement_types::block::{Block, BlockMetadata, Id};
+use movement_types::block::{self, Block, BlockMetadata};
 use movement_types::transaction::Transaction;
 
 use crate::{
 	batch::{DaBatch, FullNodeTxs},
-	block::{BlockHeight, SequencerBlockDigest},
+	block::BlockHeight,
 	celestia::blob::CelestiaBlobData,
 	celestia::CelestiaHeight,
 	DaSequencerError, DaSequencerExternalDa, DaSequencerStorage, SequencerBlock,
@@ -67,7 +67,7 @@ pub struct StorageMockInternal {
 	pub batches: Vec<DaBatch<FullNodeTxs>>,
 	pub produced_blocks: Vec<SequencerBlock>,
 	pub current_height: u64,
-	pub parent_block_id: Id,
+	pub parent_block_id: block::Id,
 }
 
 #[derive(Debug, Clone)]
@@ -81,17 +81,14 @@ impl StorageMock {
 			batches: Vec::new(),
 			current_height: 0,
 			produced_blocks: vec![],
-			parent_block_id: Id::genesis_block(),
+			parent_block_id: block::Id::genesis_block(),
 		};
 		StorageMock { inner: Arc::new(Mutex::new(inner)) }
 	}
 }
 
 impl DaSequencerStorage for StorageMock {
-	fn write_batch(
-		&self,
-		batch: DaBatch<FullNodeTxs>,
-	) -> std::result::Result<(), DaSequencerError> {
+	fn write_batch(&self, batch: DaBatch<FullNodeTxs>) -> Result<(), DaSequencerError> {
 		tracing::info!("Mock: Storage, call write_batch");
 		let mut inner = self.inner.lock().unwrap();
 		inner.batches.push(batch);
@@ -101,17 +98,14 @@ impl DaSequencerStorage for StorageMock {
 	fn get_block_at_height(
 		&self,
 		height: BlockHeight,
-	) -> std::result::Result<Option<SequencerBlock>, DaSequencerError> {
+	) -> Result<Option<SequencerBlock>, DaSequencerError> {
 		let inner = self.inner.lock().unwrap();
-		Ok(inner.produced_blocks.iter().find(|b| b.height == height).cloned())
+		Ok(inner.produced_blocks.iter().find(|b| b.height() == height).cloned())
 	}
 
-	fn get_block_with_digest(
-		&self,
-		id: SequencerBlockDigest,
-	) -> std::result::Result<Option<SequencerBlock>, DaSequencerError> {
+	fn get_block_with_id(&self, id: block::Id) -> Result<Option<SequencerBlock>, DaSequencerError> {
 		let inner = self.inner.lock().unwrap();
-		Ok(inner.produced_blocks.iter().find(|b| b.get_block_digest() == id).cloned())
+		Ok(inner.produced_blocks.iter().find(|b| b.id() == id).cloned())
 	}
 
 	fn produce_next_block(&self) -> Result<Option<SequencerBlock>, DaSequencerError> {
@@ -132,16 +126,16 @@ impl DaSequencerStorage for StorageMock {
 
 	fn get_celestia_height_for_block(
 		&self,
-		heigh: BlockHeight,
-	) -> std::result::Result<Option<CelestiaHeight>, DaSequencerError> {
+		_height: BlockHeight,
+	) -> Result<Option<CelestiaHeight>, DaSequencerError> {
 		todo!();
 	}
 
 	fn set_block_celestia_height(
 		&self,
-		block_heigh: BlockHeight,
-		celestia_heigh: CelestiaHeight,
-	) -> std::result::Result<(), DaSequencerError> {
+		_block_height: BlockHeight,
+		_celestia_height: CelestiaHeight,
+	) -> Result<(), DaSequencerError> {
 		todo!();
 	}
 
@@ -162,7 +156,7 @@ impl CelestiaMock {
 impl DaSequencerExternalDa for CelestiaMock {
 	fn send_block(
 		&self,
-		_block: SequencerBlockDigest,
+		_block_id: block::Id,
 	) -> impl Future<Output = Result<(), DaSequencerError>> + Send {
 		futures::future::ready(Ok(()))
 	}

--- a/protocol-units/da-sequencer/node/src/tests/mock.rs
+++ b/protocol-units/da-sequencer/node/src/tests/mock.rs
@@ -16,7 +16,7 @@ use movement_types::transaction::Transaction;
 use crate::{
 	batch::{DaBatch, FullNodeTxs},
 	block::BlockHeight,
-	celestia::blob::CelestiaBlobData,
+	celestia::blob::CelestiaBlob,
 	celestia::CelestiaHeight,
 	DaSequencerError, DaSequencerExternalDa, DaSequencerStorage, SequencerBlock,
 };
@@ -164,7 +164,7 @@ impl DaSequencerExternalDa for CelestiaMock {
 	fn get_blob_at_height(
 		&self,
 		_height: CelestiaHeight,
-	) -> impl Future<Output = Result<Option<CelestiaBlobData>, DaSequencerError>> + Send {
+	) -> impl Future<Output = Result<Option<CelestiaBlob>, DaSequencerError>> + Send {
 		//TODO return dummy error for now.
 		futures::future::ready(Err(DaSequencerError::DeserializationFailure))
 	}

--- a/util/movement-types/src/block.rs
+++ b/util/movement-types/src/block.rs
@@ -14,24 +14,24 @@ pub enum BlockError {
 	BlockFull,
 }
 
-pub const ID_SIZE: usize = 32;
-
 #[derive(
 	Serialize, Deserialize, Clone, Copy, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord,
 )]
-pub struct Id([u8; ID_SIZE]);
+pub struct Id([u8; Id::SIZE]);
 
 impl Id {
-	pub fn new(data: [u8; ID_SIZE]) -> Self {
+	pub const SIZE: usize = 32;
+
+	pub fn new(data: [u8; Self::SIZE]) -> Self {
 		Self(data)
 	}
 
-	pub fn as_bytes(&self) -> &[u8; ID_SIZE] {
+	pub fn as_bytes(&self) -> &[u8; Self::SIZE] {
 		&self.0
 	}
 
 	pub fn test() -> Self {
-		Self([0; ID_SIZE])
+		Self([0; Self::SIZE])
 	}
 
 	pub fn to_vec(&self) -> Vec<u8> {
@@ -39,7 +39,7 @@ impl Id {
 	}
 
 	pub fn genesis_block() -> Self {
-		Self([0; ID_SIZE])
+		Self([0; Self::SIZE])
 	}
 }
 
@@ -138,18 +138,18 @@ impl Block {
 #[derive(
 	Serialize, Deserialize, Clone, Copy, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord,
 )]
-pub struct Commitment([u8; ID_SIZE]);
+pub struct Commitment([u8; Id::SIZE]);
 
 impl Commitment {
-	pub fn new(data: [u8; ID_SIZE]) -> Self {
+	pub fn new(data: [u8; Id::SIZE]) -> Self {
 		Self(data)
 	}
 
 	pub fn test() -> Self {
-		Self([0; ID_SIZE])
+		Self([0; Id::SIZE])
 	}
 
-	pub fn as_bytes(&self) -> &[u8; ID_SIZE] {
+	pub fn as_bytes(&self) -> &[u8; Id::SIZE] {
 		&self.0
 	}
 
@@ -170,8 +170,8 @@ impl fmt::Display for Commitment {
 	}
 }
 
-impl From<Commitment> for [u8; ID_SIZE] {
-	fn from(commitment: Commitment) -> [u8; ID_SIZE] {
+impl From<Commitment> for [u8; Id::SIZE] {
+	fn from(commitment: Commitment) -> [u8; Id::SIZE] {
 		commitment.0
 	}
 }
@@ -254,7 +254,7 @@ pub mod test {
 		// construct a different block
 		let mut diff_block1 = super::Block::test();
 		let new_transaction = super::Transaction::new(vec![4, 5, 6], 0, 0);
-		diff_block1.add_transaction(new_transaction.clone());
+		diff_block1.add_transaction(new_transaction.clone()).unwrap();
 		let collapsed = super::Block::collapse(vec![block1, diff_block1]);
 		assert_eq!(collapsed.transactions().count(), 2);
 		assert_eq!(collapsed.transactions().next(), Some(&new_transaction));

--- a/util/movement-types/src/block.rs
+++ b/util/movement-types/src/block.rs
@@ -14,22 +14,24 @@ pub enum BlockError {
 	BlockFull,
 }
 
+pub const ID_SIZE: usize = 32;
+
 #[derive(
 	Serialize, Deserialize, Clone, Copy, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord,
 )]
-pub struct Id([u8; 32]);
+pub struct Id([u8; ID_SIZE]);
 
 impl Id {
-	pub fn new(data: [u8; 32]) -> Self {
+	pub fn new(data: [u8; ID_SIZE]) -> Self {
 		Self(data)
 	}
 
-	pub fn as_bytes(&self) -> &[u8; 32] {
+	pub fn as_bytes(&self) -> &[u8; ID_SIZE] {
 		&self.0
 	}
 
 	pub fn test() -> Self {
-		Self([0; 32])
+		Self([0; ID_SIZE])
 	}
 
 	pub fn to_vec(&self) -> Vec<u8> {
@@ -37,7 +39,7 @@ impl Id {
 	}
 
 	pub fn genesis_block() -> Self {
-		Self([0; 32])
+		Self([0; ID_SIZE])
 	}
 }
 
@@ -136,18 +138,18 @@ impl Block {
 #[derive(
 	Serialize, Deserialize, Clone, Copy, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord,
 )]
-pub struct Commitment([u8; 32]);
+pub struct Commitment([u8; ID_SIZE]);
 
 impl Commitment {
-	pub fn new(data: [u8; 32]) -> Self {
+	pub fn new(data: [u8; ID_SIZE]) -> Self {
 		Self(data)
 	}
 
 	pub fn test() -> Self {
-		Self([0; 32])
+		Self([0; ID_SIZE])
 	}
 
-	pub fn as_bytes(&self) -> &[u8; 32] {
+	pub fn as_bytes(&self) -> &[u8; ID_SIZE] {
 		&self.0
 	}
 
@@ -168,8 +170,8 @@ impl fmt::Display for Commitment {
 	}
 }
 
-impl From<Commitment> for [u8; 32] {
-	fn from(commitment: Commitment) -> [u8; 32] {
+impl From<Commitment> for [u8; ID_SIZE] {
+	fn from(commitment: Commitment) -> [u8; ID_SIZE] {
 		commitment.0
 	}
 }


### PR DESCRIPTION
# Summary
- #1158 
- **Categories**: `protocol-units`, `da-sequencer`

# Changelog

- Remove the block height from the Celestia blob.
- Store an array of block `Id`s in the Celestia blob.
- Remove `SequencerBlockDigest` altogether.
- Resolve all compiler warnings.

# Testing
To run the test, run the cmd:
```
cargo test -p movement-da-sequencer-node 
```
# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->
Since we no longer store the block height in the Celestia blob, we need to ensure that all block IDs in the blobs are strictly sequential concerning the block height. The batching algorithm must uphold this invariant.