### PR TITLE
Fixes duplicate submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,9 +14,6 @@
 [submodule "protocol-units/settlement/mcr/contracts/lib/openzeppelin-contracts-upgradeable"]
 	path = protocol-units/settlement/mcr/contracts/lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable
-[submodule "protocol-units/settlement/mcr/contracts/lib/openzeppelin-contracts"]
-	path = protocol-units/settlement/mcr/contracts/lib/openzeppelin-contracts
-	url = https://github.com/OpenZeppelin/openzeppelin-contracts
 [submodule "protocol-units/settlement/mcr/contracts/lib/forge-std"]
 	path = protocol-units/settlement/mcr/contracts/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**: `misc.`

Including Movement crates in other workspaces results in the following. 

```
Caused by:
  failed to load source for dependency `maptos-opt-executor`

Caused by:
  Unable to update https://github.com/movementlabsxyz/movement.git?rev=18e6297fbe106a2f7f944d5b5fad2dd6d9f1ea51

Caused by:
  duplicated submodule path 'protocol-units/settlement/mcr/contracts/lib/openzeppelin-contracts'; class=Submodule (17)
```

This can be fixed by removing the duplicate submodule. 

# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->