### PR TITLE
fix: initialize individual tracing for full node

### DIFF
--- a/networks/movement/movement-full-node/src/main.rs
+++ b/networks/movement/movement-full-node/src/main.rs
@@ -1,12 +1,14 @@
 #![forbid(unsafe_code)]
-
 use clap::*;
 use movement_full_node::MovementFullNode;
-
+use tracing_subscriber::EnvFilter;
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-	let suzuka_util = MovementFullNode::parse();
-	let result = suzuka_util.execute().await;
-
-	result
+    // Initialize default tracing
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+        .init();
+    let suzuka_util = MovementFullNode::parse();
+    let result = suzuka_util.execute().await;
+    result
 }

--- a/networks/movement/movement-full-node/src/main.rs
+++ b/networks/movement/movement-full-node/src/main.rs
@@ -4,11 +4,13 @@ use movement_full_node::MovementFullNode;
 use tracing_subscriber::EnvFilter;
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    // Initialize default tracing
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
-        .init();
-    let suzuka_util = MovementFullNode::parse();
-    let result = suzuka_util.execute().await;
-    result
+	// Initialize default tracing
+	tracing_subscriber::fmt()
+		.with_env_filter(
+			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+		)
+		.init();
+	let suzuka_util = MovementFullNode::parse();
+	let result = suzuka_util.execute().await;
+	result
 }


### PR DESCRIPTION
# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

<!--
Add your summary text here. 
 -->
updated full node to have tracing initialization independent of aptos-telemetry

# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->
modified `main.rs` in `movement-full-node`
