### PR TITLE
feat: disable remove detailed error feat flag

### DIFF
--- a/protocol-units/execution/maptos/framework/releases/pre-l1-merge/src/cached.rs
+++ b/protocol-units/execution/maptos/framework/releases/pre-l1-merge/src/cached.rs
@@ -67,8 +67,8 @@ pub mod full {
 		enable_feature_flags.push(AptosFeatureFlag::VM_BINARY_FORMAT_V7);
 
 		Features {
-			enabled: aptos_feature_flags.into_iter().map(FeatureFlag::from).collect(),
-			disabled: vec![AptosFeatureFlag::REMOVE_DETAILED_ERROR_FROM_HASH],
+			enabled: enable_feature_flags.into_iter().map(FeatureFlag::from).collect(),
+			disabled: vec![AptosFeatureFlag::REMOVE_DETAILED_ERROR_FROM_HASH.into()],
 		}
 	});
 }


### PR DESCRIPTION
# Summary
This PR disables the `REMOVE_DETAILED_ERROR_FROM_HASH` feature flag to simplify transaction replay during migration.

- Renames the mutable feature flag collection variable for clarity
- Adds the `REMOVE_DETAILED_ERROR_FROM_HASH` flag to the disabled list
- Maintains activation of existing Aptos framework feature flags

# Testing

```
just movement-full-node native build.setup.eth-local.celestia-local.test-migrate-biarritz-rc1-to-pre-l1-merge --keep-tui
```

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->