### PR TITLE
Indexer v2 skeleton: config support + minimum server impl(2/n)

### DIFF
--- a/.github/workflows/build-push-containers-all.yml
+++ b/.github/workflows/build-push-containers-all.yml
@@ -30,6 +30,7 @@ jobs:
           - movement-full-node
           - movement-faucet-service
           - movement-indexer
+          - movement-indexer-v2
     with:
       container_name: ${{ matrix.container_name }}
 
@@ -45,5 +46,6 @@ jobs:
           - movement-full-node
           - movement-faucet-service
           - movement-indexer
+          - movement-indexer-v2
     with:
       container_name: ${{ matrix.container_name }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,9 +788,9 @@ checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "aptos-abstract-gas-usage"
@@ -3234,6 +3234,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-indexer-processor-sdk"
+version = "0.1.0"
+source = "git+https://github.com/larryl3u/aptos-indexer-processor-sdk?rev=bbcc42d5a03cffe861b89c080ef7de918f37b4d0#bbcc42d5a03cffe861b89c080ef7de918f37b4d0"
+dependencies = [
+ "ahash 0.8.11",
+ "anyhow",
+ "aptos-indexer-transaction-stream",
+ "aptos-protos 1.3.1",
+ "aptos-system-utils 0.1.0 (git+https://github.com/aptos-labs/aptos-core.git?rev=2dd9c73b27fdcbe78c7391fd43c9a5d00b93e686)",
+ "async-trait",
+ "autometrics",
+ "axum 0.7.9",
+ "backtrace",
+ "bcs 0.1.4",
+ "bigdecimal",
+ "chrono",
+ "clap 4.5.21",
+ "derive_builder 0.20.2",
+ "diesel",
+ "diesel-async 0.5.2",
+ "diesel_migrations",
+ "field_count",
+ "futures",
+ "futures-util",
+ "hex",
+ "indexmap 2.6.0",
+ "instrumented-channel",
+ "kanal",
+ "mockall",
+ "native-tls",
+ "num_cpus",
+ "once_cell",
+ "petgraph 0.6.5",
+ "postgres-native-tls",
+ "prometheus 0.13.4",
+ "prometheus-client",
+ "serde",
+ "serde_json",
+ "serde_yaml 0.8.26",
+ "sha2 0.9.9",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tiny-keccak",
+ "tokio",
+ "tokio-postgres",
+ "toml 0.7.8",
+ "tracing",
+ "tracing-subscriber 0.3.18",
+ "url",
+]
+
+[[package]]
+name = "aptos-indexer-transaction-stream"
+version = "0.1.0"
+source = "git+https://github.com/larryl3u/aptos-indexer-processor-sdk?rev=bbcc42d5a03cffe861b89c080ef7de918f37b4d0#bbcc42d5a03cffe861b89c080ef7de918f37b4d0"
+dependencies = [
+ "anyhow",
+ "aptos-moving-average 0.1.0 (git+https://github.com/larryl3u/aptos-indexer-processor-sdk?rev=bbcc42d5a03cffe861b89c080ef7de918f37b4d0)",
+ "aptos-protos 1.3.1",
+ "aptos-transaction-filter",
+ "chrono",
+ "futures-util",
+ "once_cell",
+ "prometheus 0.13.4",
+ "prost 0.13.5",
+ "sample",
+ "serde",
+ "tokio",
+ "tonic 0.12.3",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "aptos-infallible"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core.git?branch=movement#31d9876e563698049a1ea0b7f1d88b48b921c3e9"
@@ -3821,6 +3895,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-moving-average"
+version = "0.1.0"
+source = "git+https://github.com/larryl3u/aptos-indexer-processor-sdk?rev=bbcc42d5a03cffe861b89c080ef7de918f37b4d0#bbcc42d5a03cffe861b89c080ef7de918f37b4d0"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core.git?branch=movement#31d9876e563698049a1ea0b7f1d88b48b921c3e9"
@@ -4396,6 +4478,19 @@ dependencies = [
 [[package]]
 name = "aptos-profiler"
 version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-core.git?rev=2dd9c73b27fdcbe78c7391fd43c9a5d00b93e686#2dd9c73b27fdcbe78c7391fd43c9a5d00b93e686"
+dependencies = [
+ "anyhow",
+ "backtrace",
+ "jemalloc-sys",
+ "jemallocator",
+ "pprof",
+ "regex",
+]
+
+[[package]]
+name = "aptos-profiler"
+version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=338f9a1bcc06f62ce4a4994f1642b9a61b631ee0#338f9a1bcc06f62ce4a4994f1642b9a61b631ee0"
 dependencies = [
  "anyhow",
@@ -4460,6 +4555,17 @@ dependencies = [
  "prost 0.12.6",
  "serde",
  "tonic 0.11.0",
+]
+
+[[package]]
+name = "aptos-protos"
+version = "1.3.1"
+source = "git+https://github.com/aptos-labs/aptos-core.git?rev=2dd9c73b27fdcbe78c7391fd43c9a5d00b93e686#2dd9c73b27fdcbe78c7391fd43c9a5d00b93e686"
+dependencies = [
+ "pbjson",
+ "prost 0.13.5",
+ "serde",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -5267,6 +5373,26 @@ dependencies = [
 [[package]]
 name = "aptos-system-utils"
 version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-core.git?rev=2dd9c73b27fdcbe78c7391fd43c9a5d00b93e686#2dd9c73b27fdcbe78c7391fd43c9a5d00b93e686"
+dependencies = [
+ "anyhow",
+ "aptos-profiler 0.1.0 (git+https://github.com/aptos-labs/aptos-core.git?rev=2dd9c73b27fdcbe78c7391fd43c9a5d00b93e686)",
+ "async-mutex",
+ "http 0.2.12",
+ "hyper 0.14.31",
+ "lazy_static",
+ "mime",
+ "pprof",
+ "regex",
+ "rstack-self",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aptos-system-utils"
+version = "0.1.0"
 source = "git+https://github.com/movementlabsxyz/aptos-core?rev=338f9a1bcc06f62ce4a4994f1642b9a61b631ee0#338f9a1bcc06f62ce4a4994f1642b9a61b631ee0"
 dependencies = [
  "anyhow",
@@ -5520,6 +5646,24 @@ dependencies = [
  "pin-project 1.1.7",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "aptos-transaction-filter"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-core.git?rev=2dd9c73b27fdcbe78c7391fd43c9a5d00b93e686#2dd9c73b27fdcbe78c7391fd43c9a5d00b93e686"
+dependencies = [
+ "anyhow",
+ "aptos-protos 1.3.1",
+ "derivative",
+ "derive_builder 0.20.2",
+ "memchr",
+ "once_cell",
+ "prost 0.13.5",
+ "serde",
+ "serde_json",
+ "serde_yaml 0.8.26",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6398,6 +6542,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "autometrics"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10eaae539e7319a3813dc8cd53776a7128bdd6d82067275c12586f5a0fce9137"
+dependencies = [
+ "autometrics-macros",
+ "cfg_aliases 0.1.1",
+ "http 1.1.0",
+ "linkme",
+ "metrics-exporter-prometheus",
+ "once_cell",
+ "opentelemetry-prometheus",
+ "opentelemetry_sdk",
+ "prometheus 0.13.4",
+ "prometheus-client",
+ "spez",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "autometrics-macros"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf7c9ebfee6425011c65788c746adf80fac99ba38957ba1cdb824b593cfc993"
+dependencies = [
+ "percent-encoding",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "aws-config"
 version = "1.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6847,6 +7024,8 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
+ "hyper 1.5.0",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -6855,10 +7034,15 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper 1.0.1",
+ "tokio",
  "tower 0.5.1",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6896,6 +7080,7 @@ dependencies = [
  "sync_wrapper 1.0.1",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6995,6 +7180,15 @@ dependencies = [
  "futures-util",
  "parking_lot 0.12.3",
  "tokio",
+]
+
+[[package]]
+name = "bcs"
+version = "0.1.4"
+source = "git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d#d31fab9d81748e2594be5cd5cdf845786a30562d"
+dependencies = [
+ "serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7367,7 +7561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2506947f73ad44e344215ccd6403ac2ae18cd8e046e581a441bf8d199f257f03"
 dependencies = [
  "borsh-derive 1.5.3",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
 ]
 
 [[package]]
@@ -7669,7 +7863,7 @@ version = "0.7.0"
 source = "git+https://github.com/eigerco/lumina?rev=c6e5b7f5e3a3040bce4262fe5fba5c21a2637b5#c6e5b7f5e3a3040bce4262fe5fba5c21a2637b52"
 dependencies = [
  "bytes 1.8.0",
- "prost 0.13.3",
+ "prost 0.13.5",
  "prost-build",
  "prost-types 0.13.3",
  "protox",
@@ -7687,7 +7881,7 @@ dependencies = [
  "celestia-types",
  "http 1.1.0",
  "jsonrpsee",
- "prost 0.13.3",
+ "prost 0.13.5",
  "serde",
  "thiserror 1.0.69",
  "tracing",
@@ -7712,7 +7906,7 @@ dependencies = [
  "multiaddr",
  "multihash",
  "nmt-rs",
- "prost 0.13.3",
+ "prost 0.13.5",
  "ruint",
  "serde",
  "serde_repr",
@@ -7743,6 +7937,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -8203,6 +8403,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -8771,6 +8981,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "delegate"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "der"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8846,7 +9067,16 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
 dependencies = [
- "derive_builder_macro",
+ "derive_builder_macro 0.12.0",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro 0.20.2",
 ]
 
 [[package]]
@@ -8862,13 +9092,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.10",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "derive_builder_macro"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
 dependencies = [
- "derive_builder_core",
+ "derive_builder_core 0.12.0",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core 0.20.2",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -8936,6 +9188,20 @@ name = "diesel-async"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c5c6ec8d5c7b8444d19a47161797cbe361e0fb1ee40c6a8124ec915b64a4125"
+dependencies = [
+ "async-trait",
+ "bb8",
+ "diesel",
+ "futures-util",
+ "scoped-futures",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "diesel-async"
+version = "0.5.2"
+source = "git+https://github.com/weiznich/diesel_async.git?rev=e3beac66cd41ab53d78a10328bb72f272103e5d1#e3beac66cd41ab53d78a10328bb72f272103e5d1"
 dependencies = [
  "async-trait",
  "bb8",
@@ -9105,6 +9371,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "dsl_auto_type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9117,6 +9389,12 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
+
+[[package]]
+name = "dtoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
 
 [[package]]
 name = "dunce"
@@ -9682,6 +9960,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+
+[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10109,7 +10393,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0edfdfb507593d47605b3bb2fb36628b391e3d397e520b85852dea2412c8e2d1"
 dependencies = [
- "prost 0.13.3",
+ "prost 0.13.5",
  "prost-types 0.13.3",
  "tonic 0.12.3",
 ]
@@ -11202,6 +11486,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "instrumented-channel"
+version = "0.1.0"
+source = "git+https://github.com/larryl3u/aptos-indexer-processor-sdk?rev=bbcc42d5a03cffe861b89c080ef7de918f37b4d0#bbcc42d5a03cffe861b89c080ef7de918f37b4d0"
+dependencies = [
+ "delegate",
+ "derive_builder 0.20.2",
+ "kanal",
+ "once_cell",
+ "prometheus 0.13.4",
+ "prometheus-client",
+]
+
+[[package]]
 name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11858,6 +12155,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linkme"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1b1703c00b2a6a70738920544aa51652532cacddfec2e162d2e29eae01e665c"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d55ca5d5a14363da83bf3c33874b8feaa34653e760d5216d7ef9829c88001a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11995,6 +12312,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12041,6 +12367,7 @@ dependencies = [
  "anyhow",
  "aptos-account-whitelist",
  "aptos-crypto 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67)",
+ "aptos-indexer-processor-sdk",
  "aptos-sdk 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67)",
  "aptos-types 0.0.3 (git+https://github.com/movementlabsxyz/aptos-core?rev=1d1cdbbd7fabb80dcb95ba5e23213faa072fab67)",
  "godfig",
@@ -12049,6 +12376,7 @@ dependencies = [
  "movement-signer",
  "movement-signer-loader",
  "poem",
+ "processor 0.1.0",
  "prometheus 0.14.0",
  "rand 0.7.3",
  "serde",
@@ -12168,7 +12496,7 @@ dependencies = [
  "once_cell",
  "poem",
  "poem-openapi",
- "prost 0.13.3",
+ "prost 0.13.5",
  "rand 0.7.3",
  "schemars",
  "serde",
@@ -12392,6 +12720,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
+dependencies = [
+ "ahash 0.8.11",
+ "metrics-macros",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d4fa7ce7c4862db464a37b0b31d89bca874562f034bd7993895572783d02950"
+dependencies = [
+ "base64 0.21.7",
+ "indexmap 1.9.3",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111cb375987443c3de8d503580b536f77dc8416d32db62d9456db5d93bd7ac47"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.13.2",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "miette"
 version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12511,6 +12890,33 @@ name = "mirai-annotations"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
+
+[[package]]
+name = "mockall"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
 
 [[package]]
 name = "more-asserts"
@@ -13890,7 +14296,7 @@ dependencies = [
  "clap_complete",
  "dashmap 5.5.3",
  "diesel",
- "diesel-async",
+ "diesel-async 0.5.1",
  "dirs 5.0.1",
  "futures",
  "hex",
@@ -13973,7 +14379,7 @@ dependencies = [
  "movement-signer-loader",
  "movement-tracing",
  "movement-types",
- "prost 0.13.3",
+ "prost 0.13.5",
  "serde",
  "serde_json",
  "tempfile",
@@ -14168,7 +14574,7 @@ dependencies = [
  "movement-da-light-node-proto",
  "movement-da-util",
  "movement-types",
- "prost 0.13.3",
+ "prost 0.13.5",
  "rand 0.7.3",
  "serde_json",
  "thiserror 1.0.69",
@@ -14183,7 +14589,7 @@ name = "movement-da-light-node-proto"
 version = "0.3.4"
 dependencies = [
  "buildtime",
- "prost 0.13.3",
+ "prost 0.13.5",
  "tonic 0.12.3",
  "tonic-build",
 ]
@@ -14249,7 +14655,7 @@ dependencies = [
  "movement-da-light-node-setup",
  "movement-da-util",
  "movement-signer",
- "prost 0.13.3",
+ "prost 0.13.5",
  "rand 0.7.3",
  "serde_json",
  "thiserror 1.0.69",
@@ -14326,7 +14732,7 @@ dependencies = [
  "movement-types",
  "once_cell",
  "poem",
- "prost 0.13.3",
+ "prost 0.13.5",
  "rand 0.7.3",
  "rand_core 0.9.0",
  "rocksdb",
@@ -14347,7 +14753,7 @@ name = "movement-da-sequencer-proto"
 version = "0.3.4"
 dependencies = [
  "buildtime",
- "prost 0.13.3",
+ "prost 0.13.5",
  "tonic 0.12.3",
  "tonic-build",
 ]
@@ -14378,7 +14784,7 @@ dependencies = [
  "movement-signer-loader",
  "movement-signer-local",
  "movement-types",
- "prost 0.13.3",
+ "prost 0.13.5",
  "rand 0.8.5",
  "serde",
  "serde_derive",
@@ -14452,7 +14858,7 @@ dependencies = [
  "movement-signer-loader",
  "movement-tracing",
  "movement-types",
- "prost 0.13.3",
+ "prost 0.13.5",
  "rocksdb",
  "serde_json",
  "sha2 0.10.8",
@@ -14468,6 +14874,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "movement-health"
+version = "0.3.4"
+dependencies = [
+ "anyhow",
+ "poem",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "movement-indexer-service"
 version = "0.3.4"
 dependencies = [
@@ -14478,6 +14894,32 @@ dependencies = [
  "maptos-execution-util",
  "num_cpus",
  "poem",
+ "processor 1.0.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=20be1190105908fd4fea4e78c330997658e9428e)",
+ "reqwest 0.12.9",
+ "serde_json",
+ "serde_yaml 0.9.34+deprecated",
+ "server-framework 1.0.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=20be1190105908fd4fea4e78c330997658e9428e)",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "movement-indexer-service-v2"
+version = "0.3.4"
+dependencies = [
+ "anyhow",
+ "aptos-indexer-processor-sdk",
+ "clap 4.5.21",
+ "dot-movement",
+ "futures",
+ "maptos-execution-util",
+ "movement-health",
+ "movement-tracing",
+ "num_cpus",
+ "poem",
+ "processor 0.1.0",
  "processor 1.0.0 (git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=20be1190105908fd4fea4e78c330997658e9428e)",
  "reqwest 0.12.9",
  "serde_json",
@@ -14790,7 +15232,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -14844,7 +15286,7 @@ checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -15168,6 +15610,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "indexmap 2.6.0",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry-prometheus"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8f082da115b0dcb250829e3ed0b8792b8f963a1ad42466e48422fbe6a079bd"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prometheus 0.13.4",
+ "protobuf 2.28.0",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry",
+ "ordered-float 4.6.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15187,6 +15675,15 @@ name = "ordered-float"
 version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
 ]
@@ -16086,6 +16583,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "pretty"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16221,6 +16744,64 @@ dependencies = [
 
 [[package]]
 name = "processor"
+version = "0.1.0"
+source = "git+https://github.com/larryl3u/aptos-indexer-processors-v2?rev=2e5dd83639886fe9e44af97726d79895a3b4f650#2e5dd83639886fe9e44af97726d79895a3b4f650"
+dependencies = [
+ "ahash 0.8.11",
+ "allocative",
+ "allocative_derive",
+ "anyhow",
+ "aptos-indexer-processor-sdk",
+ "async-trait",
+ "bcs 0.1.4",
+ "bigdecimal",
+ "bitflags 2.6.0",
+ "canonical_json",
+ "chrono",
+ "clap 4.5.21",
+ "const_format",
+ "diesel",
+ "diesel-async 0.5.2",
+ "diesel_migrations",
+ "enum_dispatch",
+ "field_count",
+ "futures",
+ "futures-util",
+ "google-cloud-googleapis 0.10.0",
+ "google-cloud-pubsub",
+ "google-cloud-storage",
+ "hex",
+ "hyper 0.14.31",
+ "itertools 0.12.1",
+ "jemallocator",
+ "lazy_static",
+ "log",
+ "native-tls",
+ "num_cpus",
+ "once_cell",
+ "parquet",
+ "parquet_derive",
+ "postgres-native-tls",
+ "prometheus 0.13.4",
+ "prost 0.13.5",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "sha3 0.10.8",
+ "strum 0.24.1",
+ "tiny-keccak",
+ "tokio",
+ "tokio-postgres",
+ "tonic 0.12.3",
+ "tracing",
+ "unescape",
+ "url",
+]
+
+[[package]]
+name = "processor"
 version = "1.0.0"
 source = "git+https://github.com/movementlabsxyz/aptos-indexer-processors?rev=20be1190105908fd4fea4e78c330997658e9428e#20be1190105908fd4fea4e78c330997658e9428e"
 dependencies = [
@@ -16238,7 +16819,7 @@ dependencies = [
  "chrono",
  "clap 4.5.21",
  "diesel",
- "diesel-async",
+ "diesel-async 0.5.1",
  "diesel_migrations",
  "enum_dispatch",
  "field_count",
@@ -16297,7 +16878,7 @@ dependencies = [
  "chrono",
  "clap 4.5.21",
  "diesel",
- "diesel-async",
+ "diesel-async 0.5.1",
  "diesel_migrations",
  "enum_dispatch",
  "field_count",
@@ -16383,6 +16964,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot 0.12.3",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "proptest"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16435,12 +17039,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes 1.8.0",
- "prost-derive 0.13.3",
+ "prost-derive 0.13.5",
 ]
 
 [[package]]
@@ -16457,7 +17061,7 @@ dependencies = [
  "once_cell",
  "petgraph 0.6.5",
  "prettyplease",
- "prost 0.13.3",
+ "prost 0.13.5",
  "prost-types 0.13.3",
  "regex",
  "syn 2.0.87",
@@ -16492,9 +17096,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",
@@ -16512,7 +17116,7 @@ dependencies = [
  "logos",
  "miette",
  "once_cell",
- "prost 0.13.3",
+ "prost 0.13.5",
  "prost-types 0.13.3",
 ]
 
@@ -16540,7 +17144,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
 dependencies = [
- "prost 0.13.3",
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -16596,7 +17200,7 @@ checksum = "6f352af331bf637b8ecc720f7c87bf903d2571fa2e14a66e9b2558846864b54a"
 dependencies = [
  "bytes 1.8.0",
  "miette",
- "prost 0.13.3",
+ "prost 0.13.5",
  "prost-reflect",
  "prost-types 0.13.3",
  "protox-parse",
@@ -16649,6 +17253,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "quanta"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach2",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -16751,7 +17371,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52cd4b1eff68bf27940dd39811292c49e007f4d0b4c357358dc9b0197be6b527"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -16904,6 +17524,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -17587,7 +18216,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -17600,7 +18229,19 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -17636,7 +18277,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afbb878bdfdf63a336a5e63561b1835e7a8c91524f51621db870169eac84b490"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-foundation-sys",
  "jni",
  "log",
@@ -17645,7 +18286,7 @@ dependencies = [
  "rustls-native-certs 0.7.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.8",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "webpki-roots 0.26.6",
  "winapi 0.3.9",
@@ -17719,6 +18360,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "sample"
+version = "0.1.0"
+source = "git+https://github.com/larryl3u/aptos-indexer-processor-sdk?rev=bbcc42d5a03cffe861b89c080ef7de918f37b4d0#bbcc42d5a03cffe861b89c080ef7de918f37b4d0"
+dependencies = [
+ "tracing",
 ]
 
 [[package]]
@@ -17853,7 +18502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
  "num-bigint 0.4.6",
@@ -17861,10 +18510,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "security-framework-sys"
-version = "2.12.1"
+name = "security-framework"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -18466,6 +19128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18547,6 +19215,17 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "sha1",
+]
+
+[[package]]
+name = "spez"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87e960f4dca2788eeb86bbdde8dd246be8948790b7618d656e68f9b720a86e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -18689,6 +19368,9 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros 0.24.3",
+]
 
 [[package]]
 name = "strum"
@@ -18927,7 +19609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.5.0",
 ]
 
@@ -18938,7 +19620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
 
@@ -19022,7 +19704,7 @@ dependencies = [
  "k256",
  "num-traits",
  "once_cell",
- "prost 0.13.3",
+ "prost 0.13.5",
  "ripemd",
  "serde",
  "serde_bytes",
@@ -19045,7 +19727,7 @@ checksum = "9ae9e1705aa0fa5ecb2c6aa7fb78c2313c4a31158ea5f02048bf318f849352eb"
 dependencies = [
  "bytes 1.8.0",
  "flex-error",
- "prost 0.13.3",
+ "prost 0.13.5",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -19082,6 +19764,12 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "textwrap"
@@ -19473,6 +20161,18 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
@@ -19499,6 +20199,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.6.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -19614,7 +20316,8 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project 1.1.7",
- "prost 0.13.3",
+ "prost 0.13.5",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "socket2",
  "tokio",
@@ -19625,6 +20328,7 @@ dependencies = [
  "tower-service",
  "tracing",
  "webpki-roots 0.26.6",
+ "zstd 0.13.2",
 ]
 
 [[package]]
@@ -19660,7 +20364,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "878d81f52e7fcfd80026b7fdb6a9b578b3c3653ba987f87f0dce4b64043cba27"
 dependencies = [
- "prost 0.13.3",
+ "prost 0.13.5",
  "prost-types 0.13.3",
  "tokio",
  "tokio-stream",
@@ -19717,8 +20421,10 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper 0.1.2",
+ "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -20302,7 +21008,7 @@ checksum = "a769a71e45deef489beed23167f79ee75d41f482b5e3d96ddab833f24fd07e51"
 dependencies = [
  "async-trait",
  "bytes 1.8.0",
- "derive_builder",
+ "derive_builder 0.12.0",
  "http 1.1.0",
  "reqwest 0.12.9",
  "rustify",
@@ -20573,7 +21279,7 @@ dependencies = [
 name = "whitelist"
 version = "0.3.4"
 dependencies = [
- "prost 0.13.3",
+ "prost 0.13.5",
  "thiserror 1.0.69",
  "tonic 0.12.3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
   "util/movement-algs",
   "util/movement-types",
   "util/tracing",
+  "util/health",
   "util/syncador",
   "util/collections",
   "util/whitelist",
@@ -127,6 +128,7 @@ movement-config = { path = "networks/movement/movement-config" }
 flocks = { path = "util/flocks" }
 godfig = { path = "util/godfig" }
 movement-tracing = { path = "util/tracing" }
+movement-health = { path = "util/health" }
 syncup = { path = "protocol-units/syncing/syncup" }
 syncador = { path = "util/syncador" }
 movement-collections = { path = "util/collections" }
@@ -204,6 +206,10 @@ movement = { git = "https://github.com/movementlabsxyz/aptos-core", rev = "1d1cd
 # Indexer
 processor = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "20be1190105908fd4fea4e78c330997658e9428e" }
 server-framework = { git = "https://github.com/movementlabsxyz/aptos-indexer-processors", rev = "20be1190105908fd4fea4e78c330997658e9428e" }
+# TODO: use forked version.
+processor-v2 = { git = "https://github.com/larryl3u/aptos-indexer-processors-v2", rev = "2e5dd83639886fe9e44af97726d79895a3b4f650", package = "processor" }
+aptos-indexer-processor-sdk = { git = "https://github.com/larryl3u/aptos-indexer-processor-sdk", rev = "bbcc42d5a03cffe861b89c080ef7de918f37b4d0" }
+
 
 bcs = { git = "https://github.com/movementlabsxyz/bcs.git", rev = "bc16d2d39cabafaabd76173dd1b04b2aa170cf0c" }
 
@@ -261,7 +267,7 @@ alloy-transport-http = { git = "https://github.com/alloy-rs/alloy.git", rev = "8
 ] }
 alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy.git", rev = "83343b172585fe4e040fb104b4d1421f58cbf9a2" }
 
-anyhow = "1.0"
+anyhow = "1.0.98"
 async-stream = "0.3.0"
 async-trait = "0.1.71"
 async-recursion = "1.1.1"

--- a/docker/build/movement-indexer-v2/Dockerfile
+++ b/docker/build/movement-indexer-v2/Dockerfile
@@ -1,0 +1,29 @@
+FROM nixos/nix:latest AS builder
+
+RUN nix-env -iA nixpkgs.rsync nixpkgs.glibc nixpkgs.gawk
+
+# Copy the source code into the container
+COPY . /tmp/build
+WORKDIR /tmp/build
+
+# Build the Rust application
+RUN nix --extra-experimental-features "nix-command flakes" \
+        develop .#docker-build --command bash -c "cargo build --release -p movement-indexer-service-v2"
+
+RUN rust_binary="./target/release/movement-indexer-service-v2"; dest_dir="/tmp/runtime"; \
+    mkdir -p "$dest_dir"; ldd "$rust_binary" | awk '{print $3}' | \
+    grep '^/' | xargs -I {} dirname {} | sort | uniq | xargs -I {} \
+    bash -c 'mkdir -p "$0/$1" && rsync -a --copy-links "$1/" "$0/$1/"' "$dest_dir" {}
+
+FROM alpine:latest
+
+# curl is needed for the health check
+RUN apk add --no-cache curl
+
+# Copy the build artifact from the builder stage
+COPY --from=builder /tmp/build/target/release/movement-indexer-service-v2 /app/movement-indexer-service-v2
+COPY --from=builder /tmp/build/target/release/load_metadata /app/load_metadata
+COPY --from=builder /tmp/runtime/nix/store /nix/store
+
+# Set the binary as the entrypoint
+ENTRYPOINT ["/app/movement-indexer-service-v2"]

--- a/docker/compose/movement-indexer/docker-compose.local-development.indexer-v2.yml
+++ b/docker/compose/movement-indexer/docker-compose.local-development.indexer-v2.yml
@@ -1,0 +1,92 @@
+services:
+
+  postgres:
+    image: postgres:15
+    user: postgres
+    command: postgres -c shared_buffers=256MB -c max_connections=1000 -c unix_socket_directories='/tmp'
+    container_name: postgres
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=postgres
+      - POSTGRES_DB_HOST=${POSTGRES_DB_HOST}
+    ports:
+      - "5432:5432"
+    restart: on-failure:3
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 1s
+      timeout: 5s
+      retries: 10
+
+  movement-indexer:
+    image: indexer-v2:892a5eef4
+    # entrypoint: '/bin/sh -c "tail -f /dev/null"'
+    container_name: movement-indexer
+    environment:
+      - DOT_MOVEMENT_PATH=/.movement
+      - MAPTOS_INDEXER_GRPC_LISTEN_HOSTNAME=${MAPTOS_INDEXER_GRPC_LISTEN_HOSTNAME}
+      - INDEXER_PROCESSOR_POSTGRES_CONNECTION_STRING=${INDEXER_PROCESSOR_POSTGRES_CONNECTION_STRING}
+      - METRICS_SERVER_PORT=10186
+      - HEALTH_SERVER_PORT=10185
+      - MAPTOS_ENABLE_TABLE_INFO_SERVICE=true
+    volumes:
+      - ${DOT_MOVEMENT_PATH}:/.movement
+      
+
+    restart: on-failure:5
+    depends_on:
+      - postgres
+    # to access services running on localhost extra_hosts from below is required
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+
+  graphql-engine:
+    image: hasura/graphql-engine:v2.40.0
+    ports:
+      - "8085:8085"
+    restart: always
+    environment:
+      HASURA_GRAPHQL_SERVER_PORT: 8085
+      ## postgres database to store Hasura metadata
+      HASURA_GRAPHQL_METADATA_DATABASE_URL: postgresql://postgres:password@${POSTGRES_DB_HOST}:5432/postgres
+      HASURA_GRAPHQL_DATABASE_URL: postgresql://postgres:password@${POSTGRES_DB_HOST}:5432/postgres
+      ## this env var can be used to add the above postgres database to Hasura as a data source. this can be removed/updated based on your needs
+      PG_DATABASE_URL: postgres://postgres:postgres:password@${POSTGRES_DB_HOST}:5432/postgres
+      ## enable the console served by server
+      HASURA_GRAPHQL_ENABLE_CONSOLE: "true" # set to "false" to disable console
+      ## enable debugging mode. It is recommended to disable this in production
+      HASURA_GRAPHQL_DEV_MODE: "true"
+      HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
+      ## uncomment next line to run console offline (i.e load console assets from server instead of CDN)
+      # HASURA_GRAPHQL_CONSOLE_ASSETS_DIR: /srv/console-assets
+      ## uncomment next line to set an admin secret
+      # HASURA_GRAPHQL_ADMIN_SECRET: myadminsecretkey
+      HASURA_GRAPHQL_METADATA_DEFAULTS: '{"backend_configs":{"dataconnector":{"athena":{"uri":"http://data-connector-agent:8081/api/v1/athena"},"mariadb":{"uri":"http://data-connector-agent:8081/api/v1/mariadb"},"mysql8":{"uri":"http://data-connector-agent:8081/api/v1/mysql"},"oracle":{"uri":"http://data-connector-agent:8081/api/v1/oracle"},"snowflake":{"uri":"http://data-connector-agent:8081/api/v1/snowflake"}}}}'
+    depends_on:
+      data-connector-agent:
+        condition: service_healthy
+
+  data-connector-agent:
+    image: hasura/graphql-data-connector:v2.40.0
+    restart: always
+    ports:
+      - 8081:8081
+    environment:
+      QUARKUS_LOG_LEVEL: ERROR # FATAL, ERROR, WARN, INFO, DEBUG, TRACE
+      ## https://quarkus.io/guides/opentelemetry#configuration-reference
+      QUARKUS_OPENTELEMETRY_ENABLED: "false"
+      ## QUARKUS_OPENTELEMETRY_TRACER_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8081/api/v1/athena/health"]
+      interval: 5s
+      timeout: 10s
+      retries: 5
+      start_period: 5s
+    depends_on:
+      - movement-indexer
+
+volumes:
+  dot-movement:
+  db_data:

--- a/networks/movement/indexer-v2/Cargo.toml
+++ b/networks/movement/indexer-v2/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "movement-indexer-service-v2"
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+publish = { workspace = true }
+rust-version = { workspace = true }
+
+[[bin]]
+name = "load_metadata"
+path = "bin/load_metadata.rs"
+
+
+[dependencies]
+anyhow = { workspace = true }
+tokio = { workspace = true }
+dot-movement = { workspace = true }
+futures = { workspace = true }
+num_cpus = { workspace = true }
+poem = { workspace = true }
+processor = { workspace = true }
+server-framework = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+maptos-execution-util = { workspace = true }
+clap = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
+serde_json = { workspace = true }
+tempfile = { workspace = true }
+processor-v2 = { workspace = true }
+aptos-indexer-processor-sdk = { workspace = true }
+movement-tracing = { workspace = true }
+movement-health = { workspace = true }
+
+serde_yaml = "0.9.34"
+
+[lints]
+workspace = true

--- a/networks/movement/indexer-v2/bin/load_metadata.rs
+++ b/networks/movement/indexer-v2/bin/load_metadata.rs
@@ -1,0 +1,120 @@
+use anyhow::{anyhow, Context, Result};
+use reqwest::Url;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+const HASURA_METADATA: &str = include_str!("../hasura_metadata.json");
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+	tracing_subscriber::fmt()
+		.with_env_filter(
+			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+		)
+		.init();
+
+	let indexer_api_url =
+		std::env::var("INDEXER_API_URL").unwrap_or("http://127.0.0.1:8085".to_string());
+
+	// Replace the postgres connection definition in the metadata file
+	// with the provided in the env var INDEXER_V2_POSTGRES_URL
+	let postgres_url = std::env::var("POSTGRES_DB_URL")
+		.unwrap_or("postgres://postgres:password@postgres:5432/postgres".to_string());
+	let metadata_file = HASURA_METADATA.replace("INDEXER_V2_POSTGRES_URL", &postgres_url);
+
+	post_metadata(indexer_api_url.parse()?, &metadata_file)
+		.await
+		.context("Failed to apply Hasura metadata for Indexer API")?;
+
+	Ok(())
+}
+
+/// This submits a POST request to apply metadata to a Hasura API.
+async fn post_metadata(url: Url, metadata_content: &str) -> Result<()> {
+	// Parse the metadata content as JSON.
+	let metadata_json: serde_json::Value = serde_json::from_str(metadata_content)?;
+
+	// Make the request.
+	info!("Submitting request to apply Hasura metadata");
+	let response =
+		make_hasura_metadata_request(url, "replace_metadata", Some(metadata_json)).await?;
+	info!("Received response for applying Hasura metadata: {:?}", response);
+
+	// Confirm that the metadata was applied successfully and there is no inconsistency
+	// between the schema and the underlying DB schema.
+	if let Some(obj) = response.as_object() {
+		if let Some(is_consistent_val) = obj.get("is_consistent") {
+			if is_consistent_val.as_bool() == Some(true) {
+				return Ok(());
+			}
+		}
+	}
+
+	Err(anyhow!(
+        "Something went wrong applying the Hasura metadata, perhaps it is not consistent with the DB. Response: {:#?}",
+        response
+    ))
+}
+
+/// This confirms that the metadata has been applied. We use this in the health
+/// checker.
+pub async fn confirm_metadata_applied(url: Url) -> Result<()> {
+	// Make the request.
+	info!("Confirming Hasura metadata applied...");
+	let response = make_hasura_metadata_request(url, "export_metadata", None).await?;
+	info!("Received response for confirming Hasura metadata applied: {:?}", response);
+
+	// If the sources field is set it means the metadata was applied successfully.
+	if let Some(obj) = response.as_object() {
+		if let Some(sources) = obj.get("sources") {
+			if let Some(sources) = sources.as_array() {
+				if !sources.is_empty() {
+					return Ok(());
+				}
+			}
+		}
+	}
+
+	Err(anyhow!("The Hasura metadata has not been applied yet. Response: {:#?}", response))
+}
+
+/// The /v1/metadata endpoint supports a few different operations based on the `type`
+/// field in the request body. All requests have a similar format, with these `type`
+/// and `args` fields.
+async fn make_hasura_metadata_request(
+	mut url: Url,
+	typ: &str,
+	args: Option<serde_json::Value>,
+) -> Result<serde_json::Value> {
+	let client = reqwest::Client::new();
+
+	// Update the query path.
+	url.set_path("/v1/metadata");
+
+	// Construct the payload.
+	let mut payload = serde_json::Map::new();
+	payload.insert("type".to_string(), serde_json::Value::String(typ.to_string()));
+
+	// If args is provided, use that. Otherwise use an empty object. We have to set it
+	// no matter what because the API expects the args key to be set.
+	let args = match args {
+		Some(args) => args,
+		None => serde_json::Value::Object(serde_json::Map::new()),
+	};
+	payload.insert("args".to_string(), args);
+
+	// Send the POST request.
+	let response = if let Ok(auth_key) = std::env::var("HASURA_ADMIN_AUTH_KEY") {
+		client
+			.post(url)
+			.header("X-Hasura-Admin-Secret", auth_key)
+			.json(&payload)
+			.send()
+			.await?
+	} else {
+		client.post(url).json(&payload).send().await?
+	};
+
+	// Return the response as a JSON value.
+	response.json().await.context("Failed to parse response as JSON")
+}

--- a/networks/movement/indexer-v2/hasura_metadata.json
+++ b/networks/movement/indexer-v2/hasura_metadata.json
@@ -1,0 +1,2302 @@
+{
+  "resource_version": 319,
+  "metadata": {
+    "version": 3,
+    "sources": [
+      {
+        "name": "indexer-v2",
+        "kind": "postgres",
+        "tables": [
+          {
+            "table": {
+              "name": "parsed_asset_uris",
+              "schema": "nft_metadata_crawler"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "animation_optimizer_retry_count",
+                    "asset_uri",
+                    "cdn_animation_uri",
+                    "cdn_image_uri",
+                    "cdn_json_uri",
+                    "inserted_at",
+                    "image_optimizer_retry_count",
+                    "json_parser_retry_count",
+                    "raw_animation_uri",
+                    "raw_image_uri"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "account_transactions",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "user_transaction",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "user_transactions",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "array_relationships": [
+              {
+                "name": "coin_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "coin_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "delegated_staking_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "delegated_staking_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "fungible_asset_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "fungible_asset_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "token_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token_activities_v2",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "token_activities_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": ["account_address", "inserted_at", "transaction_version"],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "address_events_summary",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "block_metadata",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "min_block_height": "block_height"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "block_metadata_transactions",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "min_block_height",
+                    "num_distinct_versions",
+                    "account_address"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "address_version_from_events",
+              "schema": "public"
+            },
+            "array_relationships": [
+              {
+                "name": "coin_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "coin_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "delegated_staking_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "delegated_staking_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "token_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token_activities_v2",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "token_activities_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": ["account_address", "transaction_version"],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "address_version_from_move_resources",
+              "schema": "public"
+            },
+            "array_relationships": [
+              {
+                "name": "coin_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "coin_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "delegated_staking_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "delegated_staking_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "token_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token_activities_v2",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "token_activities_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": ["address", "transaction_version"],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "block_metadata_transactions",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "block_height",
+                    "epoch",
+                    "failed_proposer_indices",
+                    "id",
+                    "previous_block_votes_bitvec",
+                    "proposer",
+                    "round",
+                    "inserted_at",
+                    "timestamp",
+                    "version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "coin_activities",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "coin_info",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "coin_type": "coin_type"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "coin_infos",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "array_relationships": [
+              {
+                "name": "aptos_names",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "owner_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "activity_type",
+                    "amount",
+                    "block_height",
+                    "coin_type",
+                    "entry_function_id_str",
+                    "event_account_address",
+                    "event_creation_number",
+                    "event_index",
+                    "event_sequence_number",
+                    "is_gas_fee",
+                    "is_transaction_success",
+                    "owner_address",
+                    "inserted_at",
+                    "storage_refund_amount",
+                    "transaction_timestamp",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "coin_balances",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "coin_type",
+                    "inserted_at",
+                    "coin_type_hash",
+                    "owner_address",
+                    "transaction_timestamp",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "coin_infos",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "coin_type",
+                    "coin_type_hash",
+                    "creator_address",
+                    "decimals",
+                    "name",
+                    "supply_aggregator_table_handle",
+                    "supply_aggregator_table_key",
+                    "symbol",
+                    "inserted_at",
+                    "transaction_created_timestamp",
+                    "transaction_version_created"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "coin_supply",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "coin_type",
+                    "coin_type_hash",
+                    "supply",
+                    "inserted_at",
+                    "transaction_epoch",
+                    "transaction_timestamp",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "collection_datas",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "description",
+                    "description_mutable",
+                    "inserted_at",
+                    "maximum",
+                    "maximum_mutable",
+                    "metadata_uri",
+                    "supply",
+                    "table_handle",
+                    "transaction_timestamp",
+                    "transaction_version",
+                    "uri_mutable"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_ans_lookup",
+              "schema": "public"
+            },
+            "array_relationships": [
+              {
+                "name": "all_token_ownerships",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_name": "name"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_ownerships",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "domain",
+                    "expiration_timestamp",
+                    "is_deleted",
+                    "inserted_at",
+                    "last_transaction_version",
+                    "registered_address",
+                    "subdomain",
+                    "token_name"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_ans_lookup_v2",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "domain",
+                    "expiration_timestamp",
+                    "inserted_at",
+                    "is_deleted",
+                    "last_transaction_version",
+                    "registered_address",
+                    "subdomain",
+                    "token_name",
+                    "token_standard"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                },
+                "comment": ""
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_ans_primary_name_v2",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "registered_address",
+                    "token_standard",
+                    "domain",
+                    "subdomain",
+                    "token_name",
+                    "is_deleted",
+                    "last_transaction_version",
+                    "inserted_at"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                },
+                "comment": ""
+              }
+            ]            
+          },
+          {
+            "table": {
+              "name": "current_aptos_names",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "is_domain_owner",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "domain_with_suffix": "token_name",
+                      "owner_address": "owner_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "domain",
+                    "subdomain",
+                    "token_name",
+                    "token_standard",
+                    "registered_address",
+                    "expiration_timestamp",
+                    "last_transaction_version",
+                    "is_primary",
+                    "domain_with_suffix",
+                    "is_active"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                },
+                "comment": ""
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_coin_balances",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "coin_info",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "coin_type_hash": "coin_type_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "coin_infos",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "coin_type",
+                    "coin_type_hash",
+                    "inserted_at",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "owner_address"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_collection_datas",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "description",
+                    "description_mutable",
+                    "inserted_at",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "maximum",
+                    "maximum_mutable",
+                    "metadata_uri",
+                    "supply",
+                    "table_handle",
+                    "uri_mutable"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_collection_ownership_v2_view",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_collection",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "collection_id": "collection_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_collections_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "distinct_tokens",
+                    "last_transaction_version",
+                    "collection_id",
+                    "collection_name",
+                    "creator_address",
+                    "owner_address",
+                    "collection_uri",
+                    "single_token_uri"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_collections_v2",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "cdn_asset_uris",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "uri": "asset_uri"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "parsed_asset_uris",
+                      "schema": "nft_metadata_crawler"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "collection_id",
+                    "collection_name",
+                    "creator_address",
+                    "current_supply",
+                    "description",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "max_supply",
+                    "inserted_at",
+                    "mutable_description",
+                    "mutable_uri",
+                    "table_handle_v1",
+                    "token_standard",
+                    "total_minted_v2",
+                    "uri"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_delegated_staking_pool_balances",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "active_table_handle",
+                    "inactive_table_handle",
+                    "last_transaction_version",
+                    "inserted_at",
+                    "operator_commission_percentage",
+                    "staking_pool_address",
+                    "total_coins",
+                    "total_shares"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_delegated_voter",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "delegation_pool_address",
+                    "delegator_address",
+                    "inserted_at",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "pending_voter",
+                    "table_handle",
+                    "voter"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                },
+                "comment": ""
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_delegator_balances",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_pool_balance",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "pool_address": "staking_pool_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_delegated_staking_pool_balances",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "staking_pool_metadata",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "pool_address": "staking_pool_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_staking_pool_voter",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "delegator_address",
+                    "last_transaction_version",
+                    "inserted_at",
+                    "parent_table_handle",
+                    "pool_address",
+                    "pool_type",
+                    "shares",
+                    "table_handle"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_fungible_asset_balances",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "metadata",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "asset_type": "asset_type"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "fungible_asset_metadata",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "asset_type",
+                    "inserted_at",
+                    "is_frozen",
+                    "is_primary",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "owner_address",
+                    "storage_id",
+                    "token_standard"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_objects",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "allow_ungated_transfer",
+                    "inserted_at",
+                    "is_deleted",
+                    "last_guid_creation_num",
+                    "last_transaction_version",
+                    "object_address",
+                    "owner_address",
+                    "state_key_hash"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_staking_pool_voter",
+              "schema": "public"
+            },
+            "array_relationships": [
+              {
+                "name": "operator_aptos_name",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "operator_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "last_transaction_version",
+                    "inserted_at",
+                    "operator_address",
+                    "staking_pool_address",
+                    "voter_address"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_table_items",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "decoded_key",
+                    "decoded_value",
+                    "is_deleted",
+                    "inserted_at",
+                    "key",
+                    "key_hash",
+                    "last_transaction_version",
+                    "table_handle"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_token_datas",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_collection_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "collection_data_id_hash": "collection_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_collection_datas",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "default_properties",
+                    "description",
+                    "description_mutable",
+                    "inserted_at",
+                    "largest_property_version",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "maximum",
+                    "maximum_mutable",
+                    "metadata_uri",
+                    "name",
+                    "payee_address",
+                    "properties_mutable",
+                    "royalty_mutable",
+                    "royalty_points_denominator",
+                    "royalty_points_numerator",
+                    "supply",
+                    "token_data_id_hash",
+                    "uri_mutable"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_token_datas_v2",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "aptos_name",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_name": "token_name"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "cdn_asset_uris",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_uri": "asset_uri"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "parsed_asset_uris",
+                      "schema": "nft_metadata_crawler"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "current_collection",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "collection_id": "collection_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_collections_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "array_relationships": [
+              {
+                "name": "current_token_ownerships",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id": "token_data_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_ownerships_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "collection_id",
+                    "decimals",
+                    "description",
+                    "inserted_at",
+                    "is_deleted_v2",
+                    "is_fungible_v2",
+                    "largest_property_version_v1",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "maximum",
+                    "supply",
+                    "token_data_id",
+                    "token_name",
+                    "token_properties",
+                    "token_standard",
+                    "token_uri"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_token_ownerships",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "aptos_name",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "name": "token_name"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "current_collection_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "collection_data_id_hash": "collection_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_collection_datas",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "current_token_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id_hash": "token_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_datas",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "inserted_at",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "name",
+                    "owner_address",
+                    "property_version",
+                    "table_type",
+                    "token_data_id_hash",
+                    "token_properties"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_token_ownerships_v2",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_token_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id": "token_data_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_datas_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "array_relationships": [
+              {
+                "name": "composed_nfts",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id": "owner_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_ownerships_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "is_fungible_v2",
+                    "is_soulbound_v2",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "non_transferrable_by_owner",
+                    "owner_address",
+                    "inserted_at",
+                    "property_version_v1",
+                    "storage_id",
+                    "table_type_v1",
+                    "token_data_id",
+                    "token_properties_mutated_v1",
+                    "token_standard"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_token_pending_claims",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_collection_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "collection_data_id_hash": "collection_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_collection_datas",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "current_collection_v2",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "collection_id": "collection_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_collections_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "current_token_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id_hash": "token_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_datas",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "current_token_data_v2",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id": "token_data_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_datas_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "last_transaction_version": "transaction_version",
+                      "property_version": "property_version",
+                      "token_data_id_hash": "token_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "tokens",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "collection_data_id_hash",
+                    "collection_id",
+                    "collection_name",
+                    "creator_address",
+                    "inserted_at",
+                    "from_address",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "name",
+                    "property_version",
+                    "table_handle",
+                    "to_address",
+                    "token_data_id",
+                    "token_data_id_hash"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "delegated_staking_activities",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "delegator_address",
+                    "inserted_at",
+                    "event_index",
+                    "event_type",
+                    "pool_address",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "delegated_staking_pool_balances",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "active_table_handle",
+                    "inactive_table_handle",
+                    "inserted_at",
+                    "operator_commission_percentage",
+                    "staking_pool_address",
+                    "total_coins",
+                    "total_shares",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                },
+                "comment": ""
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "delegated_staking_pools",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_staking_pool",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "staking_pool_address": "staking_pool_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_staking_pool_voter",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "first_transaction_version",
+                    "inserted_at",
+                    "staking_pool_address"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "delegator_distinct_pool",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_pool_balance",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "pool_address": "staking_pool_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_delegated_staking_pool_balances",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "staking_pool_metadata",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "pool_address": "staking_pool_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_staking_pool_voter",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": ["delegator_address", "pool_address"],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "events",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "account_address",
+                    "creation_number",
+                    "data",
+                    "event_index",
+                    "inserted_at",
+                    "sequence_number",
+                    "transaction_block_height",
+                    "transaction_version",
+                    "type",
+                    "indexed_type"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "fungible_asset_activities",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "metadata",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "asset_type": "asset_type"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "fungible_asset_metadata",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "array_relationships": [
+              {
+                "name": "owner_aptos_names",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "owner_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "asset_type",
+                    "block_height",
+                    "entry_function_id_str",
+                    "event_index",
+                    "gas_fee_payer_address",
+                    "inserted_at",
+                    "is_frozen",
+                    "is_gas_fee",
+                    "is_transaction_success",
+                    "owner_address",
+                    "storage_id",
+                    "storage_refund_amount",
+                    "token_standard",
+                    "transaction_timestamp",
+                    "transaction_version",
+                    "type"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "fungible_asset_metadata",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "asset_type",
+                    "creator_address",
+                    "decimals",
+                    "icon_uri",
+                    "inserted_at",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "maximum_v2",
+                    "name",
+                    "project_uri",
+                    "supply_aggregator_table_handle_v1",
+                    "supply_aggregator_table_key_v1",
+                    "supply_v2",
+                    "symbol",
+                    "token_standard"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "indexer_status",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": ["db", "is_indexer_up"],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "ledger_infos",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": ["chain_id"],
+                  "filter": {}
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "move_resources",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": ["address", "inserted_at", "transaction_version"],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "num_active_delegator_per_pool",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": ["num_active_delegator", "pool_address"],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "processor_status",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "last_success_version",
+                    "last_transaction_timestamp",
+                    "last_updated",
+                    "processor"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "proposal_votes",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "num_votes",
+                    "inserted_at",
+                    "proposal_id",
+                    "should_pass",
+                    "staking_pool_address",
+                    "transaction_timestamp",
+                    "transaction_version",
+                    "voter_address"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "signatures",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "is_sender_primary",
+                    "inserted_at",
+                    "multi_agent_index",
+                    "multi_sig_index",
+                    "public_key",
+                    "public_key_indices",
+                    "signature",
+                    "signer",
+                    "threshold",
+                    "transaction_block_height",
+                    "transaction_version",
+                    "type"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                },
+                "comment": ""
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "table_items",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "decoded_key",
+                    "decoded_value",
+                    "inserted_at",
+                    "key",
+                    "table_handle",
+                    "transaction_version",
+                    "write_set_change_index"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "table_metadatas",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": ["handle", "inserted_at", "key_type", "value_type"],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "token_activities",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_token_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id_hash": "token_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_datas",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "array_relationships": [
+              {
+                "name": "aptos_names_owner",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "event_account_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "aptos_names_to",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "to_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "coin_amount",
+                    "coin_type",
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "event_account_address",
+                    "event_creation_number",
+                    "event_index",
+                    "event_sequence_number",
+                    "from_address",
+                    "inserted_at",
+                    "name",
+                    "property_version",
+                    "to_address",
+                    "token_amount",
+                    "token_data_id_hash",
+                    "transaction_timestamp",
+                    "transaction_version",
+                    "transfer_type"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "token_activities_v2",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_token_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id": "token_data_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_datas_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "array_relationships": [
+              {
+                "name": "aptos_names_from",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "from_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "aptos_names_to",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "to_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "after_value",
+                    "before_value",
+                    "entry_function_id_str",
+                    "event_account_address",
+                    "event_index",
+                    "inserted_at",
+                    "from_address",
+                    "is_fungible_v2",
+                    "property_version_v1",
+                    "to_address",
+                    "token_amount",
+                    "token_data_id",
+                    "token_standard",
+                    "transaction_timestamp",
+                    "transaction_version",
+                    "type"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "token_datas",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "default_properties",
+                    "description",
+                    "description_mutable",
+                    "inserted_at",
+                    "largest_property_version",
+                    "maximum",
+                    "maximum_mutable",
+                    "metadata_uri",
+                    "name",
+                    "payee_address",
+                    "properties_mutable",
+                    "royalty_mutable",
+                    "royalty_points_denominator",
+                    "royalty_points_numerator",
+                    "supply",
+                    "token_data_id_hash",
+                    "transaction_timestamp",
+                    "transaction_version",
+                    "uri_mutable"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "token_ownerships",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "inserted_at",
+                    "name",
+                    "owner_address",
+                    "property_version",
+                    "table_handle",
+                    "table_type",
+                    "token_data_id_hash",
+                    "transaction_timestamp",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "tokens",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "inserted_at",
+                    "name",
+                    "property_version",
+                    "token_data_id_hash",
+                    "token_properties",
+                    "transaction_timestamp",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "user_transactions",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "readonly",
+                "permission": {
+                  "columns": [
+                    "block_height",
+                    "entry_function_id_str",
+                    "epoch",
+                    "expiration_timestamp_secs",
+                    "gas_unit_price",
+                    "inserted_at",
+                    "max_gas_amount",
+                    "parent_signature_type",
+                    "sender",
+                    "sequence_number",
+                    "timestamp",
+                    "version"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          }
+        ],
+        "configuration": {
+          "connection_info": {
+            "database_url": "INDEXER_V2_POSTGRES_URL",
+            "isolation_level": "read-committed",
+            "use_prepared_statements": false
+          }
+        }
+      }
+    ],
+    "query_collections": [
+      {
+        "name": "allowed-queries",
+        "definition": {
+          "queries": [
+            {
+              "name": "Latest Processor Status",
+              "query": "query LatestProcessorStatus {\n  processor_status {\n    processor\n    last_updated\n    last_success_version\n    last_transaction_timestamp\n  }\n}"
+            }
+          ]
+        }
+      }
+    ],
+    "allowlist": [
+      {
+        "collection": "allowed-queries",
+        "scope": {
+          "global": true
+        }
+      }
+    ],
+    "rest_endpoints": [
+      {
+        "comment": "",
+        "definition": {
+          "query": {
+            "collection_name": "allowed-queries",
+            "query_name": "Latest Processor Status"
+          }
+        },
+        "methods": ["GET"],
+        "name": "Latest Processor Status",
+        "url": "get_latest_processor_status"
+      }
+    ],
+    "api_limits": {
+      "depth_limit": {
+        "global": 5,
+        "per_role": {}
+      },
+      "disabled": false,
+      "time_limit": {
+        "global": 10,
+        "per_role": {}
+      }
+    },
+    "metrics_config": {
+      "analyze_query_variables": true,
+      "analyze_response_body": true
+    }
+  }
+}

--- a/networks/movement/indexer-v2/src/main.rs
+++ b/networks/movement/indexer-v2/src/main.rs
@@ -1,0 +1,85 @@
+use aptos_indexer_processor_sdk::server_framework::RunnableConfig;
+use maptos_execution_util::config::Config;
+use movement_health::run_service;
+use movement_tracing::simple_metrics::start_metrics_server;
+use processor_v2::config::indexer_processor_config::IndexerProcessorConfig;
+
+const RUNTIME_WORKER_MULTIPLIER: usize = 2;
+
+fn main() -> Result<(), anyhow::Error> {
+	init_logger();
+
+	let runtime = get_maptos_runtime();
+	let maptos_config = load_maptos_config()?;
+	let runnable_processor_config: IndexerProcessorConfig =
+		maptos_config.indexer_processor_v2.clone().into();
+
+	runtime.block_on(async move {
+		let metrics_handle = tokio::spawn(async move {
+			start_metrics_server(
+				maptos_config.indexer_processor_v2.metrics_config.listen_hostname,
+				maptos_config.indexer_processor_v2.metrics_config.listen_port,
+			)
+			.await
+		});
+		let health_handle = tokio::spawn(async move {
+			run_service(
+				maptos_config.indexer_processor_v2.health_config.hostname,
+				maptos_config.indexer_processor_v2.health_config.port,
+			)
+			.await
+		});
+
+		let processor_handle = tokio::spawn(async move { runnable_processor_config.run().await });
+
+		tokio::select! {
+			metrics_handle = metrics_handle => {
+				tracing::error!("Metrics server exited abnormally: {:?}", metrics_handle);
+			}
+			health_handle = health_handle => {
+				tracing::error!("Health server exited abnormally: {:?}", health_handle);
+			}
+			processor_handle = processor_handle => {
+				tracing::error!("Indexer processor exited abnormally: {:?}", processor_handle);
+			}
+		}
+	});
+	panic!("Indexer v2 stack exited abnormally.");
+}
+
+fn init_logger() {
+	use tracing_subscriber::EnvFilter;
+
+	tracing_subscriber::fmt()
+		.with_env_filter(
+			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+		)
+		.init();
+}
+
+fn get_maptos_runtime() -> tokio::runtime::Runtime {
+	let num_cpus = num_cpus::get();
+	let worker_threads = (num_cpus * RUNTIME_WORKER_MULTIPLIER).max(16);
+	tracing::info!(
+		"[Processor] Starting processor tokio runtime: num_cpus={}, worker_threads={}",
+		num_cpus,
+		worker_threads
+	);
+
+	let mut builder = tokio::runtime::Builder::new_multi_thread();
+	let runtime =
+		match builder.disable_lifo_slot().enable_all().worker_threads(worker_threads).build() {
+			Ok(runtime) => runtime,
+			Err(e) => {
+				tracing::error!("Error building tokio runtime: {}", e);
+				panic!("Error building tokio runtime for indexer-v2.");
+			}
+		};
+	runtime
+}
+
+fn load_maptos_config() -> anyhow::Result<Config> {
+	let dot_movement = dot_movement::DotMovement::try_from_env()?;
+	let maptos_config = dot_movement.try_get_config_from_json::<Config>()?;
+	Ok(maptos_config)
+}

--- a/protocol-units/execution/maptos/opt-executor/src/executor/initialization.rs
+++ b/protocol-units/execution/maptos/opt-executor/src/executor/initialization.rs
@@ -85,6 +85,10 @@ impl Executor {
 		node_config.indexer_grpc.enabled = true;
 
 		// indexer_grpc config
+		if maptos_config.chain.enable_table_info_service {
+			node_config.indexer_table_info.enabled = true;
+			node_config.storage.enable_indexer = true;
+		}
 		node_config.indexer_grpc.processor_batch_size = 4;
 		node_config.indexer_grpc.processor_task_count = 4;
 		node_config.indexer_grpc.output_batch_size = 4;

--- a/protocol-units/execution/maptos/opt-executor/src/indexer.rs
+++ b/protocol-units/execution/maptos/opt-executor/src/indexer.rs
@@ -27,8 +27,9 @@ impl Context {
 		)
 		.ok_or(anyhow::anyhow!("Failed to bootstrap table info runtime"))?;
 
-		// Bootstrap indexer grpc.
-		// this one actually serves the gRPC service
+		// Bootstrap indexer grpc, aka, transaction stream service.
+		// TSS requires the table info service and internal indexer db.
+		// TODO: add mempool client receiver to the bootstrap function.
 		let _indexer_grpc = bootstrap_indexer_grpc(
 			&self.node_config,
 			self.maptos_config.chain.maptos_chain_id.clone(),
@@ -37,19 +38,6 @@ impl Context {
 			None,
 		)
 		.ok_or(anyhow::anyhow!("Failed to bootstrap indexer grpc runtime"))?;
-
-		// Grpc stream works without the indexer.
-		// By default indexer is not started on Movement node.
-		// bootstrap indexer stream
-		// Commented because not needed. Done the external indexer.
-		// let _indexer_stream = bootstrap_indexer_stream(
-		// 	&self.node_config,
-		// 	self.maptos_config.chain.maptos_chain_id.clone(),
-		// 	self.db.reader.clone(),
-		// 	self.mempool_client_sender.clone(),
-		// ).ok_or(
-		// 	anyhow::anyhow!("Failed to bootstrap indexer stream runtime"),
-		// )?;
 
 		Ok(IndexerRuntime { _table_info_runtime, _indexer_grpc }) //, _indexer_stream
 	}

--- a/protocol-units/execution/maptos/util/Cargo.toml
+++ b/protocol-units/execution/maptos/util/Cargo.toml
@@ -31,7 +31,8 @@ url = { workspace =  true }
 tracing = { workspace =  true }
 poem = { workspace = true }
 prometheus = { workspace = true }
-
+processor-v2 = { workspace = true }
+aptos-indexer-processor-sdk = { workspace = true }
 
 aptos-sdk = { workspace = true }
 movement-signer-loader = { workspace = true }

--- a/protocol-units/execution/maptos/util/src/config/chain.rs
+++ b/protocol-units/execution/maptos/util/src/config/chain.rs
@@ -1,8 +1,9 @@
 use super::common::{
-	default_enable_pruning, default_genesis_block_hash_hex, default_genesis_timestamp_microseconds,
-	default_maptos_chain_id, default_maptos_epoch_snapshot_prune_window,
-	default_maptos_ledger_prune_window, default_maptos_private_key_signer_identifier,
-	default_maptos_read_only, default_maptos_rest_listen_hostname, default_maptos_rest_listen_port,
+	default_enable_pruning, default_enable_table_info_service, default_genesis_block_hash_hex,
+	default_genesis_timestamp_microseconds, default_maptos_chain_id,
+	default_maptos_epoch_snapshot_prune_window, default_maptos_ledger_prune_window,
+	default_maptos_private_key_signer_identifier, default_maptos_read_only,
+	default_maptos_rest_listen_hostname, default_maptos_rest_listen_port,
 	default_maptos_state_merkle_prune_window,
 };
 use aptos_types::chain_id::ChainId;
@@ -80,6 +81,10 @@ pub struct Config {
 	/// The version to not increase the epoch until
 	#[serde(default = "default_dont_increase_epoch_until_version")]
 	pub dont_increase_epoch_until_version: u64,
+
+	/// Enable the table info service for indexer.
+	#[serde(default = "default_enable_table_info_service")]
+	pub enable_table_info_service: bool,
 }
 
 impl Default for Config {
@@ -99,6 +104,7 @@ impl Default for Config {
 			maptos_db_path: None,
 			known_framework_release_str: default_known_framework_release_str(),
 			dont_increase_epoch_until_version: default_dont_increase_epoch_until_version(),
+			enable_table_info_service: default_enable_table_info_service(),
 		}
 	}
 }

--- a/protocol-units/execution/maptos/util/src/config/common.rs
+++ b/protocol-units/execution/maptos/util/src/config/common.rs
@@ -202,6 +202,8 @@ env_default!(
 
 env_default!(default_enable_pruning, "MAPTOS_ENABLE_PRUNING", bool, false);
 
+env_default!(default_enable_table_info_service, "MAPTOS_ENABLE_TABLE_INFO_SERVICE", bool, false);
+
 env_default!(default_maptos_ledger_prune_window, "MAPTOS_LEDGER_PRUNING_WINDOW", u64, 50_000_000);
 
 env_default!(
@@ -233,6 +235,13 @@ env_default!(
 );
 
 env_default!(
+	default_indexer_processor_name,
+	"INDEXER_PROCESSOR_NAME",
+	String,
+	"default_processor".to_string()
+);
+
+env_default!(
 	default_genesis_timestamp_microseconds,
 	"MAPTOS_GENESIS_TIMESTAMP_MICROSECONDS",
 	u64,
@@ -261,7 +270,7 @@ env_default!(
 	String,
 	"0.0.0.0".to_string()
 );
-env_default!(default_metrics_server_port, "METRICS_SERVER_PORT", u16, 18185);
+env_default!(default_metrics_server_port, "METRICS_SERVER_PORT", u16, 18186);
 
 env_default!(default_batch_production_time, "MAPTOS_BATCH_PRODUCTION_TIME_MS", u64, 2000);
 

--- a/protocol-units/execution/maptos/util/src/config/indexer_processor_v2.rs
+++ b/protocol-units/execution/maptos/util/src/config/indexer_processor_v2.rs
@@ -1,0 +1,143 @@
+use crate::config::common::default_maptos_indexer_grpc_ping_interval;
+
+use super::common::{
+	default_indexer_processor_auth_token, default_indexer_processor_name,
+	default_maptos_indexer_grpc_listen_hostname, default_maptos_indexer_grpc_listen_port,
+	default_postgres_connection_string,
+};
+use crate::config::health_server::Config as HealthServerConfig;
+use crate::config::metrics_server::MetricsConfig;
+use aptos_indexer_processor_sdk::aptos_indexer_transaction_stream::utils::additional_headers::AdditionalHeaders;
+use aptos_indexer_processor_sdk::aptos_indexer_transaction_stream::TransactionStreamConfig;
+use processor_v2::config::db_config::{DbConfig, PostgresConfig};
+use processor_v2::config::indexer_processor_config::IndexerProcessorConfig;
+use processor_v2::config::processor_mode::{BootStrapConfig, ProcessorMode};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use url::Url;
+
+// Stream related configs.
+const DEFAULT_INDEXER_GRPC_RECONNECTION_TIMEOUT_SECS: u64 = 30;
+const DEFAULT_INDEXER_GRPC_RESPONSE_ITEM_TIMEOUT_SECS: u64 = 30;
+const DEFAULT_INDEXER_GRPC_RECONNECTION_MAX_RETRIES: u64 = 10;
+
+const DEFAULT_ANS_V2_CONTRACT_ADDRESS: &str =
+	"0x67bf15b3eed0fc62deea9630bbbd1d48842550655140f913699a1ca7e6f727d8";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Config {
+	#[serde(default = "default_postgres_connection_string")]
+	pub postgres_connection_string: String,
+
+	#[serde(default = "default_indexer_processor_auth_token")]
+	pub indexer_processor_auth_token: String,
+
+	#[serde(default = "default_maptos_indexer_grpc_listen_hostname")]
+	pub maptos_indexer_grpc_listen_hostname: String,
+
+	#[serde(default = "default_maptos_indexer_grpc_listen_port")]
+	pub maptos_indexer_grpc_listen_port: u16,
+
+	#[serde(default = "default_indexer_processor_name")]
+	pub processor_name: String,
+
+	// This is to allow additional fields specified in the config file.
+	pub additional_config: Value,
+
+	pub metrics_config: MetricsConfig,
+
+	pub health_config: HealthServerConfig,
+}
+
+impl Default for Config {
+	fn default() -> Self {
+		Self {
+			processor_name: default_indexer_processor_name(),
+			postgres_connection_string: default_postgres_connection_string(),
+			indexer_processor_auth_token: default_indexer_processor_auth_token(),
+			maptos_indexer_grpc_listen_hostname: default_maptos_indexer_grpc_listen_hostname(),
+			maptos_indexer_grpc_listen_port: default_maptos_indexer_grpc_listen_port(),
+			additional_config: Value::Null,
+			metrics_config: MetricsConfig::default(),
+			health_config: HealthServerConfig::default(),
+		}
+	}
+}
+
+impl Into<IndexerProcessorConfig> for Config {
+	fn into(self) -> IndexerProcessorConfig {
+		let indexer_grpc_data_service_address = self.get_grpc_url();
+		let mut processor_config_map = serde_json::Map::new();
+		// Required field.
+		processor_config_map.insert("type".to_string(), Value::from(self.processor_name.clone()));
+
+		match self.processor_name.as_str() {
+			"default_processor" => {
+				processor_config_map
+					.insert("type".to_string(), Value::from(self.processor_name.clone()));
+			}
+			"ans_processor" => {
+				processor_config_map
+					.insert("ans_v1_primary_names_table_handle".to_string(), Value::from("temp"));
+				processor_config_map
+					.insert("ans_v1_name_records_table_handle".to_string(), Value::from("temp"));
+				processor_config_map.insert(
+					"ans_v2_contract_address".to_string(),
+					Value::from(DEFAULT_ANS_V2_CONTRACT_ADDRESS.to_string()),
+				);
+			}
+			"token_v2_processor" => {
+				processor_config_map.insert("query_retries".to_string(), Value::from(5));
+			}
+			"token_processor" => {
+				processor_config_map.insert("nft_points_contract".to_string(), Value::from("null"));
+			}
+			_ => {}
+		}
+		let processor_config = serde_json::from_value(Value::Object(processor_config_map)).unwrap();
+		tracing::error!("processor_config: {:?}", processor_config);
+
+		IndexerProcessorConfig {
+			processor_config: processor_config,
+			// Default running mode.
+			processor_mode: ProcessorMode::Default(BootStrapConfig { initial_starting_version: 0 }),
+			db_config: DbConfig::PostgresConfig(PostgresConfig {
+				connection_string: self.postgres_connection_string,
+				db_pool_size: PostgresConfig::default_db_pool_size(),
+			}),
+			transaction_stream_config: TransactionStreamConfig {
+				indexer_grpc_data_service_address,
+				auth_token: self.indexer_processor_auth_token,
+				request_name_header: "MAPTOS_INDEXER_PROCESSOR".to_string(),
+				additional_headers: AdditionalHeaders::default(),
+				// Default to start from the genesis block.
+				starting_version: Some(0),
+				// Default to request all the blocks until the latest block.
+				request_ending_version: None,
+				indexer_grpc_http2_ping_interval_secs: default_maptos_indexer_grpc_ping_interval(),
+				indexer_grpc_http2_ping_timeout_secs: default_maptos_indexer_grpc_ping_interval(),
+				indexer_grpc_reconnection_timeout_secs:
+					DEFAULT_INDEXER_GRPC_RECONNECTION_TIMEOUT_SECS,
+				indexer_grpc_response_item_timeout_secs:
+					DEFAULT_INDEXER_GRPC_RESPONSE_ITEM_TIMEOUT_SECS,
+				indexer_grpc_reconnection_max_retries:
+					DEFAULT_INDEXER_GRPC_RECONNECTION_MAX_RETRIES,
+				transaction_filter: None,
+			},
+		}
+	}
+}
+
+impl Config {
+	fn get_grpc_url(&self) -> Url {
+		let indexer_grpc_data_service_address = format!(
+			"http://{}:{}",
+			self.maptos_indexer_grpc_listen_hostname, self.maptos_indexer_grpc_listen_port
+		);
+		tracing::info!(
+			"Connecting to indexer gRPC server at: {}",
+			indexer_grpc_data_service_address.clone()
+		);
+		Url::parse(&indexer_grpc_data_service_address).unwrap()
+	}
+}

--- a/protocol-units/execution/maptos/util/src/config/mod.rs
+++ b/protocol-units/execution/maptos/util/src/config/mod.rs
@@ -7,6 +7,7 @@ pub mod fin;
 pub mod health_server;
 pub mod indexer;
 pub mod indexer_processor;
+pub mod indexer_processor_v2;
 pub mod load_shedding;
 pub mod mempool;
 pub mod metrics_server;
@@ -26,6 +27,10 @@ pub struct Config {
 	/// The indexer processor configuration
 	#[serde(default)]
 	pub indexer_processor: indexer_processor::Config,
+
+	/// The indexer processor configuration
+	#[serde(default)]
+	pub indexer_processor_v2: indexer_processor_v2::Config,
 
 	/// The client configuration
 	#[serde(default)]
@@ -62,6 +67,7 @@ impl Default for Config {
 			chain: chain::Config::default(),
 			indexer: indexer::Config::default(),
 			indexer_processor: indexer_processor::Config::default(),
+			indexer_processor_v2: indexer_processor_v2::Config::default(),
 			client: client::Config::default(),
 			faucet: faucet::Config::default(),
 			fin: fin::Config::default(),

--- a/util/health/Cargo.toml
+++ b/util/health/Cargo.toml
@@ -13,6 +13,8 @@ rust-version.workspace = true
 [dependencies]
 poem = { workspace = true }
 anyhow = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/util/health/src/lib.rs
+++ b/util/health/src/lib.rs
@@ -1,12 +1,17 @@
-use anyhow::Error;
+use anyhow::Context;
 use poem::listener::TcpListener;
 use poem::{get, handler, IntoResponse, Response, Route, Server};
 
-pub async fn run_service(hostname: String, port: u16) -> Result<(), Error> {
+/// Run a health server on the given hostname and port.
+/// It's considered fatal if the health server fails.
+pub async fn run_service(hostname: String, port: u16) -> anyhow::Result<()> {
 	let route = Route::new().at("/health", get(health));
 	let url = format!("{}:{}", hostname, port);
 	tracing::info!("Start health check access on :{url} .");
-	Server::new(TcpListener::bind(url)).run(route).await.map_err(Into::into)
+	Server::new(TcpListener::bind(url))
+		.run(route)
+		.await
+		.context("Failed to start health server")
 }
 
 #[handler]

--- a/util/tracing/src/simple_metrics.rs
+++ b/util/tracing/src/simple_metrics.rs
@@ -1,30 +1,21 @@
+use anyhow::Context;
 use poem::http::StatusCode;
 use poem::{get, handler, listener::TcpListener, IntoResponse, Route, Server};
 use prometheus::{gather, Encoder, TextEncoder};
-use tokio::task::JoinHandle;
 
 /// Start a simple metrics server on the given hostname and port. This is for the usage other than the node.
-pub async fn start_metrics_server(
-	listen_hostname: String,
-	listen_port: u16,
-) -> Result<JoinHandle<()>, anyhow::Error> {
+pub async fn start_metrics_server(listen_hostname: String, listen_port: u16) -> anyhow::Result<()> {
 	let bind_address = format!("{}:{}", listen_hostname, listen_port);
 
 	let metrics_route = Route::new().at("/metrics", get(metrics_handler));
 
-	let server_handle = tokio::spawn(async move {
-		let listener = TcpListener::bind(&bind_address);
-		aptos_logger::info!(
-			"Starting Prometheus metrics server on http://{}/metrics",
-			bind_address
-		);
+	let listener = TcpListener::bind(&bind_address);
+	aptos_logger::info!("Starting Prometheus metrics server on http://{}/metrics", bind_address);
 
-		if let Err(e) = Server::new(listener).run(metrics_route).await {
-			aptos_logger::error!("Metrics server error: {}", e);
-		}
-	});
-
-	Ok(server_handle)
+	Server::new(listener)
+		.run(metrics_route)
+		.await
+		.context("Failed to start metrics server")
 }
 
 #[handler]


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**: `indexer`

<!--
Add your summary text here. 
 -->

This change includes:

1. indexer-v2 config handling. We move away from the existing yaml file manipulation to yaml builder. 

2. Indexer-v2 dependency integration.



# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->

# Testing

```bash
export MAPTOS_DA_SEQUENCER_CONNECTION_URL=https://da-sequencer.mainnet.movementinfra.xyz/
export MAPTOS_CHAIN_ID=126
export MAPTOS_ENABLE_INDEXER_GRPC=true
just movement-full-node native build.setup.fullnode 
```

## Verify data
```
grpcurl -plaintext \
  -d '{ "starting_version": "13", "transactions_count": "1" }' \
  0.0.0.0:30734 \
  aptos.indexer.v1.RawData/GetTransactions | \
  jq '.transactions[].info.changes[] | select(.type == "TYPE_WRITE_TABLE_ITEM") | select(.writeTableItem.data != null)'
```

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->