### PR TITLE
Bug, warn on batch rejected by the da sequencer.

### DIFF
--- a/protocol-units/da-sequencer/node/src/server.rs
+++ b/protocol-units/da-sequencer/node/src/server.rs
@@ -70,6 +70,10 @@ pub enum GrpcRequests {
 pub struct DaSequencerNode {
 	request_tx: mpsc::Sender<GrpcRequests>,
 	whitelist: Whitelist,
+	// State propagation is not a main functionality of the da-sequencer. It's used to detect instabilities.
+	// `main_node_verifying_key` contains the main node signing public key for state propagation.
+	// It's optional because issue on the mainnode can stop the network.
+	// To be able to recover fast, disabling it can be useful.
 	main_node_verifying_key: Option<VerifyingKey>,
 }
 

--- a/protocol-units/execution/maptos/opt-executor/src/background/transaction_pipe.rs
+++ b/protocol-units/execution/maptos/opt-executor/src/background/transaction_pipe.rs
@@ -177,8 +177,7 @@ impl TransactionPipe {
 								Ok(Ok(response)) => {
 									debug!("After sent batch.");
 									if !response.answer {
-										tracing::error!("DA Sequencer reject batch, can't send batch, exit process");
-										return Err(Error::InternalError(format!("DA Sequencer reject batch, can't send batch, exit process")));
+										tracing::warn!("DA Sequencer reject batch, can't send the batch.");
 									}
 								}
 								Ok(Err(err)) => {


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

If the da-sequencer rejects the full node batch, the full node crashes.
Remove the panic to avoid the node to  crash and only log a warning.
<!--
Add your summary text here. 
 -->

# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->