### PR TITLE
feat: telemetry intialization in full node and added env variables

### DIFF
--- a/docker/compose/movement-full-node/docker-compose.fullnode.yml
+++ b/docker/compose/movement-full-node/docker-compose.fullnode.yml
@@ -7,6 +7,20 @@ services:
       - DOT_MOVEMENT_PATH=/.movement
       - MOVEMENT_TIMING=info
       - RUST_BACKTRACE=1
+      - MOVEMENT_METRICS_ADDR=0.0.0.0:9464
+      - APTOS_FORCE_ENABLE_TELEMETRY=1
+      - APTOS_METRICS_PORT=9464
+      - APTOS_METRICS_HOST=0.0.0.0
+      - APTOS_DISABLE_TELEMETRY_PUSH_METRICS=1
+      - PROMETHEUS_METRICS_ENABLED=1
+      - APTOS_ENABLE_CONSENSUS_METRICS=1
+      - APTOS_ENABLE_DB_METRICS=1
+      - APTOS_ENABLE_MEMPOOL_METRICS=1
+      - APTOS_ENABLE_NETWORK_METRICS=1
+      - APTOS_ENABLE_STORAGE_METRICS=1
+      - APTOS_ENABLE_VM_METRICS=1
+      # OTEL Configuration (optional - uncomment and set your endpoint)
+      # - MOVEMENT_OTEL_ENDPOINT=http://otel-collector:4317
     volumes:
       - ${DOT_MOVEMENT_PATH}:/.movement
     ports:

--- a/networks/movement/movement-full-node/src/main.rs
+++ b/networks/movement/movement-full-node/src/main.rs
@@ -2,6 +2,7 @@
 use clap::*;
 use movement_full_node::MovementFullNode;
 use tracing_subscriber::EnvFilter;
+
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
 	// Initialize default tracing
@@ -10,6 +11,12 @@ async fn main() -> Result<(), anyhow::Error> {
 			EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
 		)
 		.init();
+
+	// Initialize telemetry if MOVEMENT_METRICS_ADDR is set
+	if std::env::var("MOVEMENT_METRICS_ADDR").is_ok() {
+		movement_tracing::ensure_telemetry_initialized();
+	}
+
 	let suzuka_util = MovementFullNode::parse();
 	let result = suzuka_util.execute().await;
 	result

--- a/util/tracing/src/lib.rs
+++ b/util/tracing/src/lib.rs
@@ -341,6 +341,12 @@ pub fn start_telemetry_service() {
 	std::env::set_var("APTOS_ENABLE_STORAGE_METRICS", "1");
 	std::env::set_var("APTOS_ENABLE_VM_METRICS", "1");
 
+	// Configure OTEL if endpoint is provided
+	if let Ok(otel_endpoint) = std::env::var("MOVEMENT_OTEL_ENDPOINT") {
+		std::env::set_var("APTOS_OTEL_ENDPOINT", &otel_endpoint);
+		info!("Configured OTEL endpoint: {}", otel_endpoint);
+	}
+
 	// Register custom metrics
 	register_custom_metrics();
 


### PR DESCRIPTION

# Summary
- **RFCs**: [Link to RFC](#./link/to/rfc), [Link to RFC](#./link/to/rfc), or $\emptyset$.
- **Categories**: any of `protocol-units`, `networks`, `scripts`, `util`, `cicd`, or `misc`.

<!--
Add your summary text here. 
 -->
Added explicit initialization for telemetry in full node and also aded env variables for the docker compose for full node so that telemetry gets automatically initialized along with fullnode when using docker instead of process compose
# Changelog

<!-- 
Describe your changes. List roughly in order of importance.
-->
- Added metrics env variables in `docker/compose/movement-full-node/docker-compose.fullnode.yml`
- Initialize telemetry explicitly in `networks/movement/movement-full-node/src/main.rs`
- configura otel endpoint locally in `util/tracing/src/lib.rs`
# Testing

<!--
Describe your Test Plan and explain added or modified test components.
-->

# Outstanding issues
<!--
List any outstanding issues that need to be addressed in future PRs, but which do not block merging this PR.
-->