### PR TITLE
fix[da-light-node]: fix block proposer buffer size

### DIFF
--- a/networks/movement/movement-client/src/tests/complex-alice/Move.toml
+++ b/networks/movement/movement-client/src/tests/complex-alice/Move.toml
@@ -9,8 +9,8 @@ resource_roulette = '_'
 [dev-addresses]
 
 [dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-core.git"
-rev = "mainnet"
+git = "https://github.com/movementlabsxyz/aptos-core.git"
+rev = "movement"
 subdir = "aptos-move/framework/aptos-framework"
 
 [dev-dependencies]

--- a/networks/movement/movement-client/src/tests/complex-alice/deploy.sh
+++ b/networks/movement/movement-client/src/tests/complex-alice/deploy.sh
@@ -2,9 +2,9 @@
 
 # Initializes an account if keys are not present
 echo "Initializing account"
-initialize_output=$(echo -ne '\n' | aptos init --network custom --rest-url $NODE_URL --faucet-url $FAUCET_URL --assume-yes)
+initialize_output=$(echo -ne '\n' | movement init --network custom --rest-url $NODE_URL --faucet-url $FAUCET_URL --assume-yes)
 echo "$initialize_output"
 
 echo "Publishing the module"
-aptos move clean --assume-yes
-aptos move publish --package-dir src/tests/complex-alice --named-addresses resource_roulette=default --assume-yes
+movement move clean --assume-yes
+movement move publish --package-dir src/tests/complex-alice --named-addresses resource_roulette=default --assume-yes

--- a/networks/movement/movement-client/src/tests/hey-partners/test.sh
+++ b/networks/movement/movement-client/src/tests/hey-partners/test.sh
@@ -9,21 +9,21 @@ ls
 cd src/tests/hey-partners
 
 # Initializes an account if keys are not present
-initialize_output=$(echo -ne '\n' | aptos init --network custom --rest-url $FULLNODE --faucet-url $FAUCET --assume-yes)
+initialize_output=$(echo -ne '\n' | movement init --network custom --rest-url $FULLNODE --faucet-url $FAUCET --assume-yes)
 
-CONFIG_FILE=".aptos/config.yaml"
+CONFIG_FILE=".movement/config.yaml"
 
 if [ ! -f "$CONFIG_FILE" ]; then
   echo "Initialization failed. Config file not found."
   exit 1
 fi
 
-aptos move compile
+movement move compile
 
 PrivateKey=$(grep 'private_key:' "$CONFIG_FILE" | awk -F': ' '{print $2}' | tr -d '"')
 
 # Lookup the SwapDeployer address
-lookup_address_output=$(aptos account lookup-address)
+lookup_address_output=$(movement account lookup-address)
 echo "Lookup Address Output: $lookup_address_output"
 SwapDeployer=0x$(echo "$lookup_address_output" | grep -o '"Result": "[0-9a-fA-F]\{64\}"' | sed 's/"Result": "\(.*\)"/\1/')
 if [ -z "$SwapDeployer" ]; then
@@ -32,7 +32,7 @@ if [ -z "$SwapDeployer" ]; then
 fi
 
 # Lookup the ResourceAccountDeployer address test IS expected to fail as long as we can retrieve the account address anyway
- test_resource_account_output=$(aptos move test --package-dir "$PATH_TO_REPO/Swap/" \
+ test_resource_account_output=$(movement move test --package-dir "$PATH_TO_REPO/Swap/" \
 --filter test_resource_account --named-addresses SwapDeployer=$SwapDeployer,uq64x64=$SwapDeployer,u256=$SwapDeployer,ResourceAccountDeployer=$SwapDeployer)
 echo "Test Resource Account Output: $test_resource_account_output"
 ResourceAccountDeployer=$(echo "$test_resource_account_output" | grep -o '\[debug\] @[^\s]*' | sed 's/\[debug\] @\(.*\)/\1/')
@@ -69,64 +69,64 @@ add_or_update_env "FAUCET" $FAUCET
 
 # publish 
 echo "Publish uq64x64"
-aptos move publish --package-dir $PATH_TO_REPO/uq64x64/ --assume-yes --named-addresses uq64x64=$SwapDeployer 
+movement move publish --package-dir $PATH_TO_REPO/uq64x64/ --assume-yes --named-addresses uq64x64=$SwapDeployer 
 echo "Publish u256"
-aptos move publish --package-dir $PATH_TO_REPO/u256/ --assume-yes --named-addresses u256=$SwapDeployer 
+movement move publish --package-dir $PATH_TO_REPO/u256/ --assume-yes --named-addresses u256=$SwapDeployer 
 echo "Publish TestCoin"
-aptos move publish --package-dir $PATH_TO_REPO/TestCoin/ --assume-yes --named-addresses SwapDeployer=$SwapDeployer 
+movement move publish --package-dir $PATH_TO_REPO/TestCoin/ --assume-yes --named-addresses SwapDeployer=$SwapDeployer 
 echo "Publish Faucet"
-aptos move publish --package-dir $PATH_TO_REPO/Faucet/ --assume-yes --named-addresses SwapDeployer=$SwapDeployer
+movement move publish --package-dir $PATH_TO_REPO/Faucet/ --assume-yes --named-addresses SwapDeployer=$SwapDeployer
 echo "Publish Resource Account"
-aptos move publish --package-dir $PATH_TO_REPO/LPResourceAccount/ --assume-yes --named-addresses SwapDeployer=$SwapDeployer
+movement move publish --package-dir $PATH_TO_REPO/LPResourceAccount/ --assume-yes --named-addresses SwapDeployer=$SwapDeployer
 # create resource account & publish LPCoin
 # use this command to compile LPCoin
-aptos move compile --package-dir $PATH_TO_REPO/LPCoin/ --save-metadata --named-addresses ResourceAccountDeployer=$ResourceAccountDeployer
+movement move compile --package-dir $PATH_TO_REPO/LPCoin/ --save-metadata --named-addresses ResourceAccountDeployer=$ResourceAccountDeployer
 # get the first arg
 arg1=$(hexdump -ve '1/1 "%02x"' $PATH_TO_REPO/LPCoin/build/LPCoin/package-metadata.bcs)
 # get the second arg
 arg2=$(hexdump -ve '1/1 "%02x"' $PATH_TO_REPO/LPCoin/build/LPCoin/bytecode_modules/LPCoinV1.mv)
 # This command is to publish LPCoin contract, using ResourceAccountDeployer address. Note: replace two args with the above two hex
 echo "Initialize LPAccount"
-aptos move run --function-id ${SwapDeployer}::LPResourceAccount::initialize_lp_account \
+movement move run --function-id ${SwapDeployer}::LPResourceAccount::initialize_lp_account \
 --args hex:$arg1 hex:$arg2 --assume-yes
 
 echo "Publishing MovementSwap"
-aptos move publish --package-dir $PATH_TO_REPO/Swap/ --assume-yes --named-addresses uq64x64=$SwapDeployer,u256=$SwapDeployer,SwapDeployer=$SwapDeployer,ResourceAccountDeployer=$ResourceAccountDeployer
+movement move publish --package-dir $PATH_TO_REPO/Swap/ --assume-yes --named-addresses uq64x64=$SwapDeployer,u256=$SwapDeployer,SwapDeployer=$SwapDeployer,ResourceAccountDeployer=$ResourceAccountDeployer
 
 # admin steps
 # TestCoinsV1
 echo "Initialize TestCoinsV1"
-aptos move run --function-id ${SwapDeployer}::TestCoinsV1::initialize --assume-yes
+movement move run --function-id ${SwapDeployer}::TestCoinsV1::initialize --assume-yes
 echo "Mint USDT TestCoinsV1"
-aptos move run --function-id ${SwapDeployer}::TestCoinsV1::mint_coin \
+movement move run --function-id ${SwapDeployer}::TestCoinsV1::mint_coin \
 --args address:${SwapDeployer} u64:20000000000000000 \
 --type-args ${SwapDeployer}::TestCoinsV1::USDT --assume-yes
 echo "Mint BTC TestCoinsV1"
-aptos move run --function-id ${SwapDeployer}::TestCoinsV1::mint_coin \
+movement move run --function-id ${SwapDeployer}::TestCoinsV1::mint_coin \
 --args address:${SwapDeployer} u64:2000000000000 \
 --type-args ${SwapDeployer}::TestCoinsV1::BTC --assume-yes
 
 # FaucetV1
 echo "Create USDT FaucetV1"
-aptos move run --function-id ${SwapDeployer}::FaucetV1::create_faucet \
+movement move run --function-id ${SwapDeployer}::FaucetV1::create_faucet \
 --args u64:10000000000000000 u64:1000000000 u64:3600 \
 --type-args ${SwapDeployer}::TestCoinsV1::USDT --assume-yes
 echo "Create BTC FaucetV1"
-aptos move run --function-id ${SwapDeployer}::FaucetV1::create_faucet \
+movement move run --function-id ${SwapDeployer}::FaucetV1::create_faucet \
 --args u64:1000000000000 u64:10000000 u64:3600 \
 --type-args ${SwapDeployer}::TestCoinsV1::BTC --assume-yes
 
 # AnimeSwapPool
 echo "add USDT:MOVE pair"
-aptos move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::add_liquidity_entry \
+movement move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::add_liquidity_entry \
 --args u64:10000000000 u64:100000000 u64:1 u64:1 \
 --type-args ${SwapDeployer}::TestCoinsV1::USDT 0x1::aptos_coin::AptosCoin --assume-yes
 echo "add BTC:MOVE pair"
-aptos move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::add_liquidity_entry \
+movement move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::add_liquidity_entry \
 --args u64:10000000 u64:100000000 u64:1 u64:1 \
 --type-args ${SwapDeployer}::TestCoinsV1::BTC 0x1::aptos_coin::AptosCoin --assume-yes
 echo "add BTC:USDT pair"
-aptos move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::add_liquidity_entry \
+movement move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::add_liquidity_entry \
 --args u64:100000000 u64:100000000000 u64:1 u64:1 \
 --type-args ${SwapDeployer}::TestCoinsV1::BTC ${SwapDeployer}::TestCoinsV1::USDT --assume-yes
 
@@ -134,58 +134,58 @@ echo "Finished Admin Functions"
 # user
 # fund
 echo "Request USDT"
-aptos move run --function-id ${SwapDeployer}::FaucetV1::request \
+movement move run --function-id ${SwapDeployer}::FaucetV1::request \
 --args address:${SwapDeployer} \
 --type-args ${SwapDeployer}::TestCoinsV1::USDT --assume-yes
 echo "Request BTC"
-aptos move run --function-id ${SwapDeployer}::FaucetV1::request \
+movement move run --function-id ${SwapDeployer}::FaucetV1::request \
 --args address:${SwapDeployer} \
 --type-args ${SwapDeployer}::TestCoinsV1::BTC --assume-yes
 # swap (type args shows the swap direction, in this example, swap BTC to APT)
 echo "Swap exact BTC for MOVE"
-aptos move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::swap_exact_coins_for_coins_entry \
+movement move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::swap_exact_coins_for_coins_entry \
 --args u64:100 u64:1 \
 --type-args ${SwapDeployer}::TestCoinsV1::BTC 0x1::aptos_coin::AptosCoin --assume-yes
 # swap
 echo "Swap BTC for exact MOVE"
-aptos move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::swap_coins_for_exact_coins_entry \
+movement move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::swap_coins_for_exact_coins_entry \
 --args u64:100 u64:1000000000 \
 --type-args ${SwapDeployer}::TestCoinsV1::BTC 0x1::aptos_coin::AptosCoin --assume-yes
 # multiple pair swap (this example, swap 100 BTC->APT->USDT)
 echo "Swap BTC for USDT"
-aptos move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::swap_exact_coins_for_coins_2_pair_entry \
+movement move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::swap_exact_coins_for_coins_2_pair_entry \
 --args u64:100 u64:1 \
 --type-args ${SwapDeployer}::TestCoinsV1::BTC 0x1::aptos_coin::AptosCoin ${SwapDeployer}::TestCoinsV1::USDT --assume-yes
 # add lp (if pair not exist, will auto create lp first)
 echo "Add LP for BTC:MOVE"
-aptos move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::add_liquidity_entry \
+movement move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::add_liquidity_entry \
 --args u64:1000 u64:10000 u64:1 u64:1 \
 --type-args ${SwapDeployer}::TestCoinsV1::BTC 0x1::aptos_coin::AptosCoin --assume-yes
 echo "Remove LP from BTC:MOVE"
-aptos move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::remove_liquidity_entry \
+movement move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::remove_liquidity_entry \
 --args u64:1000 u64:1 u64:1 \
 --type-args ${SwapDeployer}::TestCoinsV1::BTC 0x1::aptos_coin::AptosCoin --assume-yes
 
 # Admin cmd example
 echo "Set dao fee"
-aptos move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::set_dao_fee_to \
+movement move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::set_dao_fee_to \
 --args address:${SwapDeployer} --assume-yes
 echo "Set admin address"
-aptos move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::set_admin_address \
+movement move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::set_admin_address \
 --args address:${SwapDeployer} --assume-yes
 echo "set dao fee"
-aptos move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::set_dao_fee \
+movement move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::set_dao_fee \
 --args u64:5
 echo "set swap fee"
-aptos move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::set_swap_fee \
+movement move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::set_swap_fee \
 --args u64:30 --assume-yes
 echo "withdraw dao fee"
-aptos move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::withdraw_dao_fee \
+movement move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::withdraw_dao_fee \
 --type-args ${SwapDeployer}::TestCoinsV1::BTC ${SwapDeployer}::TestCoinsV1::USDT --assume-yes
 echo "pause"
-aptos move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::pause --assume-yes
+movement move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::pause --assume-yes
 echo "unpause"
-aptos move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::unpause --assume-yes
+movement move run --function-id ${SwapDeployer}::AnimeSwapPoolV1::unpause --assume-yes
 
 echo "Finished User Functions"
 

--- a/networks/movement/movement-client/src/tests/mod.rs
+++ b/networks/movement/movement-client/src/tests/mod.rs
@@ -324,7 +324,7 @@ async fn test_complex_alice_internal() -> Result<(), anyhow::Error> {
 	let five_sec = time::Duration::from_millis(5000);
 	thread::sleep(five_sec);
 
-	let yaml_content = fs::read_to_string(".aptos/config.yaml")?;
+	let yaml_content = fs::read_to_string(".movement/config.yaml")?;
 
 	let config: Config = serde_yaml::from_str(&yaml_content)?;
 

--- a/networks/movement/movement-client/src/tests/mod.rs
+++ b/networks/movement/movement-client/src/tests/mod.rs
@@ -309,7 +309,7 @@ async fn test_complex_alice_internal() -> Result<(), anyhow::Error> {
 
 	// Get the root path of the cargo workspace
 	let root: PathBuf = cargo_workspace()?;
-	let additional_path = "networks/movement/movements-tests/src/tests/complex-alice/";
+	let additional_path = "networks/movement/movement-client/src/tests/complex-alice/";
 	let combined_path = root.join(additional_path);
 
 	// Convert the combined path to a string
@@ -584,7 +584,7 @@ pub async fn test_hey_partners() -> Result<(), anyhow::Error> {
 
 async fn test_hey_partners_internal() -> Result<(), anyhow::Error> {
 	let root: PathBuf = cargo_workspace()?;
-	let additional_path = "networks/movement/movements-tests/src/tests/hey-partners/";
+	let additional_path = "networks/movement/movement-client/src/tests/hey-partners/";
 	let combined_path = root.join(additional_path);
 
 	let test = combined_path.to_string_lossy();

--- a/process-compose/movement-full-node/process-compose.complex-alice-load.yml
+++ b/process-compose/movement-full-node/process-compose.complex-alice-load.yml
@@ -6,7 +6,7 @@ processes:
 
   complex-alice-tests:
     command: |
-      LOADTEST_NUMBER_SCENARIO=30 LOADTEST_NUMBER_SCENARIO_PER_CLIENT=10 cargo test -p movement-tests complex_alice_load -- --nocapture
+      LOADTEST_NUMBER_SCENARIO=30 LOADTEST_NUMBER_SCENARIO_PER_CLIENT=10 cargo test -p movement-client complex_alice_load -- --nocapture
     depends_on:
       movement-full-node:
         condition: process_healthy

--- a/process-compose/movement-full-node/process-compose.complex-alice-soak.yml
+++ b/process-compose/movement-full-node/process-compose.complex-alice-soak.yml
@@ -6,7 +6,7 @@ processes:
 
   complex-alice-tests:
     command: |
-      LOADTEST_NUMBER_SCENARIO=1 LOADTEST_NUMBER_SCENARIO_PER_CLIENT=1 cargo test -p movement-tests complex_alice_soak -- --nocapture
+      LOADTEST_NUMBER_SCENARIO=1 LOADTEST_NUMBER_SCENARIO_PER_CLIENT=1 cargo test -p movement-client complex_alice_soak -- --nocapture
     depends_on:
       movement-full-node:
         condition: process_healthy

--- a/process-compose/movement-full-node/process-compose.hey-partners-load.yml
+++ b/process-compose/movement-full-node/process-compose.hey-partners-load.yml
@@ -8,7 +8,7 @@ processes:
     env:
       MOVEMENT_SWAP_PATH: ${MOVEMENT_SWAP_PATH}
     command: |
-      LOADTEST_NUMBER_SCENARIO=1 LOADTEST_NUMBER_SCENARIO_PER_CLIENT=1 cargo test -p movement-tests hey_partners_load -- --nocapture
+      LOADTEST_NUMBER_SCENARIO=1 LOADTEST_NUMBER_SCENARIO_PER_CLIENT=1 cargo test -p movement-client hey_partners_load -- --nocapture
     depends_on:
       movement-full-node:
         condition: process_healthy

--- a/process-compose/movement-full-node/process-compose.hey-partners-soak.yml
+++ b/process-compose/movement-full-node/process-compose.hey-partners-soak.yml
@@ -8,7 +8,7 @@ processes:
     env:
       MOVEMENT_SWAP_PATH: ${MOVEMENT_SWAP_PATH}
     command: |
-      LOADTEST_NUMBER_SCENARIO=1 LOADTEST_NUMBER_SCENARIO_PER_CLIENT=1 cargo test -p movement-tests hey_partners_soak -- --nocapture
+      LOADTEST_NUMBER_SCENARIO=1 LOADTEST_NUMBER_SCENARIO_PER_CLIENT=1 cargo test -p movement-client hey_partners_soak -- --nocapture
     depends_on:
       movement-full-node:
         condition: process_healthy

--- a/protocol-units/da/movement/protocol/light-node/src/sequencer.rs
+++ b/protocol-units/da/movement/protocol/light-node/src/sequencer.rs
@@ -34,6 +34,7 @@ use std::time::Duration;
 use crate::{passthrough::LightNode as LightNodePassThrough, LightNodeRuntime};
 
 const LOGGING_UID: AtomicU64 = AtomicU64::new(0);
+const BLOCK_PROPOSER_CHANNEL_BUFFER_SIZE: usize = 2usize.pow(10);
 
 #[derive(Clone)]
 pub struct LightNode<O, C, Da, V>
@@ -279,7 +280,7 @@ where
 	}
 
 	pub async fn run_block_proposer(&self) -> Result<(), anyhow::Error> {
-		let (sender, mut receiver) = tokio::sync::mpsc::channel(2 ^ 10);
+		let (sender, mut receiver) = tokio::sync::mpsc::channel(BLOCK_PROPOSER_CHANNEL_BUFFER_SIZE);
 
 		loop {
 			info!(target: "movement_timing", "START: run_block_propoer iteration");

--- a/protocol-units/da/movement/protocol/light-node/src/sequencer.rs
+++ b/protocol-units/da/movement/protocol/light-node/src/sequencer.rs
@@ -283,7 +283,7 @@ where
 		let (sender, mut receiver) = tokio::sync::mpsc::channel(BLOCK_PROPOSER_CHANNEL_BUFFER_SIZE);
 
 		loop {
-			info!(target: "movement_timing", "START: run_block_propoer iteration");
+			info!(target: "movement_timing", "START: run_block_proposer iteration");
 			match futures::try_join!(
 				self.run_block_builder(sender.clone()),
 				self.run_block_publisher(&mut receiver),


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

<!--
Add your summary text here. 
 -->

# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

This PR fixes the block proposer channel buffer size in the light-node sequencer by replacing the incorrect exponentiation (using the XOR operator) with a correct computation via a constant.

- Fixed the channel buffer size creation by introducing BLOCK_PROPOSER_CHANNEL_BUFFER_SIZE.
- Updated the usage of the channel constructor to use the new constant.

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->