### PR TITLE
[script] fix the system env check in nix script.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -158,7 +158,7 @@
               # export PKG_CONFIG_PATH=$PKG_CONFIG_PATH_FOR_TARGET
 
               # Export linker flags if on Darwin (macOS)
-              if [[ "$(${pkgs.stdenv.hostPlatform.system})" =~ "darwin" ]]; then
+              if [[ "${pkgs.stdenv.hostPlatform.system}" =~ "darwin" ]]; then
                 export LDFLAGS="-L/opt/homebrew/opt/zlib/lib"
                 export CPPFLAGS="-I/opt/homebrew/opt/zlib/include"
               fi


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**: `scripts`

Fixes a bug in the Nix `shellHook` that caused the dev shell to attempt executing `x86_64-linux` as a shell command, resulting in:

```
bash: x86_64-linux: command not found
```

<!--
Add your summary text here. 
 -->


# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

### Fixed

- Fixed a bug in `flake.nix` where the dev shell attempted to execute the platform string as a command (`x86_64-linux`), causing startup errors.

# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

Locally tested and looks good. 
![image](https://github.com/user-attachments/assets/ff62a302-8666-4351-bd6a-819449177324)


# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->