### PR TITLE
fix: duplicate submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "protocol-units/dispute/lib/forge-std"]
 	path = protocol-units/settlement/mcr/contracts/lib/forge-std
     url = https://github.com/foundry-rs/forge-std
-[submodule "protocol-units/dispute/lib/openzeppelin-contracts"]
-	path = protocol-units/settlement/mcr/contracts/lib/openzeppelin-contracts
-    url = https://github.com/OpenZeppelin/openzeppelin-contracts
 [submodule "protocol-units/dispute/lib/murky"]
 	path = protocol-units/settlement/mcr/contracts/lib/murky
 	url = https://github.com/dmfxyz/murky


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

<!--
Add your summary text here. 
 -->

# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->