### PR TITLE
feat[pre-l1-merge]: activate Aptos feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -785,7 +785,7 @@ checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -809,7 +809,7 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "aptos-admin-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -829,7 +829,7 @@ dependencies = [
  "aptos-logger",
  "aptos-runtimes",
  "aptos-storage-interface",
- "aptos-system-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67)",
+ "aptos-system-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12)",
  "aptos-types",
  "bcs 0.1.6 (git+https://github.com/movementlabsxyz/bcs.git?rev=bc16d2d39cabafaabd76173dd1b04b2aa170cf0c)",
  "http 0.2.12",
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-logger",
  "aptos-types",
@@ -856,7 +856,7 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -898,7 +898,7 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -928,7 +928,7 @@ dependencies = [
 [[package]]
 name = "aptos-backup-cli"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-backup-service",
@@ -976,7 +976,7 @@ dependencies = [
 [[package]]
 name = "aptos-backup-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-crypto",
  "aptos-db",
@@ -998,7 +998,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "hex",
@@ -1007,7 +1007,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -1016,7 +1016,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -1051,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -1072,7 +1072,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "futures",
  "rustversion",
@@ -1082,7 +1082,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "shadow-rs",
 ]
@@ -1090,7 +1090,7 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1104,7 +1104,7 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -1115,7 +1115,7 @@ dependencies = [
 [[package]]
 name = "aptos-cli-common"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anstyle",
  "clap 4.5.21",
@@ -1125,12 +1125,12 @@ dependencies = [
 [[package]]
 name = "aptos-collections"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -1142,7 +1142,7 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1251,7 +1251,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-crypto",
  "aptos-runtimes",
@@ -1266,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1293,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "aptos-crash-handler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-logger",
  "backtrace",
@@ -1305,7 +1305,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1358,7 +1358,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1368,7 +1368,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-config",
  "aptos-crypto",
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-streaming-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -1425,7 +1425,7 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
@@ -1473,7 +1473,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1493,7 +1493,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer-schemas"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-schemadb",
@@ -1507,7 +1507,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1538,7 +1538,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg-runtime"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-infallible",
  "aptos-metrics-core",
@@ -1587,7 +1587,7 @@ dependencies = [
 [[package]]
 name = "aptos-enum-conversion-derive"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1596,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -1612,7 +1612,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-consensus-types",
@@ -1644,7 +1644,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-block-partitioner",
  "aptos-config",
@@ -1674,7 +1674,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -1696,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1716,7 +1716,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-runtimes",
  "core_affinity",
@@ -1729,7 +1729,7 @@ dependencies = [
 [[package]]
 name = "aptos-fallible"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -1737,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1771,7 +1771,7 @@ dependencies = [
 [[package]]
 name = "aptos-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2056,7 +2056,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "either",
  "move-core-types",
@@ -2065,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2080,7 +2080,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -2100,7 +2100,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
@@ -2113,7 +2113,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule-updator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-gas-schedule",
@@ -2128,7 +2128,7 @@ dependencies = [
 [[package]]
 name = "aptos-genesis"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -2153,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "aptos-github-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-proxy",
  "serde",
@@ -2165,17 +2165,17 @@ dependencies = [
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 
 [[package]]
 name = "aptos-indexer"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -2207,7 +2207,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -2219,7 +2219,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-metrics-core",
  "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=77a36245400250e7d8a854360194288d078681bc)",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12)",
  "aptos-runtimes",
  "aptos-storage-interface",
  "aptos-types",
@@ -2245,11 +2245,11 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-server-framework"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
- "aptos-system-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67)",
+ "aptos-system-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12)",
  "async-trait",
  "backtrace",
  "clap 4.5.21",
@@ -2267,7 +2267,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-table-info"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -2298,11 +2298,11 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-utils"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12)",
  "async-trait",
  "backoff",
  "base64 0.13.1",
@@ -2329,12 +2329,12 @@ dependencies = [
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 
 [[package]]
 name = "aptos-inspection-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-build-info",
@@ -2360,7 +2360,7 @@ dependencies = [
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "aptos-jwk-consensus"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2424,7 +2424,7 @@ dependencies = [
 [[package]]
 name = "aptos-jwk-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2439,7 +2439,7 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -2449,7 +2449,7 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
@@ -2493,7 +2493,7 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -2506,7 +2506,7 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2516,7 +2516,7 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-infallible",
  "aptos-log-derive",
@@ -2540,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
@@ -2553,7 +2553,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -2593,7 +2593,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-types",
  "async-trait",
@@ -2606,7 +2606,7 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-infallible",
  "bytes 1.8.0",
@@ -2617,7 +2617,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-debugger"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-block-executor",
@@ -2652,7 +2652,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -2683,7 +2683,7 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2704,7 +2704,7 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2721,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
@@ -2738,7 +2738,7 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2783,7 +2783,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-benchmark"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-config",
  "aptos-logger",
@@ -2803,7 +2803,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-builder"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -2826,7 +2826,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-checker"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -2843,7 +2843,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-discovery"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -2868,7 +2868,7 @@ dependencies = [
 [[package]]
 name = "aptos-node"
 version = "0.0.0-main"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-admin-service",
@@ -2942,7 +2942,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2953,7 +2953,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-build-info",
  "aptos-infallible",
@@ -2969,7 +2969,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2979,7 +2979,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -2992,7 +2992,7 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -3005,7 +3005,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -3030,7 +3030,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-server"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-bounded-executor",
  "aptos-build-info",
@@ -3056,7 +3056,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-config",
  "aptos-types",
@@ -3068,7 +3068,7 @@ dependencies = [
 [[package]]
 name = "aptos-profiler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=338f9a1bcc06f62ce4a4994f1642b9a61b631ee0#338f9a1bcc06f62ce4a4994f1642b9a61b631ee0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3081,7 +3081,7 @@ dependencies = [
 [[package]]
 name = "aptos-profiler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=338f9a1bcc06f62ce4a4994f1642b9a61b631ee0#338f9a1bcc06f62ce4a4994f1642b9a61b631ee0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3094,23 +3094,11 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "crossbeam",
  "proptest",
  "proptest-derive",
-]
-
-[[package]]
-name = "aptos-protos"
-version = "1.3.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
-dependencies = [
- "futures-core",
- "pbjson",
- "prost 0.12.6",
- "serde",
- "tonic 0.11.0",
 ]
 
 [[package]]
@@ -3126,9 +3114,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-protos"
+version = "1.3.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
+dependencies = [
+ "futures-core",
+ "pbjson",
+ "prost 0.12.6",
+ "serde",
+ "tonic 0.11.0",
+]
+
+[[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "ipnet",
 ]
@@ -3136,7 +3136,7 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -3147,7 +3147,7 @@ dependencies = [
 [[package]]
 name = "aptos-release-builder"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -3186,7 +3186,7 @@ dependencies = [
 [[package]]
 name = "aptos-reliable-broadcast"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
@@ -3208,7 +3208,7 @@ dependencies = [
 [[package]]
 name = "aptos-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -3222,7 +3222,7 @@ dependencies = [
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -3245,7 +3245,7 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-config",
  "rocksdb",
@@ -3254,7 +3254,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "rayon",
  "tokio",
@@ -3263,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "aptos-safety-rules"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -3304,7 +3304,7 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-crypto",
  "aptos-drop-helper",
@@ -3323,7 +3323,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -3345,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -3363,11 +3363,11 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12)",
  "bcs 0.1.6 (git+https://github.com/movementlabsxyz/bcs.git?rev=bc16d2d39cabafaabd76173dd1b04b2aa170cf0c)",
  "crossbeam-channel",
  "once_cell",
@@ -3381,7 +3381,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-crypto",
  "aptos-infallible",
@@ -3402,7 +3402,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -3424,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "aptos-state-sync-driver"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -3486,7 +3486,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-config",
  "aptos-network",
@@ -3497,7 +3497,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-notifications"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-channels",
  "async-trait",
@@ -3509,7 +3509,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-server"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -3538,7 +3538,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-compression",
  "aptos-config",
@@ -3549,26 +3549,6 @@ dependencies = [
  "num-traits",
  "serde",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "aptos-system-utils"
-version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
-dependencies = [
- "anyhow",
- "aptos-profiler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67)",
- "async-mutex",
- "http 0.2.12",
- "hyper 0.14.31",
- "lazy_static",
- "mime",
- "pprof",
- "regex",
- "rstack-self",
- "tokio",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -3592,9 +3572,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-system-utils"
+version = "0.1.0"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
+dependencies = [
+ "anyhow",
+ "aptos-profiler 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12)",
+ "async-mutex",
+ "http 0.2.12",
+ "hyper 0.14.31",
+ "lazy_static",
+ "mime",
+ "pprof",
+ "regex",
+ "rstack-self",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -3612,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "aptos-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "aptos-telemetry-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -3691,7 +3691,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -3713,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -3770,12 +3770,12 @@ dependencies = [
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 
 [[package]]
 name = "aptos-validator-interface"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "aptos-validator-transaction-pool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-channels",
  "aptos-crypto",
@@ -3809,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -3876,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-cached-packages",
  "aptos-crypto",
@@ -3897,7 +3897,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -3912,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -3934,7 +3934,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -9543,7 +9543,7 @@ dependencies = [
  "aptos-language-e2e-tests",
  "aptos-logger",
  "aptos-mempool",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12)",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
@@ -10086,7 +10086,7 @@ dependencies = [
  "aptos-language-e2e-tests",
  "aptos-logger",
  "aptos-mempool",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12)",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
@@ -10471,7 +10471,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "bcs 0.1.6 (git+https://github.com/movementlabsxyz/bcs.git?rev=bc16d2d39cabafaabd76173dd1b04b2aa170cf0c)",
@@ -10488,7 +10488,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -10503,12 +10503,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "bcs 0.1.6 (git+https://github.com/movementlabsxyz/bcs.git?rev=bc16d2d39cabafaabd76173dd1b04b2aa170cf0c)",
@@ -10523,7 +10523,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-spec"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "once_cell",
  "quote",
@@ -10533,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -10545,7 +10545,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "fail",
  "move-binary-format",
@@ -10559,7 +10559,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "clap 4.5.21",
@@ -10574,7 +10574,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "clap 4.5.21",
@@ -10604,7 +10604,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "difference",
@@ -10621,7 +10621,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "bcs 0.1.6 (git+https://github.com/movementlabsxyz/bcs.git?rev=bc16d2d39cabafaabd76173dd1b04b2aa170cf0c)",
@@ -10647,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -10678,7 +10678,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10703,7 +10703,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "bcs 0.1.6 (git+https://github.com/movementlabsxyz/bcs.git?rev=bc16d2d39cabafaabd76173dd1b04b2aa170cf0c)",
@@ -10722,7 +10722,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "clap 4.5.21",
@@ -10739,7 +10739,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "clap 4.5.21",
@@ -10758,7 +10758,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -10770,7 +10770,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "bcs 0.1.6 (git+https://github.com/movementlabsxyz/bcs.git?rev=bc16d2d39cabafaabd76173dd1b04b2aa170cf0c)",
@@ -10786,7 +10786,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -10804,7 +10804,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "hex",
@@ -10817,7 +10817,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -10830,7 +10830,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "codespan",
@@ -10856,7 +10856,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "clap 4.5.21",
@@ -10890,7 +10890,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "atty",
@@ -10917,7 +10917,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10946,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -10963,7 +10963,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "hex",
@@ -10990,7 +10990,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "abstract-domain-derive",
  "codespan-reporting",
@@ -11009,7 +11009,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "hex",
@@ -11032,7 +11032,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "once_cell",
  "serde",
@@ -11041,7 +11041,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "better_any",
  "bytes 1.8.0",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "better_any",
@@ -11084,7 +11084,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "better_any",
  "bytes 1.8.0",
@@ -11108,7 +11108,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "bytes 1.8.0",
@@ -11124,7 +11124,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "bcs 0.1.6 (git+https://github.com/movementlabsxyz/bcs.git?rev=bc16d2d39cabafaabd76173dd1b04b2aa170cf0c)",
  "derivative",
@@ -11140,7 +11140,7 @@ dependencies = [
 [[package]]
 name = "movement"
 version = "3.5.0"
-source = "git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67#1d1cdbbd7fabb80dcb95ba5e23213faa072fab67"
+source = "git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12#4883c47d74bc386e07ba271120c48aa2e3a95c12"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -11166,7 +11166,7 @@ dependencies = [
  "aptos-move-debugger",
  "aptos-network-checker",
  "aptos-node",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12)",
  "aptos-rest-client",
  "aptos-sdk",
  "aptos-storage-interface",
@@ -11310,7 +11310,7 @@ dependencies = [
  "anyhow",
  "aptos-crypto",
  "aptos-language-e2e-tests",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12)",
  "aptos-sdk",
  "aptos-types",
  "async-trait",
@@ -12590,7 +12590,7 @@ dependencies = [
  "aptos-language-e2e-tests",
  "aptos-logger",
  "aptos-mempool",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=4883c47d74bc386e07ba271120c48aa2e3a95c12)",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,44 +3,44 @@
 resolver = "2"
 
 members = [
-  "protocol-units/execution/maptos/dof",
-  "protocol-units/execution/maptos/opt-executor",
-  "protocol-units/execution/maptos/fin-view",
-  "protocol-units/execution/maptos/util",
-  "protocol-units/da/movement/protocol/*",
-  "protocol-units/sequencing/memseq/*",
-  "protocol-units/mempool/*",
-  "protocol-units/syncing/*",
-  "protocol-units/settlement/mcr/client",
-  "protocol-units/settlement/mcr/config",
-  "protocol-units/settlement/mcr/manager",
-  "protocol-units/settlement/mcr/setup",
-  "protocol-units/settlement/mcr/runner",
-  "protocol-units/movement-rest",
-  "protocol-units/access-control/aptos/account-whitelist",
-  "util/buildtime",
-  "util/buildtime/buildtime-helpers",
-  "util/buildtime/buildtime-macros",
-  "util/commander",
-  "util/dot-movement",
-  "util/flocks",
-  "util/godfig",
-  "util/movement-algs",
-  "util/movement-types",
-  "util/tracing",
-  "util/syncador",
-  "util/collections",
-  "util/whitelist",
-  "networks/movement/*",
-  "benches/*",
-  "util/signing/interface",
-  "util/signing/integrations/aptos",
-  "util/signing/providers/aws-kms",
-  "util/signing/providers/hashicorp-vault",
-  "util/signing/testing",
-  "demo/hsm",
-  "protocol-units/execution/maptos/framework/releases/*",
-  "protocol-units/execution/maptos/framework/migrations/*",
+    "protocol-units/execution/maptos/dof",
+    "protocol-units/execution/maptos/opt-executor",
+    "protocol-units/execution/maptos/fin-view",
+    "protocol-units/execution/maptos/util",
+    "protocol-units/da/movement/protocol/*",
+    "protocol-units/sequencing/memseq/*",
+    "protocol-units/mempool/*",
+    "protocol-units/syncing/*",
+    "protocol-units/settlement/mcr/client",
+    "protocol-units/settlement/mcr/config",
+    "protocol-units/settlement/mcr/manager",
+    "protocol-units/settlement/mcr/setup",
+    "protocol-units/settlement/mcr/runner",
+    "protocol-units/movement-rest",
+    "protocol-units/access-control/aptos/account-whitelist",
+    "util/buildtime",
+    "util/buildtime/buildtime-helpers",
+    "util/buildtime/buildtime-macros",
+    "util/commander",
+    "util/dot-movement",
+    "util/flocks",
+    "util/godfig",
+    "util/movement-algs",
+    "util/movement-types",
+    "util/tracing",
+    "util/syncador",
+    "util/collections",
+    "util/whitelist",
+    "networks/movement/*",
+    "benches/*",
+    "util/signing/interface",
+    "util/signing/integrations/aptos",
+    "util/signing/providers/aws-kms",
+    "util/signing/providers/hashicorp-vault",
+    "util/signing/testing",
+    "demo/hsm",
+    "protocol-units/execution/maptos/framework/releases/*",
+    "protocol-units/execution/maptos/framework/migrations/*",
 ]
 
 [workspace.package]
@@ -151,44 +151,44 @@ borsh = { version = "0.10" } # todo: internalize jmt and bump
 
 ### We use a forked version so that we can override dependency versions. This is required
 ### to be avoid dependency conflicts with other Sovereign Labs crates.
-aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67", features = [
-  "cloneable-private-keys",
+aptos-api = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-api-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-bitvec = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-block-executor = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-cached-packages = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-config = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-consensus-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-crypto = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12", features = [
+    "cloneable-private-keys",
 ] }
-aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-release-builder = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-aptos-gas-schedule = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-move-package = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
-movement = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cdbbd7fabb80dcb95ba5e23213faa072fab67" }
+aptos-db = { git = "https://github.com/movementlabsxyz/aptos-core.git", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-executor = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-executor-test-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-executor-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-faucet-core = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-framework = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-language-e2e-tests = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-mempool = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-proptest-helpers = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-sdk = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-state-view = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-storage-interface = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-temppath = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-vm = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-vm-genesis = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-vm-logging = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-vm-validator = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-logger = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-vm-types = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-indexer = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-indexer-grpc-fullnode = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-indexer-grpc-table-info = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-protos = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-release-builder = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+aptos-gas-schedule = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+move-package = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
+movement = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "4883c47d74bc386e07ba271120c48aa2e3a95c12" }
 
 # Indexer
 processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "ceaff42dfb4d1e5c84ee45e7568bb071de4b07f2" }
@@ -209,9 +209,9 @@ move-table-extension = { git = "https://github.com/diem/move" }
 move-core-types = { git = "https://github.com/diem/move" }
 
 secp256k1 = { version = "0.27", default-features = false, features = [
-  "global-context",
-  "rand-std",
-  "recovery",
+    "global-context",
+    "rand-std",
+    "recovery",
 ] }
 
 ## Celestia Dependencies
@@ -221,15 +221,15 @@ celestia-types = { git = "https://github.com/eigerco/lumina", rev = "c6e5b7f5e3a
 # External Dependencies
 
 alloy = { git = "https://github.com/alloy-rs/alloy.git", package = "alloy", rev = "83343b172585fe4e040fb104b4d1421f58cbf9a2", features = [
-  "node-bindings",
-  "rpc-types-trace",
-  "json-rpc",
-  "json-abi",
-  "rpc-client",
-  "signers",
-  "signer-yubihsm",
-  "pubsub",
-  "providers",
+    "node-bindings",
+    "rpc-types-trace",
+    "json-rpc",
+    "json-abi",
+    "rpc-client",
+    "signers",
+    "signer-yubihsm",
+    "pubsub",
+    "providers",
 ] }
 alloy-rpc-types-eth = "0.1.3"
 alloy-eips = { git = "https://github.com/alloy-rs/alloy.git", rev = "83343b172585fe4e040fb104b4d1421f58cbf9a2" }
@@ -238,7 +238,7 @@ alloy-network = { git = "https://github.com/alloy-rs/alloy.git", rev = "83343b17
 alloy-primitives = { version = "0.7.2", default-features = false }
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy.git", rev = "83343b172585fe4e040fb104b4d1421f58cbf9a2" }
 alloy-provider = { git = "https://github.com/alloy-rs/alloy.git", rev = "83343b172585fe4e040fb104b4d1421f58cbf9a2", features = [
-  "ws",
+    "ws",
 ] }
 alloy-rlp = "0.3.5"
 alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy.git", rev = "83343b172585fe4e040fb104b4d1421f58cbf9a2" }
@@ -246,7 +246,7 @@ alloy-sol-types = { version = "0.7.2", features = ["json"] }
 alloy-signer = { git = "https://github.com/alloy-rs/alloy.git", rev = "83343b172585fe4e040fb104b4d1421f58cbf9a2" }
 alloy-transport = { git = "https://github.com/alloy-rs/alloy.git", rev = "83343b172585fe4e040fb104b4d1421f58cbf9a2" }
 alloy-transport-http = { git = "https://github.com/alloy-rs/alloy.git", rev = "83343b172585fe4e040fb104b4d1421f58cbf9a2", features = [
-  "reqwest-rustls-tls",
+    "reqwest-rustls-tls",
 ] }
 alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy.git", rev = "83343b172585fe4e040fb104b4d1421f58cbf9a2" }
 
@@ -271,8 +271,8 @@ fail = "0.5.1"
 futures = "0.3.17"
 hashbrown = "0.14.3"
 hex = { version = "0.4.3", default-features = false, features = [
-  "alloc",
-  "serde",
+    "alloc",
+    "serde",
 ] }
 ics23 = { version = "0.11.0" }
 k256 = { version = "0.13.3" }
@@ -299,10 +299,10 @@ reqwest = "0.12.4"
 risc0-build = "0.20"
 risc0-zkvm = { version = "0.21", features = ["std", "getrandom"] }
 rocksdb = { version = "0.22.0", features = [
-  "snappy",
-  "lz4",
-  "zstd",
-  "zlib",
+    "snappy",
+    "lz4",
+    "zstd",
+    "zlib",
 ], default-features = false }
 schemars = { version = "0.8.16", features = ["derive"] }
 serde_with = "3.7.0"

--- a/protocol-units/execution/maptos/framework/releases/pre-l1-merge/src/cached.rs
+++ b/protocol-units/execution/maptos/framework/releases/pre-l1-merge/src/cached.rs
@@ -57,6 +57,18 @@ pub mod full {
 		// Note: when testing into the future, you may have to use a different revision of [aptos_types] in this crate's Cargo.toml
 		// Or, I suppose you can keep and GOVERNED_GAS_POOL feature flag and a GOVERNED_GAS_POOL_V2 feature flag and just make sure you're disabling the former and enabling the latter. Thereafter, it won't matter what happens to the GOVERNED_GAS_POOL feature flag, i.e., it can be replaced.
 		aptos_feature_flags.push(AptosFeatureFlag::GOVERNED_GAS_POOL);
+		aptos_feature_flags.push(AptosFeatureFlag::PERIODICAL_REWARD_RATE_DECREASE);
+		aptos_feature_flags.push(AptosFeatureFlag::PARTIAL_GOVERNANCE_VOTING);
+		aptos_feature_flags.push(AptosFeatureFlag::DELEGATION_POOL_PARTIAL_GOVERNANCE_VOTING);
+		aptos_feature_flags.push(AptosFeatureFlag::VM_BINARY_FORMAT_V7);
+
+		aptos_feature_flags.push(AptosFeatureFlag::ALLOW_SERIALIZED_SCRIPT_ARGS);
+		aptos_feature_flags.push(AptosFeatureFlag::ENABLE_ENUM_TYPES);
+		aptos_feature_flags.push(AptosFeatureFlag::FEDERATED_KEYLESS);
+		aptos_feature_flags.push(AptosFeatureFlag::TRANSACTION_SIMULATION_ENHANCEMENT);
+		aptos_feature_flags.push(AptosFeatureFlag::COLLECTION_OWNER);
+		aptos_feature_flags.push(AptosFeatureFlag::NATIVE_MEMORY_OPERATIONS);
+		aptos_feature_flags.push(AptosFeatureFlag::ACCOUNT_ABSTRACTION);
 
 		Features {
 			enabled: aptos_feature_flags.into_iter().map(FeatureFlag::from).collect(),


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**: `protocol-units`.

<!--
Add your summary text here. 
 -->
Activate previously inactive Aptos feature flags as part of the `pre-l1-merge` upgrade.
See https://github.com/movementlabsxyz/movement-migration/issues/30#issuecomment-2862738427

# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->