### PR TITLE
feat, close Da connecton is teh server receive a bad node state

### DIFF
--- a/protocol-units/da-sequencer/node/src/server.rs
+++ b/protocol-units/da-sequencer/node/src/server.rs
@@ -273,7 +273,8 @@ impl DaSequencerNodeService for DaSequencerNode {
 	) -> Result<tonic::Response<BatchWriteResponse>, tonic::Status> {
 		if self.main_node_verifying_key.is_none() {
 			tracing::warn!("Receive a node state and no verifying key is defined.");
-			return Ok(tonic::Response::new(BatchWriteResponse { answer: false }));
+			//return Ok(tonic::Response::new(BatchWriteResponse { answer: false }));
+			return Err(tonic::Status::internal("Send state No verification"));
 		}
 		let state_data = request.into_inner();
 
@@ -296,7 +297,8 @@ impl DaSequencerNodeService for DaSequencerNode {
 		//unwrap tested just before
 		if let Err(err) = self.main_node_verifying_key.as_ref().unwrap().verify(&data, &signature) {
 			tracing::warn!("Grpc send_state called with a wrong signature : {err}");
-			return Ok(tonic::Response::new(BatchWriteResponse { answer: false }));
+			//return Ok(tonic::Response::new(BatchWriteResponse { answer: false }));
+			return Err(tonic::Status::internal("Send state: Bad state"));
 		}
 
 		let state =


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

Currently there's a lot of spam on the da entry point: `send_state` 
Like hundred of line like than on the DA
```
2025-06-11T12:12:50.271117Z  WARN movement_da_sequencer_node::server: Grpc send_state called with a wrong signature : signature error: Verification equation was not satisfied
2025-06-11T12:12:50.289673Z  WARN movement_da_sequencer_node::server: Grpc send_state called with a wrong signature : signature error: Verification equation was not satisfied
2025-06-11T12:12:50.382953Z  WARN movement_da_sequencer_node::server: Grpc send_state called with a wrong signature : signature error: Verification equation was not satisfied
2025-06-11T12:12:50.474381Z  WARN movement_da_sequencer_node::server: Grpc send_state called with a wrong signature : signature error: Verification equation was not satisfied
2025-06-11T12:12:50.501904Z  WARN movement_da_sequencer_node::server: Grpc send_state called with a wrong signature : signature error: Verification equation was not satisfied

```

I have warned the partners to verify their config and all say it's ok. So now I consider it like spam and the connection should be closed.
Currently, the DA responds so that the node doesn't crash. With this update, the node will crash so the configuration must be ok, and it will be harder to spam a lot. Need to reconnect.

# Changelog
 * Update `send_state` , return an error instead of a response.
 
<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing
No automatic test.
Will be tested on testnet then mainnet.
<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->