### PR TITLE
Bug, update indexer commit rev to link the remove panic one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2667,7 +2667,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=77a36245400250e7d8a854360194288d078681bc#77a36245400250e7d8a854360194288d078681bc"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=20be1190105908fd4fea4e78c330997658e9428e#20be1190105908fd4fea4e78c330997658e9428e"
 dependencies = [
  "chrono",
 ]
@@ -2675,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=ceaff42dfb4d1e5c84ee45e7568bb071de4b07f2#ceaff42dfb4d1e5c84ee45e7568bb071de4b07f2"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=77a36245400250e7d8a854360194288d078681bc#77a36245400250e7d8a854360194288d078681bc"
 dependencies = [
  "chrono",
 ]
@@ -11704,11 +11704,11 @@ dependencies = [
  "maptos-execution-util",
  "num_cpus",
  "poem",
- "processor 1.0.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=ceaff42dfb4d1e5c84ee45e7568bb071de4b07f2)",
+ "processor 1.0.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=20be1190105908fd4fea4e78c330997658e9428e)",
  "reqwest 0.12.9",
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
- "server-framework 1.0.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=ceaff42dfb4d1e5c84ee45e7568bb071de4b07f2)",
+ "server-framework 1.0.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=20be1190105908fd4fea4e78c330997658e9428e)",
  "tempfile",
  "tokio",
  "tracing",
@@ -13517,6 +13517,65 @@ dependencies = [
 [[package]]
 name = "processor"
 version = "1.0.0"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=20be1190105908fd4fea4e78c330997658e9428e#20be1190105908fd4fea4e78c330997658e9428e"
+dependencies = [
+ "ahash 0.8.11",
+ "allocative",
+ "allocative_derive",
+ "anyhow",
+ "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=20be1190105908fd4fea4e78c330997658e9428e)",
+ "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=338f9a1bcc06f62ce4a4994f1642b9a61b631ee0)",
+ "async-trait",
+ "bcs 0.1.6 (git+https://github.com/movementlabsxyz/bcs.git?rev=bc16d2d39cabafaabd76173dd1b04b2aa170cf0c)",
+ "bigdecimal",
+ "bitflags 2.6.0",
+ "canonical_json",
+ "chrono",
+ "clap 4.5.21",
+ "diesel",
+ "diesel-async",
+ "diesel_migrations",
+ "enum_dispatch",
+ "field_count",
+ "futures",
+ "futures-util",
+ "google-cloud-googleapis 0.10.0",
+ "google-cloud-pubsub",
+ "google-cloud-storage",
+ "hex",
+ "hyper 0.14.31",
+ "itertools 0.12.1",
+ "jemallocator",
+ "kanal",
+ "lazy_static",
+ "native-tls",
+ "num",
+ "num_cpus",
+ "once_cell",
+ "parquet",
+ "parquet_derive",
+ "postgres-native-tls",
+ "prometheus",
+ "prost 0.12.6",
+ "regex",
+ "serde",
+ "serde_json",
+ "server-framework 1.0.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=20be1190105908fd4fea4e78c330997658e9428e)",
+ "sha2 0.9.9",
+ "sha3 0.9.1",
+ "strum 0.26.3",
+ "tiny-keccak",
+ "tokio",
+ "tokio-postgres",
+ "tonic 0.11.0",
+ "tracing",
+ "unescape",
+ "url",
+]
+
+[[package]]
+name = "processor"
+version = "1.0.0"
 source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=77a36245400250e7d8a854360194288d078681bc#77a36245400250e7d8a854360194288d078681bc"
 dependencies = [
  "ahash 0.8.11",
@@ -13561,65 +13620,6 @@ dependencies = [
  "serde",
  "serde_json",
  "server-framework 1.0.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=77a36245400250e7d8a854360194288d078681bc)",
- "sha2 0.9.9",
- "sha3 0.9.1",
- "strum 0.26.3",
- "tiny-keccak",
- "tokio",
- "tokio-postgres",
- "tonic 0.11.0",
- "tracing",
- "unescape",
- "url",
-]
-
-[[package]]
-name = "processor"
-version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=ceaff42dfb4d1e5c84ee45e7568bb071de4b07f2#ceaff42dfb4d1e5c84ee45e7568bb071de4b07f2"
-dependencies = [
- "ahash 0.8.11",
- "allocative",
- "allocative_derive",
- "anyhow",
- "aptos-moving-average 0.1.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=ceaff42dfb4d1e5c84ee45e7568bb071de4b07f2)",
- "aptos-protos 1.3.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=338f9a1bcc06f62ce4a4994f1642b9a61b631ee0)",
- "async-trait",
- "bcs 0.1.6 (git+https://github.com/movementlabsxyz/bcs.git?rev=bc16d2d39cabafaabd76173dd1b04b2aa170cf0c)",
- "bigdecimal",
- "bitflags 2.6.0",
- "canonical_json",
- "chrono",
- "clap 4.5.21",
- "diesel",
- "diesel-async",
- "diesel_migrations",
- "enum_dispatch",
- "field_count",
- "futures",
- "futures-util",
- "google-cloud-googleapis 0.10.0",
- "google-cloud-pubsub",
- "google-cloud-storage",
- "hex",
- "hyper 0.14.31",
- "itertools 0.12.1",
- "jemallocator",
- "kanal",
- "lazy_static",
- "native-tls",
- "num",
- "num_cpus",
- "once_cell",
- "parquet",
- "parquet_derive",
- "postgres-native-tls",
- "prometheus",
- "prost 0.12.6",
- "regex",
- "serde",
- "serde_json",
- "server-framework 1.0.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=ceaff42dfb4d1e5c84ee45e7568bb071de4b07f2)",
  "sha2 0.9.9",
  "sha3 0.9.1",
  "strum 0.26.3",
@@ -15448,7 +15448,7 @@ dependencies = [
 [[package]]
 name = "server-framework"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=77a36245400250e7d8a854360194288d078681bc#77a36245400250e7d8a854360194288d078681bc"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=20be1190105908fd4fea4e78c330997658e9428e#20be1190105908fd4fea4e78c330997658e9428e"
 dependencies = [
  "anyhow",
  "aptos-system-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=338f9a1bcc06f62ce4a4994f1642b9a61b631ee0)",
@@ -15469,7 +15469,7 @@ dependencies = [
 [[package]]
 name = "server-framework"
 version = "1.0.0"
-source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=ceaff42dfb4d1e5c84ee45e7568bb071de4b07f2#ceaff42dfb4d1e5c84ee45e7568bb071de4b07f2"
+source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=77a36245400250e7d8a854360194288d078681bc#77a36245400250e7d8a854360194288d078681bc"
 dependencies = [
  "anyhow",
  "aptos-system-utils 0.1.0 (git+https://github.com/movementlabsxyz/aptos-core?rev=338f9a1bcc06f62ce4a4994f1642b9a61b631ee0)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,8 +191,8 @@ move-package = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "c
 movement = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "c34b9e9347a0e4c0440930796ba06555e8be3355" }
 
 # Indexer
-processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "ceaff42dfb4d1e5c84ee45e7568bb071de4b07f2" }
-server-framework = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "ceaff42dfb4d1e5c84ee45e7568bb071de4b07f2" }
+processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "20be1190105908fd4fea4e78c330997658e9428e" }
+server-framework = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "20be1190105908fd4fea4e78c330997658e9428e" }
 
 bcs = { git = "https://github.com/movementlabsxyz/bcs.git", rev = "bc16d2d39cabafaabd76173dd1b04b2aa170cf0c" }
 


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

Remove most of the panic to [the indexer code](https://github.com/movementlabsxyz/aptos-indexer-processors/pull/11).
<!--
Add your summary text here. 
 -->

# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->
to test to start the indexer:
```
CELESTIA_LOG_LEVEL=FATAL MOVEMENT_PREBUILT=false nix develop --extra-experimental-features nix-command --extra-experimental-features flakes --command bash  -c "just movement-full-node native build.setup.eth-local.celestia-local.indexer.hasura.indexer-test --keep-tui"
```
# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->