### PR TITLE
feat: add restic restore scripts

### DIFF
--- a/docs/movement-node/run-fullnode/scripts/devnet/restic-restore.sh
+++ b/docs/movement-node/run-fullnode/scripts/devnet/restic-restore.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -e
+
+export DOT_MOVEMENT_PATH="$HOME/.movement"
+export AWS_REGION="us-west-2"
+export RESTIC_PASSWORD="movebackup"
+export RESTIC_HOST="devnet_fullnode"
+export SYNC_BUCKET="movement-sync-devnet"
+export RESTIC_REPOSITORY="s3:s3.${AWS_REGION}.amazonaws.com/${SYNC_BUCKET}/restic_node_backup"
+
+echo "Removing old Movement DB files..."
+
+rm -rf "$DOT_MOVEMENT_PATH/maptos"
+rm -rf "$DOT_MOVEMENT_PATH/maptos-storage"
+rm -rf "$DOT_MOVEMENT_PATH/movement-da-db"
+
+echo "Restoring latest snapshot from Restic..."
+
+restic \
+  --no-lock \
+  -r "s3:s3.${AWS_REGION}.amazonaws.com/${SYNC_BUCKET}/restic_node_backup" \
+  --host "$RESTIC_HOST" \
+  restore latest \
+  --target "$DOT_MOVEMENT_PATH" \
+  --include "/.movement/maptos" \
+  --include "/.movement/maptos-storage" \
+  --include "/.movement/movement-da-db" \
+  --include "/.movement/default_signer_address_whitelist" \
+  -o s3.unsafe-anonymous-auth=true
+
+echo "Restore complete."

--- a/docs/movement-node/run-fullnode/scripts/mainnet/restic-restore.sh
+++ b/docs/movement-node/run-fullnode/scripts/mainnet/restic-restore.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+
+# Find the root of the repo (3 levels up from this script)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../../" && pwd)"
+
+export DOT_MOVEMENT_PATH="$HOME/.movement"
+export AWS_REGION="us-west-2"
+export RESTIC_PASSWORD="movebackup"
+export RESTIC_HOST="mainnet_fullnode"
+export SYNC_BUCKET="movement-sync-mainnet"
+export RESTIC_REPOSITORY="s3:s3.${AWS_REGION}.amazonaws.com/${SYNC_BUCKET}/restic_node_backup"
+
+echo "Removing old Movement DB files..."
+
+rm -rf "$DOT_MOVEMENT_PATH/maptos"
+rm -rf "$DOT_MOVEMENT_PATH/maptos-storage"
+rm -rf "$DOT_MOVEMENT_PATH/movement-da-db"
+
+echo "Restoring latest snapshot from Restic..."
+
+restic \
+  --no-lock \
+  -r "s3:s3.${AWS_REGION}.amazonaws.com/${SYNC_BUCKET}/restic_node_backup" \
+  --host "$RESTIC_HOST" \
+  restore latest \
+  --target "$DOT_MOVEMENT_PATH" \
+  --include "/.movement/maptos" \
+  --include "/.movement/maptos-storage" \
+  --include "/.movement/movement-da-db" \
+  --include "/.movement/default_signer_address_whitelist" \
+  -o s3.unsafe-anonymous-auth=true
+
+echo "Restore complete."

--- a/docs/movement-node/run-fullnode/scripts/mainnet/restore.sh
+++ b/docs/movement-node/run-fullnode/scripts/mainnet/restore.sh
@@ -1,20 +1,22 @@
 #!/bin/bash -e
 
-# Find the root of the repo (3 levels up from this script)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../../" && pwd)"
-
-export DOT_MOVEMENT_PATH="$HOME/.movement"
+export DOT_MOVEMENT_PATH=$HOME/.movement
 export AWS_REGION="us-west-2"
 export RESTIC_PASSWORD="movebackup"
 export RESTIC_HOST="mainnet_fullnode"
 export SYNC_BUCKET="movement-sync-mainnet"
 
+# Remove old DB files
+# Remove old DB files
 echo "Remove Maptos DB files"
+if [ -d "$DOT_MOVEMENT_PATH/maptos" ]; then
+  rm -rf $DOT_MOVEMENT_PATH/maptos
+fi
+if [ -d "$DOT_MOVEMENT_PATH/maptos-storage" ]; then
+  rm -rf $DOT_MOVEMENT_PATH/maptos-storage
+fi
+if [ -d "$DOT_MOVEMENT_PATH/movement-da-db" ]; then
+  rm -rf $DOT_MOVEMENT_PATH/movement-da-db
+fi
 
-rm -rf "$DOT_MOVEMENT_PATH/maptos"
-rm -rf "$DOT_MOVEMENT_PATH/maptos-storage"
-rm -rf "$DOT_MOVEMENT_PATH/movement-da-db"
-
-# Use absolute path to docker-compose file
-docker compose -f "$REPO_ROOT/docker/compose/movement-full-node/snapshot/docker-compose.restore.yml" up --force-recreate
+/usr/bin/docker compose -f ./movement/docker/compose/movement-full-node/snapshot/docker-compose.restore.yml up --force-recreate

--- a/docs/movement-node/run-fullnode/scripts/mainnet/restore.sh
+++ b/docs/movement-node/run-fullnode/scripts/mainnet/restore.sh
@@ -1,22 +1,20 @@
 #!/bin/bash -e
 
-export DOT_MOVEMENT_PATH=$HOME/.movement
+# Find the root of the repo (3 levels up from this script)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../../" && pwd)"
+
+export DOT_MOVEMENT_PATH="$HOME/.movement"
 export AWS_REGION="us-west-2"
 export RESTIC_PASSWORD="movebackup"
 export RESTIC_HOST="mainnet_fullnode"
 export SYNC_BUCKET="movement-sync-mainnet"
 
-# Remove old DB files
-# Remove old DB files
 echo "Remove Maptos DB files"
-if [ -d "$DOT_MOVEMENT_PATH/maptos" ]; then
-  rm -rf $DOT_MOVEMENT_PATH/maptos
-fi
-if [ -d "$DOT_MOVEMENT_PATH/maptos-storage" ]; then
-  rm -rf $DOT_MOVEMENT_PATH/maptos-storage
-fi
-if [ -d "$DOT_MOVEMENT_PATH/movement-da-db" ]; then
-  rm -rf $DOT_MOVEMENT_PATH/movement-da-db
-fi
 
-/usr/bin/docker compose -f ./movement/docker/compose/movement-full-node/snapshot/docker-compose.restore.yml up --force-recreate
+rm -rf "$DOT_MOVEMENT_PATH/maptos"
+rm -rf "$DOT_MOVEMENT_PATH/maptos-storage"
+rm -rf "$DOT_MOVEMENT_PATH/movement-da-db"
+
+# Use absolute path to docker-compose file
+docker compose -f "$REPO_ROOT/docker/compose/movement-full-node/snapshot/docker-compose.restore.yml" up --force-recreate

--- a/docs/movement-node/run-fullnode/scripts/testnet/restic-restore.sh
+++ b/docs/movement-node/run-fullnode/scripts/testnet/restic-restore.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -e
+
+export DOT_MOVEMENT_PATH="$HOME/.movement"
+export AWS_REGION="us-west-2"
+export RESTIC_PASSWORD="movebackup"
+export RESTIC_HOST="testnet_fullnode"
+export SYNC_BUCKET="movement-sync-testnet"
+export RESTIC_REPOSITORY="s3:s3.${AWS_REGION}.amazonaws.com/${SYNC_BUCKET}/restic_node_backup"
+
+# Remove old DB files
+echo "Remove Maptos DB files"
+if [ -d "$DOT_MOVEMENT_PATH/maptos" ]; then
+  rm -rf "$DOT_MOVEMENT_PATH/maptos"
+fi
+if [ -d "$DOT_MOVEMENT_PATH/maptos-storage" ]; then
+  rm -rf "$DOT_MOVEMENT_PATH/maptos-storage"
+fi
+if [ -d "$DOT_MOVEMENT_PATH/movement-da-db" ]; then
+  rm -rf "$DOT_MOVEMENT_PATH/movement-da-db"
+fi
+
+echo "Restoring latest snapshot from Restic..."
+
+restic \
+  --no-lock \
+  -r "s3:s3.${AWS_REGION}.amazonaws.com/${SYNC_BUCKET}/restic_node_backup" \
+  --host "$RESTIC_HOST" \
+  restore latest \
+  --target "$DOT_MOVEMENT_PATH" \
+  --include "/.movement/maptos" \
+  --include "/.movement/maptos-storage" \
+  --include "/.movement/movement-da-db" \
+  --include "/.movement/default_signer_address_whitelist" \
+  -o s3.unsafe-anonymous-auth=true
+
+echo "Restore complete."

--- a/docs/movement-node/run-fullnode/scripts/testnet/restic-restore.sh
+++ b/docs/movement-node/run-fullnode/scripts/testnet/restic-restore.sh
@@ -8,7 +8,7 @@ export SYNC_BUCKET="movement-sync-testnet"
 export RESTIC_REPOSITORY="s3:s3.${AWS_REGION}.amazonaws.com/${SYNC_BUCKET}/restic_node_backup"
 
 # Remove old DB files
-echo "Remove Maptos DB files"
+echo "Removing Maptos DB files"
 if [ -d "$DOT_MOVEMENT_PATH/maptos" ]; then
   rm -rf "$DOT_MOVEMENT_PATH/maptos"
 fi


### PR DESCRIPTION
## Pull Request Overview

This PR adds standardized Restic restore scripts for testnet, devnet, and mainnet environments. This script allows any developer to download the any of our network data to their local machine for testing. 

- Introduce `restic-restore.sh` for testnet, devnet, and mainnet  

## Changelog

| File                                                         | Description                                                |
| ------------------------------------------------------------ | ---------------------------------------------------------- |
| docs/movement-node/run-fullnode/scripts/testnet/restic-restore.sh | Add new testnet Restic restore script                      |
| docs/movement-node/run-fullnode/scripts/mainnet/restic-restore.sh | Add new mainnet Restic restore script                      |
| docs/movement-node/run-fullnode/scripts/devnet/restic-restore.sh  | Add new devnet Restic restore script                       |


# Testing
To try out the devnet restic restoration. From the root of your repo
```
./docs/movement-node/run-fullnode/scripts/devnet/restic-restore.sh
```

