### PR TITLE
Extract insights and statistics from replay validation logs

### DIFF
--- a/networks/movement/movement-full-node/src/admin/l1_migration/validate/compare.rs
+++ b/networks/movement/movement-full-node/src/admin/l1_migration/validate/compare.rs
@@ -2,36 +2,28 @@ use aptos_api_types::transaction::UserTransaction;
 use aptos_api_types::{Event, WriteSetChange};
 use tracing::error;
 
+pub struct CompareResult {
+	pub events_match: bool,
+	pub changes_match: bool,
+}
+
 pub fn compare_transaction_outputs(
 	movement_txn: UserTransaction,
 	aptos_txn: UserTransaction,
 	show_diff: bool,
-) -> anyhow::Result<bool> {
+) -> CompareResult {
 	let txn_hash = movement_txn.info.hash.0.to_hex_literal();
-
-	if movement_txn.info.hash != aptos_txn.info.hash {
-		error!(
-			"Transaction hash mismatch:\nMovement transaction hash:{}\nAptos transaction hash:{}",
-			txn_hash,
-			aptos_txn.info.hash.0.to_hex_literal()
-		);
-		return Ok(false);
-	}
 
 	let movement_events =
 		movement_txn.events.iter().map(Into::<EventCompare>::into).collect::<Vec<_>>();
 	let aptos_events = aptos_txn.events.iter().map(Into::<EventCompare>::into).collect::<Vec<_>>();
-	if movement_events != aptos_events {
-		if show_diff {
-			error!(
-				"Transaction events mismatch ({})\n{}",
-				txn_hash,
-				display_diff(&movement_txn.events, &aptos_txn.events)?
-			);
-		} else {
-			error!("Transaction events mismatch ({})", txn_hash,);
-		}
-		return Ok(false);
+	let events_match = movement_events == aptos_events;
+	if !events_match && show_diff {
+		error!(
+			"Transaction events mismatch ({})\n{}",
+			txn_hash,
+			display_diff(&movement_txn.events, &aptos_txn.events)
+		);
 	}
 
 	let movement_changes = movement_txn
@@ -46,32 +38,32 @@ pub fn compare_transaction_outputs(
 		.iter()
 		.map(Into::<WriteSetChangeCompare>::into)
 		.collect::<Vec<_>>();
-	if movement_changes != aptos_changes {
-		if show_diff {
-			error!(
-				"Transaction write-set mismatch ({})\n{}",
-				txn_hash,
-				display_diff(&movement_txn.info.changes, &aptos_txn.info.changes)?
-			);
-		} else {
-			error!("Transaction write-set mismatch ({})", txn_hash,);
-		}
-		return Ok(false);
+	let changes_match = movement_changes == aptos_changes;
+	if !changes_match && show_diff {
+		error!(
+			"Transaction write-set mismatch ({})\n{}",
+			txn_hash,
+			display_diff(&movement_txn.info.changes, &aptos_txn.info.changes)
+		);
 	}
 
-	Ok(true)
+	CompareResult { events_match, changes_match }
 }
 
-fn display_diff<T>(movement_values: &[T], aptos_values: &[T]) -> anyhow::Result<String>
+fn display_diff<T>(movement_values: &[T], aptos_values: &[T]) -> String
 where
 	T: serde::Serialize,
 {
-	let movement_json = serde_json::to_string_pretty(movement_values)?;
-	let aptos_json = serde_json::to_string_pretty(aptos_values)?;
-	Ok(create_diff(&movement_json, &aptos_json)?)
+	let movement_json = serde_json::to_string_pretty(movement_values);
+	let aptos_json = serde_json::to_string_pretty(aptos_values);
+	if let (Ok(movement_json), Ok(aptos_json)) = (movement_json, aptos_json) {
+		create_diff(&movement_json, &aptos_json)
+	} else {
+		"Failed to create diff".into()
+	}
 }
 
-fn create_diff(movement: &str, aptos: &str) -> anyhow::Result<String> {
+fn create_diff(movement: &str, aptos: &str) -> String {
 	use console::Style;
 	use similar::{ChangeTag, TextDiff};
 	use std::fmt::Write;
@@ -85,8 +77,8 @@ fn create_diff(movement: &str, aptos: &str) -> anyhow::Result<String> {
 		.collect::<Vec<_>>();
 	let last_hunk_idx = hunks.len() - 1;
 
-	writeln!(out, "--- Movement full-node")?;
-	writeln!(out, "+++ Aptos validator-node")?;
+	writeln!(out, "--- Movement full-node").unwrap();
+	writeln!(out, "+++ Aptos validator-node").unwrap();
 	for (idx, hunk) in hunks.iter().enumerate() {
 		for op in hunk.iter() {
 			for change in diff.iter_changes(op) {
@@ -95,15 +87,15 @@ fn create_diff(movement: &str, aptos: &str) -> anyhow::Result<String> {
 					ChangeTag::Insert => ("+", Style::new().green()),
 					ChangeTag::Equal => (" ", Style::new()),
 				};
-				write!(out, "{}{}", style.apply_to(sign).bold(), style.apply_to(change))?;
+				write!(out, "{}{}", style.apply_to(sign).bold(), style.apply_to(change)).unwrap();
 			}
 		}
 		if idx < last_hunk_idx {
-			writeln!(out, "===")?;
+			writeln!(out, "===").unwrap();
 		}
 	}
 
-	Ok(out)
+	out
 }
 
 struct EventCompare<'a>(&'a Event);

--- a/networks/movement/movement-full-node/src/admin/l1_migration/validate/compare.rs
+++ b/networks/movement/movement-full-node/src/admin/l1_migration/validate/compare.rs
@@ -8,8 +8,8 @@ pub struct CompareResult {
 }
 
 pub fn compare_transaction_outputs(
-	movement_txn: UserTransaction,
-	aptos_txn: UserTransaction,
+	movement_txn: &UserTransaction,
+	aptos_txn: &UserTransaction,
 	show_diff: bool,
 ) -> CompareResult {
 	let txn_hash = movement_txn.info.hash.0.to_hex_literal();

--- a/networks/movement/movement-full-node/src/admin/l1_migration/validate/replay.rs
+++ b/networks/movement/movement-full-node/src/admin/l1_migration/validate/replay.rs
@@ -167,7 +167,7 @@ async fn submit_transactions(
 					.map(|item| (item.transaction_index, item.error))
 					.collect::<HashMap<_, _>>();
 
-				if let Some(ref tx_validate_submission) = tx_validate_execution {
+				if let Some(ref tx_validate_execution) = tx_validate_execution {
 					if txns
 						.iter()
 						.enumerate()
@@ -178,7 +178,7 @@ async fn submit_transactions(
 							_ => None,
 						})
 						.try_for_each(|(hash, payload)| {
-							tx_validate_submission.send(ValidateExecution { hash, payload })
+							tx_validate_execution.send(ValidateExecution { hash, payload })
 						})
 						.is_err()
 					{

--- a/networks/movement/movement-full-node/src/admin/l1_migration/validate/replay.rs
+++ b/networks/movement/movement-full-node/src/admin/l1_migration/validate/replay.rs
@@ -2,16 +2,27 @@ use crate::admin::l1_migration::validate::compare::compare_transaction_outputs;
 use crate::admin::l1_migration::validate::types::api::{AptosRestClient, MovementRestClient};
 use crate::admin::l1_migration::validate::types::da::{get_da_block_height, DaSequencerClient};
 use anyhow::Context;
+use aptos_api_types::AptosError;
 use aptos_crypto::HashValue;
-use aptos_types::transaction::SignedTransaction;
+use aptos_rest_client::error::RestError;
+use aptos_types::transaction::{SignedTransaction, TransactionPayload};
 use clap::{Args, Parser};
-use std::collections::HashSet;
+use std::collections::HashMap;
+use std::fmt::Display;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio_stream::StreamExt;
 use tracing::{debug, error, info, warn};
+
+const LOG_PREFIX: &str = "@MAR:";
+const SUBMISSION: &str = "S:";
+const EXECUTION: &str = "E:";
+const APTOS_FAILED: &str = "AF:";
+const MOVEMENT_FAILED: &str = "MF:";
+const BOTH_FAILED: &str = "BF:";
+const BOTH_SUCCEEDED: &str = "BS:";
 
 #[derive(Parser, Debug)]
 #[clap(name = "replay", about = "Stream transactions from DA-sequencer blocks")]
@@ -55,22 +66,36 @@ impl DaReplayTransactions {
 		let aptos_rest_client = AptosRestClient::try_connect(&self.aptos_api_url).await?;
 
 		// Spawn a task which compares transaction outputs from the Movement node and Aptos node
-		let tx_hashes = if let Some(ref movement_api_url) = self.movement_api_url {
+		let (tx_validate_execution, tx_validate_submission) = if let Some(ref movement_api_url) =
+			self.movement_api_url
+		{
 			let movement_rest_client = MovementRestClient::try_connect(movement_api_url).await?;
-			let (tx_hashes, rx_hashes) = mpsc::unbounded_channel::<HashValue>();
-			tasks.spawn(validate_transactions(
+			let (tx_validate_execution, rx_validate_execution) =
+				mpsc::unbounded_channel::<ValidateExecution>();
+			let (tx_validate_submission, rx_validate_submission) =
+				mpsc::unbounded_channel::<ValidateSubmission>();
+			tasks.spawn(validate_transaction_execution(
 				aptos_rest_client.clone(),
-				movement_rest_client,
-				rx_hashes,
+				movement_rest_client.clone(),
+				rx_validate_execution,
 				self.show_diff,
 			));
-			Some(tx_hashes)
+			tasks.spawn(validate_transaction_submission(
+				movement_rest_client,
+				rx_validate_submission,
+			));
+			(Some(tx_validate_execution), Some(tx_validate_submission))
 		} else {
-			None
+			(None, None)
 		};
 
 		// Spawn a task which submits transaction batches to the validator node
-		tasks.spawn(submit_transactions(aptos_rest_client, rx_batches, tx_hashes));
+		tasks.spawn(submit_transactions(
+			aptos_rest_client,
+			rx_batches,
+			tx_validate_execution,
+			tx_validate_submission,
+		));
 		// Spawn a task which fetches transaction batches ahead
 		tasks.spawn(stream_transactions(da_sequencer_client, tx_batches, block_height));
 
@@ -126,29 +151,51 @@ async fn stream_transactions(
 async fn submit_transactions(
 	aptos_rest_client: AptosRestClient,
 	mut rx_batches: mpsc::Receiver<Vec<SignedTransaction>>,
-	tx_hashes: Option<mpsc::UnboundedSender<HashValue>>,
+	tx_validate_execution: Option<mpsc::UnboundedSender<ValidateExecution>>,
+	tx_validate_submission: Option<mpsc::UnboundedSender<ValidateSubmission>>,
 ) {
 	while let Some(txns) = rx_batches.recv().await {
 		match aptos_rest_client.submit_batch_bcs(&txns).await {
 			Ok(result) => {
 				debug!("Submitted {} Aptos transaction(s)", txns.len());
-				let mut failed_txns = HashSet::new();
-				for failure in result.into_inner().transaction_failures {
-					failed_txns.insert(failure.transaction_index);
-					let txn = &txns[failure.transaction_index];
-					let hash = txn.committed_hash().to_hex_literal();
-					error!("Failed to submit Aptos transaction {}: {}", hash, failure.error);
-				}
 
-				if let Some(ref tx_hashes) = tx_hashes {
+				let errors = result
+					.into_inner()
+					.transaction_failures
+					.into_iter()
+					.map(|item| (item.transaction_index, item.error))
+					.collect::<HashMap<_, _>>();
+
+				if let Some(ref tx_validate_submission) = tx_validate_execution {
 					if txns
 						.iter()
 						.enumerate()
 						.filter_map(|item| match item {
-							(idx, _) if failed_txns.contains(&idx) => None,
-							(_, txn) => Some(txn.committed_hash()),
+							(idx, txn) if !errors.contains_key(&idx) => {
+								Some((txn.committed_hash(), payload_info(txn)))
+							}
+							_ => None,
 						})
-						.try_for_each(|hash| tx_hashes.send(hash))
+						.try_for_each(|(hash, payload)| {
+							tx_validate_submission.send(ValidateExecution { hash, payload })
+						})
+						.is_err()
+					{
+						// channel is closed
+						break;
+					}
+				}
+
+				if let Some(ref tx_validate_submission) = tx_validate_submission {
+					if txns
+						.iter()
+						.enumerate()
+						.try_for_each(|(idx, txn)| {
+							tx_validate_submission.send(ValidateSubmission {
+								hash: txn.committed_hash(),
+								error: errors.get(&idx).cloned(),
+							})
+						})
 						.is_err()
 					{
 						// channel is closed
@@ -165,16 +212,15 @@ async fn submit_transactions(
 	warn!("Stream of transaction batches ended unexpectedly");
 }
 
-async fn validate_transactions(
+async fn validate_transaction_execution(
 	aptos_rest_client: AptosRestClient,
 	movement_rest_client: MovementRestClient,
-	mut rx_hashes: mpsc::UnboundedReceiver<HashValue>,
+	mut rx_validate_execution: mpsc::UnboundedReceiver<ValidateExecution>,
 	show_diff: bool,
 ) {
 	use aptos_api_types::transaction::Transaction;
 
-	while let Some(hash) = rx_hashes.recv().await {
-		let hash_str = hash.to_hex_literal();
+	while let Some(ValidateExecution { hash, payload }) = rx_validate_execution.recv().await {
 		let timeout = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + 60;
 		let result = tokio::join!(
 			movement_rest_client.wait_for_transaction_by_hash(hash, timeout, None, None),
@@ -189,27 +235,124 @@ async fn validate_transactions(
 				let Transaction::UserTransaction(txn_aptos) = txn_aptos.into_inner() else {
 					unreachable!()
 				};
-
-				match compare_transaction_outputs(*txn_movement, *txn_aptos, show_diff) {
-					Ok(valid) if valid => debug!("Validated transaction {}", hash_str),
-					Ok(_) => {} // invalid, errors logged elsewhere
-					Err(e) => error!("Failed to validate transaction {}: {}", hash_str, e),
-				}
+				let result = compare_transaction_outputs(*txn_movement, *txn_aptos, show_diff);
+				let (is_error, msg) = match (result.events_match, result.changes_match) {
+					(true, true) => (false, "ok"),
+					(true, false) => (true, "changes mismatch"),
+					(false, true) => (true, "events mismatch"),
+					(false, false) => (true, "events mismatch, changes mismatch"),
+				};
+				log_execution(is_error, BOTH_SUCCEEDED, hash, &payload, msg);
 			}
 			(Ok(_), Err(error_aptos)) => {
-				error!(
-					"The execution of the transaction {} failed on Aptos: {}",
-					hash_str, error_aptos
-				)
+				log_execution(true, APTOS_FAILED, hash, &payload, error_aptos);
 			}
-			(Err(error_movement), Ok(_)) => error!(
-				"The execution of the transaction {} failed on Movement but succeeded on Aptos: {}",
-				hash_str, error_movement
-			),
-			_ => {
-				// ignore if the execution failed on both sides???
+			(Err(error_movement), Ok(_)) => {
+				log_execution(true, MOVEMENT_FAILED, hash, &payload, error_movement);
+			}
+			(Err(error_movement), Err(error_aptos)) => {
+				let error_movement = format!("{}", error_movement);
+				let error_aptos = format!("{}", error_aptos);
+
+				if error_movement == error_aptos {
+					log_execution(false, BOTH_FAILED, hash, &payload, "same error");
+				} else {
+					log_execution(
+						true,
+						BOTH_FAILED,
+						hash,
+						&payload,
+						format!("(movement: {} // aptos: {})", error_movement, error_aptos),
+					);
+				}
 			}
 		}
 	}
 	warn!("Stream of transaction hashes ended unexpectedly");
+}
+
+fn log_execution(
+	is_error: bool,
+	result: &str,
+	hash: HashValue,
+	payload: &str,
+	message: impl Display,
+) {
+	let msg = format!(
+		"{}{}{}({}/{}): {}",
+		LOG_PREFIX,
+		EXECUTION,
+		result,
+		hash.to_hex_literal(),
+		payload,
+		message
+	);
+	if is_error {
+		error!("{msg}");
+	} else {
+		info!("{msg}");
+	}
+}
+
+async fn validate_transaction_submission(
+	movement_rest_client: MovementRestClient,
+	mut rx_validate_submission: mpsc::UnboundedReceiver<ValidateSubmission>,
+) {
+	while let Some(ValidateSubmission { hash, error }) = rx_validate_submission.recv().await {
+		let result = movement_rest_client.get_transaction_by_hash(hash).await;
+
+		match (result, error) {
+			(Ok(_), None) => {
+				log_submission(false, BOTH_SUCCEEDED, hash, "ok");
+			}
+			(Ok(_), Some(error_aptos)) => {
+				log_submission(true, APTOS_FAILED, hash, error_aptos);
+			}
+			(Err(error_movement), None) => {
+				log_submission(true, MOVEMENT_FAILED, hash, error_movement);
+			}
+			(Err(mvmt_err), Some(error_aptos)) => {
+				if let RestError::Http(_, _) = mvmt_err {
+					log_submission(false, BOTH_FAILED, hash, "not executed on movement");
+				} else {
+					// Submission of the txn succeeded on Movement, but the execution failed.
+					// However, we are logging only the Aptos submission error here
+					// because we assume that if the submission had succeeded, the execution
+					// would have failed on Aptos in the same way.
+					log_submission(true, APTOS_FAILED, hash, error_aptos);
+				}
+			}
+		}
+	}
+}
+
+fn log_submission(is_error: bool, result: &str, hash: HashValue, message: impl Display) {
+	let msg =
+		format!("{}{}{}({}): {}", LOG_PREFIX, SUBMISSION, result, hash.to_hex_literal(), message);
+	if is_error {
+		error!("{msg}");
+	} else {
+		info!("{msg}");
+	}
+}
+
+fn payload_info(txn: &SignedTransaction) -> String {
+	match txn.payload() {
+		TransactionPayload::Script(_) => "script".to_string(),
+		TransactionPayload::ModuleBundle(_) => "depricated".to_string(),
+		TransactionPayload::EntryFunction(ef) => {
+			format!("entry:{}::{}", ef.module(), ef.function())
+		}
+		TransactionPayload::Multisig(sig) => format!("multisig:{}", sig.multisig_address.to_hex()),
+	}
+}
+
+struct ValidateExecution {
+	pub hash: HashValue,
+	pub payload: String,
+}
+
+struct ValidateSubmission {
+	pub hash: HashValue,
+	pub error: Option<AptosError>,
 }

--- a/networks/movement/movement-full-node/src/admin/l1_migration/validate/replay.rs
+++ b/networks/movement/movement-full-node/src/admin/l1_migration/validate/replay.rs
@@ -67,9 +67,16 @@ impl DaReplayTransactions {
 		let da_sequencer_client = DaSequencerClient::try_connect(&self.da_sequencer_url).await?;
 		let aptos_rest_client = AptosRestClient::try_connect(&self.aptos_api_url).await?;
 
+		let gas_price = aptos_rest_client.estimate_gas_price().await?.into_inner();
+		info!("Gas price Aptos: {:?}", gas_price);
+
 		// Spawn a task which compares transaction outputs from the Movement node and Aptos node
 		let tx_validate_submission = if let Some(ref movement_api_url) = self.movement_api_url {
 			let movement_rest_client = MovementRestClient::try_connect(movement_api_url).await?;
+
+			let gas_price = aptos_rest_client.estimate_gas_price().await?.into_inner();
+			info!("Gas price Movement: {:?}", gas_price);
+
 			let (tx_validate_execution, rx_validate_execution) =
 				mpsc::unbounded_channel::<ValidateExecution>();
 			let (tx_validate_submission, rx_validate_submission) =
@@ -224,27 +231,81 @@ async fn validate_transaction_execution(
 				let Transaction::UserTransaction(txn_aptos) = txn_aptos.into_inner() else {
 					unreachable!()
 				};
-				let result = compare_transaction_outputs(*txn_movement, *txn_aptos, show_diff);
+				let result = compare_transaction_outputs(&txn_movement, &txn_aptos, show_diff);
 				let (is_error, msg) = match (result.events_match, result.changes_match) {
 					(true, true) => (false, "ok"),
 					(true, false) => (true, "changes mismatch"),
 					(false, true) => (true, "events mismatch"),
 					(false, false) => (true, "events mismatch, changes mismatch"),
 				};
-				log_execution(is_error, BOTH_SUCCEEDED, hash, &txn_info.payload, msg);
+				let version_movement = Some(*txn_movement.info.version.inner());
+				let gas_movement = Some(*txn_movement.info.gas_used.inner());
+				let version_aptos = Some(*txn_aptos.info.version.inner());
+				let gas_aptos = Some(*txn_aptos.info.gas_used.inner());
+				log_execution(
+					is_error,
+					BOTH_SUCCEEDED,
+					hash,
+					&txn_info.payload,
+					msg,
+					version_movement,
+					gas_movement,
+					version_aptos,
+					gas_aptos,
+				);
 			}
-			(Ok(_), Err(error_aptos)) => {
-				log_execution(true, APTOS_FAILED, hash, &txn_info.payload, error_aptos);
+			(Ok(txn_movement), Err(error_aptos)) => {
+				let Transaction::UserTransaction(txn_movement) = txn_movement.into_inner() else {
+					unreachable!()
+				};
+				let version_movement = Some(*txn_movement.info.version.inner());
+				let gas_movement = Some(*txn_movement.info.gas_used.inner());
+				log_execution(
+					true,
+					APTOS_FAILED,
+					hash,
+					&txn_info.payload,
+					error_aptos,
+					version_movement,
+					gas_movement,
+					None,
+					None,
+				);
 			}
-			(Err(error_movement), Ok(_)) => {
-				log_execution(true, MOVEMENT_FAILED, hash, &txn_info.payload, error_movement);
+			(Err(error_movement), Ok(txn_aptos)) => {
+				let Transaction::UserTransaction(txn_aptos) = txn_aptos.into_inner() else {
+					unreachable!()
+				};
+				let version_aptos = Some(*txn_aptos.info.version.inner());
+				let gas_aptos = Some(*txn_aptos.info.gas_used.inner());
+				log_execution(
+					true,
+					MOVEMENT_FAILED,
+					hash,
+					&txn_info.payload,
+					error_movement,
+					None,
+					None,
+					version_aptos,
+					gas_aptos,
+				);
 			}
 			(Err(error_movement), Err(error_aptos)) => {
 				let error_movement = format!("{}", error_movement);
 				let error_aptos = format!("{}", error_aptos);
 
 				if error_movement == error_aptos {
-					log_execution(false, BOTH_FAILED, hash, &txn_info.payload, "same error");
+					log_execution(
+						false,
+						BOTH_FAILED,
+						hash,
+						&txn_info.payload,
+						"same error",
+						None,
+						None,
+						None,
+						None,
+					);
 				} else {
 					log_execution(
 						true,
@@ -252,6 +313,10 @@ async fn validate_transaction_execution(
 						hash,
 						&txn_info.payload,
 						format!("(movement: {} // aptos: {})", error_movement, error_aptos),
+						None,
+						None,
+						None,
+						None,
 					);
 				}
 			}
@@ -266,14 +331,22 @@ fn log_execution(
 	hash: HashValue,
 	payload: &str,
 	message: impl Display,
+	version_movement: Option<u64>,
+	gas_movement: Option<u64>,
+	version_aptos: Option<u64>,
+	gas_aptos: Option<u64>,
 ) {
 	let msg = format!(
-		"{}{}{}({}/{}): {}",
+		"{}{}{}({}/{})[A:{}:{}/M:{}:{}]: {}",
 		LOG_PREFIX,
 		EXECUTION,
 		result,
 		hash.to_hex_literal(),
 		payload,
+		version_aptos.map_or("none".to_string(), |version| version.to_string()),
+		gas_aptos.map_or("none".to_string(), |gas| gas.to_string()),
+		version_movement.map_or("none".to_string(), |version| version.to_string()),
+		gas_movement.map_or("none".to_string(), |gas| gas.to_string()),
 		message
 	);
 	if is_error {

--- a/networks/movement/movement-full-node/src/admin/l1_migration/validate/replay.rs
+++ b/networks/movement/movement-full-node/src/admin/l1_migration/validate/replay.rs
@@ -11,12 +11,13 @@ use clap::{Args, Parser};
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::path::PathBuf;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio_stream::StreamExt;
 use tracing::{debug, error, info, warn};
 
+const DEFAULT_MAX_SERVER_LAG_WAIT_DURATION: Duration = Duration::from_secs(60);
 const LOG_PREFIX: &str = "@R:";
 const SUBMISSION: &str = "S:";
 const EXECUTION: &str = "E:";
@@ -67,9 +68,7 @@ impl DaReplayTransactions {
 		let aptos_rest_client = AptosRestClient::try_connect(&self.aptos_api_url).await?;
 
 		// Spawn a task which compares transaction outputs from the Movement node and Aptos node
-		let (tx_validate_execution, tx_validate_submission) = if let Some(ref movement_api_url) =
-			self.movement_api_url
-		{
+		let tx_validate_submission = if let Some(ref movement_api_url) = self.movement_api_url {
 			let movement_rest_client = MovementRestClient::try_connect(movement_api_url).await?;
 			let (tx_validate_execution, rx_validate_execution) =
 				mpsc::unbounded_channel::<ValidateExecution>();
@@ -84,19 +83,15 @@ impl DaReplayTransactions {
 			tasks.spawn(validate_transaction_submission(
 				movement_rest_client,
 				rx_validate_submission,
+				tx_validate_execution,
 			));
-			(Some(tx_validate_execution), Some(tx_validate_submission))
+			Some(tx_validate_submission)
 		} else {
-			(None, None)
+			None
 		};
 
 		// Spawn a task which submits transaction batches to the validator node
-		tasks.spawn(submit_transactions(
-			aptos_rest_client,
-			rx_batches,
-			tx_validate_execution,
-			tx_validate_submission,
-		));
+		tasks.spawn(submit_transactions(aptos_rest_client, rx_batches, tx_validate_submission));
 		// Spawn a task which fetches transaction batches ahead
 		tasks.spawn(stream_transactions(da_sequencer_client, tx_batches, block_height));
 
@@ -152,7 +147,6 @@ async fn stream_transactions(
 async fn submit_transactions(
 	aptos_rest_client: AptosRestClient,
 	mut rx_batches: mpsc::Receiver<Vec<SignedTransaction>>,
-	tx_validate_execution: Option<mpsc::UnboundedSender<ValidateExecution>>,
 	tx_validate_submission: Option<mpsc::UnboundedSender<ValidateSubmission>>,
 ) {
 	while let Some(txns) = rx_batches.recv().await {
@@ -160,32 +154,12 @@ async fn submit_transactions(
 			Ok(result) => {
 				debug!("Submitted {} Aptos transaction(s)", txns.len());
 
-				let errors = result
+				let mut errors = result
 					.into_inner()
 					.transaction_failures
 					.into_iter()
 					.map(|item| (item.transaction_index, item.error))
 					.collect::<HashMap<_, _>>();
-
-				if let Some(ref tx_validate_execution) = tx_validate_execution {
-					if txns
-						.iter()
-						.enumerate()
-						.filter_map(|item| match item {
-							(idx, txn) if !errors.contains_key(&idx) => {
-								Some((txn.committed_hash(), payload_info(txn)))
-							}
-							_ => None,
-						})
-						.try_for_each(|(hash, payload)| {
-							tx_validate_execution.send(ValidateExecution { hash, payload })
-						})
-						.is_err()
-					{
-						// channel is closed
-						break;
-					}
-				}
 
 				if let Some(ref tx_validate_submission) = tx_validate_submission {
 					if txns
@@ -193,8 +167,12 @@ async fn submit_transactions(
 						.enumerate()
 						.try_for_each(|(idx, txn)| {
 							tx_validate_submission.send(ValidateSubmission {
-								hash: txn.committed_hash(),
-								error: errors.get(&idx).cloned(),
+								txn_info: TransactionInfo {
+									hash: txn.committed_hash(),
+									payload: payload_info(txn),
+									expires: txn.expiration_timestamp_secs(),
+								},
+								error: errors.remove(&idx),
 							})
 						})
 						.is_err()
@@ -221,11 +199,21 @@ async fn validate_transaction_execution(
 ) {
 	use aptos_api_types::transaction::Transaction;
 
-	while let Some(ValidateExecution { hash, payload }) = rx_validate_execution.recv().await {
-		let timeout = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + 60;
+	while let Some(ValidateExecution { txn_info }) = rx_validate_execution.recv().await {
+		let hash = txn_info.hash;
 		let result = tokio::join!(
-			movement_rest_client.wait_for_transaction_by_hash(hash, timeout, None, None),
-			aptos_rest_client.wait_for_transaction_by_hash(hash, timeout, None, None)
+			movement_rest_client.wait_for_transaction_by_hash(
+				hash,
+				txn_info.expires,
+				Some(DEFAULT_MAX_SERVER_LAG_WAIT_DURATION),
+				None
+			),
+			aptos_rest_client.wait_for_transaction_by_hash(
+				hash,
+				txn_info.expires,
+				Some(DEFAULT_MAX_SERVER_LAG_WAIT_DURATION),
+				None,
+			)
 		);
 
 		match result {
@@ -243,26 +231,26 @@ async fn validate_transaction_execution(
 					(false, true) => (true, "events mismatch"),
 					(false, false) => (true, "events mismatch, changes mismatch"),
 				};
-				log_execution(is_error, BOTH_SUCCEEDED, hash, &payload, msg);
+				log_execution(is_error, BOTH_SUCCEEDED, hash, &txn_info.payload, msg);
 			}
 			(Ok(_), Err(error_aptos)) => {
-				log_execution(true, APTOS_FAILED, hash, &payload, error_aptos);
+				log_execution(true, APTOS_FAILED, hash, &txn_info.payload, error_aptos);
 			}
 			(Err(error_movement), Ok(_)) => {
-				log_execution(true, MOVEMENT_FAILED, hash, &payload, error_movement);
+				log_execution(true, MOVEMENT_FAILED, hash, &txn_info.payload, error_movement);
 			}
 			(Err(error_movement), Err(error_aptos)) => {
 				let error_movement = format!("{}", error_movement);
 				let error_aptos = format!("{}", error_aptos);
 
 				if error_movement == error_aptos {
-					log_execution(false, BOTH_FAILED, hash, &payload, "same error");
+					log_execution(false, BOTH_FAILED, hash, &txn_info.payload, "same error");
 				} else {
 					log_execution(
 						true,
 						BOTH_FAILED,
 						hash,
-						&payload,
+						&txn_info.payload,
 						format!("(movement: {} // aptos: {})", error_movement, error_aptos),
 					);
 				}
@@ -298,8 +286,11 @@ fn log_execution(
 async fn validate_transaction_submission(
 	movement_rest_client: MovementRestClient,
 	mut rx_validate_submission: mpsc::UnboundedReceiver<ValidateSubmission>,
+	tx_validate_execution: mpsc::UnboundedSender<ValidateExecution>,
 ) {
-	while let Some(ValidateSubmission { hash, error }) = rx_validate_submission.recv().await {
+	while let Some(ValidateSubmission { txn_info, error }) = rx_validate_submission.recv().await {
+		let hash = txn_info.hash;
+		let execute = error.is_none();
 		let result = get_transaction_by_hash(&movement_rest_client, hash, 3).await;
 
 		match (result, error) {
@@ -322,6 +313,13 @@ async fn validate_transaction_submission(
 					// would have failed on Aptos in the same way.
 					log_submission(true, APTOS_FAILED, hash, error_aptos);
 				}
+			}
+		};
+
+		if execute {
+			if tx_validate_execution.send(ValidateExecution { txn_info }).is_err() {
+				// channel is closed
+				break;
 			}
 		}
 	}
@@ -378,12 +376,17 @@ fn payload_info(txn: &SignedTransaction) -> String {
 	}
 }
 
-struct ValidateExecution {
+struct TransactionInfo {
 	pub hash: HashValue,
 	pub payload: String,
+	pub expires: u64,
+}
+
+struct ValidateExecution {
+	pub txn_info: TransactionInfo,
 }
 
 struct ValidateSubmission {
-	pub hash: HashValue,
+	pub txn_info: TransactionInfo,
 	pub error: Option<AptosError>,
 }

--- a/networks/movement/movement-full-node/src/admin/l1_migration/validate/replay.rs
+++ b/networks/movement/movement-full-node/src/admin/l1_migration/validate/replay.rs
@@ -2,9 +2,10 @@ use crate::admin::l1_migration::validate::compare::compare_transaction_outputs;
 use crate::admin::l1_migration::validate::types::api::{AptosRestClient, MovementRestClient};
 use crate::admin::l1_migration::validate::types::da::{get_da_block_height, DaSequencerClient};
 use anyhow::Context;
-use aptos_api_types::AptosError;
+use aptos_api_types::{AptosError, AptosErrorCode, Transaction};
 use aptos_crypto::HashValue;
 use aptos_rest_client::error::RestError;
+use aptos_rest_client::Response;
 use aptos_types::transaction::{SignedTransaction, TransactionPayload};
 use clap::{Args, Parser};
 use std::collections::HashMap;
@@ -16,7 +17,7 @@ use tokio::task::JoinSet;
 use tokio_stream::StreamExt;
 use tracing::{debug, error, info, warn};
 
-const LOG_PREFIX: &str = "@MAR:";
+const LOG_PREFIX: &str = "@R:";
 const SUBMISSION: &str = "S:";
 const EXECUTION: &str = "E:";
 const APTOS_FAILED: &str = "AF:";
@@ -299,7 +300,7 @@ async fn validate_transaction_submission(
 	mut rx_validate_submission: mpsc::UnboundedReceiver<ValidateSubmission>,
 ) {
 	while let Some(ValidateSubmission { hash, error }) = rx_validate_submission.recv().await {
-		let result = movement_rest_client.get_transaction_by_hash(hash).await;
+		let result = get_transaction_by_hash(&movement_rest_client, hash, 3).await;
 
 		match (result, error) {
 			(Ok(_), None) => {
@@ -324,6 +325,36 @@ async fn validate_transaction_submission(
 			}
 		}
 	}
+}
+
+async fn get_transaction_by_hash(
+	movement_rest_client: &MovementRestClient,
+	hash: HashValue,
+	retries: u8,
+) -> Result<Response<Transaction>, RestError> {
+	for idx in (0..retries).into_iter().rev() {
+		let result = movement_rest_client.get_transaction_by_hash(hash).await;
+		match result {
+			Ok(txn_movement) => {
+				return Ok(txn_movement);
+			}
+			Err(err) if idx == 0 => {
+				return Err(err);
+			}
+			Err(err) => match err {
+				RestError::Api(ref api_err) => {
+					if let AptosErrorCode::TransactionNotFound = api_err.error.error_code {
+						tokio::time::sleep(Duration::from_secs(1)).await;
+						continue;
+					} else {
+						return Err(err);
+					}
+				}
+				_ => return Err(err),
+			},
+		}
+	}
+	unreachable!()
 }
 
 fn log_submission(is_error: bool, result: &str, hash: HashValue, message: impl Display) {

--- a/scripts/l1_migration/process_replay_logs.sh
+++ b/scripts/l1_migration/process_replay_logs.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+
+# Exit on first error
+set -e
+
+# Check if input file parameter is provided
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <replay_logs_file>"
+    echo "Example: $0 replay_logs"
+    exit 1
+fi
+
+INPUT_FILE="$1"
+
+# Check if input file exists
+if [ ! -f "$INPUT_FILE" ]; then
+    echo "Error: Input file '$INPUT_FILE' does not exist."
+    exit 1
+fi
+
+# Get the directory of the input file
+INPUT_DIR=$(dirname "$INPUT_FILE")
+
+# Function to create output file path in the same directory as input
+get_output_path() {
+    echo "$INPUT_DIR/$1"
+}
+
+# Function to log file creation
+log_creation() {
+    echo "Creating file: $1"
+}
+
+echo "Processing log file: $INPUT_FILE"
+echo "Output directory: $INPUT_DIR"
+echo
+
+# Step 1: Extract replay logs
+CLEAN_LOGS=$(get_output_path "clean_logs")
+log_creation "$CLEAN_LOGS"
+grep "@R:" "$INPUT_FILE" | sed -e "s|.*@R:|@|g" > "$CLEAN_LOGS"
+
+# Step 2: Extract submission results from replay logs
+S_LOGS=$(get_output_path "S_logs")
+log_creation "$S_LOGS"
+grep "@S:" "$CLEAN_LOGS" | sed -e "s|@S:|@|g" > "$S_LOGS"
+
+# Step 3: Split submission results into different scenarios
+S_BS_LOGS=$(get_output_path "S_BS_logs")
+log_creation "$S_BS_LOGS"
+grep "@BS:" "$S_LOGS" | sed -E "s|@BS:(.*)|@\1|" > "$S_BS_LOGS"
+
+S_BF_LOGS=$(get_output_path "S_BF_logs")
+log_creation "$S_BF_LOGS"
+grep "@BF:" "$S_LOGS" | sed -E "s|@BF:(.*)|@\1|" > "$S_BF_LOGS"
+
+S_AF_LOGS=$(get_output_path "S_AF_logs")
+log_creation "$S_AF_LOGS"
+grep "@AF:" "$S_LOGS" | sed -E "s|@AF:(.*)|@\1|" > "$S_AF_LOGS"
+
+S_MF_LOGS=$(get_output_path "S_MF_logs")
+log_creation "$S_MF_LOGS"
+grep "@MF:" "$S_LOGS" | sed -E "s|@MF:(.*)|@\1|" > "$S_MF_LOGS"
+
+# Step 4: Extract execution results from replay logs
+E_LOGS=$(get_output_path "E_logs")
+log_creation "$E_LOGS"
+grep "@E:" "$CLEAN_LOGS" | sed -e "s|@E:|@|g" > "$E_LOGS"
+
+# Step 5: Split execution results into different scenarios
+E_BS_LOGS=$(get_output_path "E_BS_logs")
+log_creation "$E_BS_LOGS"
+grep "@BS:" "$E_LOGS" | sed -E "s|@BS:(.*)|@\1|" > "$E_BS_LOGS"
+
+E_BF_LOGS=$(get_output_path "E_BF_logs")
+log_creation "$E_BF_LOGS"
+grep "@BF:" "$E_LOGS" | sed -E "s|@BF:(.*)|@\1|" > "$E_BF_LOGS"
+
+E_AF_LOGS=$(get_output_path "E_AF_logs")
+log_creation "$E_AF_LOGS"
+grep "@AF:" "$E_LOGS" | sed -E "s|@AF:(.*)|@\1|" > "$E_AF_LOGS"
+
+E_MF_LOGS=$(get_output_path "E_MF_logs")
+log_creation "$E_MF_LOGS"
+grep "@MF:" "$E_LOGS" | sed -E "s|@MF:(.*)|@\1|" > "$E_MF_LOGS"
+
+# Step 6: Filter for different outputs (events, changes) and errors
+E_BS_DIFF_LOGS=$(get_output_path "E_BS_diff_logs")
+log_creation "$E_BS_DIFF_LOGS"
+grep -v "): ok" "$E_BS_LOGS" > "$E_BS_DIFF_LOGS"
+
+E_BF_DIFF_LOGS=$(get_output_path "E_BF_diff_logs")
+log_creation "$E_BF_DIFF_LOGS"
+grep -v "same error" "$E_BF_LOGS" > "$E_BF_DIFF_LOGS"
+
+# Step 7: Extract entry functions and abort functions for failed executions
+E_AF_ENTRY=$(get_output_path "E_AF_entry")
+log_creation "$E_AF_ENTRY"
+grep "entry:" "$E_AF_LOGS" | sed -E "s|.*/entry:([_:a-zA-Z0-9]*)\).*|\1|" | sort | uniq > "$E_AF_ENTRY"
+
+E_AF_ABORT=$(get_output_path "E_AF_abort")
+log_creation "$E_AF_ABORT"
+grep "Move abort in" "$E_AF_LOGS" | sed -E "s|.*Move abort in ([_:a-zA-Z0-9]*).*|\1|" | sort | uniq > "$E_AF_ABORT"
+
+# Step 8: Clean up and prepare frequency files for failed entry and abort functions
+E_AF_ENTRY_FREQ=$(get_output_path "E_AF_entry_freq")
+E_AF_ABORT_FREQ=$(get_output_path "E_AF_abort_freq")
+
+rm -f "$E_AF_ENTRY_FREQ"
+rm -f "$E_AF_ABORT_FREQ"
+
+# Step 9: Generate frequency counts for failed entry functions
+log_creation "$E_AF_ENTRY_FREQ"
+while IFS='' read -r LINE || [ -n "${LINE}" ]; do
+    COUNT=$(grep -c "${LINE}" "$CLEAN_LOGS")
+    echo "${LINE} ${COUNT}" >> "$E_AF_ENTRY_FREQ"
+done < "$E_AF_ENTRY"
+
+# Step 10: Generate frequency counts for abort functions
+log_creation "$E_AF_ABORT_FREQ"
+while IFS='' read -r LINE || [ -n "${LINE}" ]; do
+    COUNT=$(grep -c "${LINE}" "$CLEAN_LOGS")
+    echo "${LINE} ${COUNT}" >> "$E_AF_ABORT_FREQ"
+done < "$E_AF_ABORT"
+
+# Step 11: Generate statistics for transaction submissions
+S_LOGS_STATS=$(get_output_path "S_logs_stats")
+log_creation "$S_LOGS_STATS"
+
+# Get number of submitted transactions
+S_LOGS_COUNT=$(wc -l < "$S_LOGS")
+
+# Get counts from individual files
+S_BS_COUNT=$(wc -l < "$S_BS_LOGS")
+S_BF_COUNT=$(wc -l < "$S_BF_LOGS")
+S_AF_COUNT=$(wc -l < "$S_AF_LOGS")
+S_MF_COUNT=$(wc -l < "$S_MF_LOGS")
+
+# Calculate percentages
+if [ "$S_LOGS_COUNT" -gt 0 ]; then
+    S_BS_PERCENT=$(echo "scale=2; $S_BS_COUNT * 100 / $S_LOGS_COUNT" | bc)
+    S_BF_PERCENT=$(echo "scale=2; $S_BF_COUNT * 100 / $S_LOGS_COUNT" | bc)
+    S_AF_PERCENT=$(echo "scale=2; $S_AF_COUNT * 100 / $S_LOGS_COUNT" | bc)
+    S_MF_PERCENT=$(echo "scale=2; $S_MF_COUNT * 100 / $S_LOGS_COUNT" | bc)
+else
+    S_BS_PERCENT=0.00
+    S_BF_PERCENT=0.00
+    S_AF_PERCENT=0.00
+    S_MF_PERCENT=0.00
+fi
+
+# Write statistics to file
+cat > "$S_LOGS_STATS" << EOF
+Submission Statistics Report
+============================
+
+Base file: S_logs
+Total submitted transactions: $S_LOGS_COUNT
+
+Breakdown by category:
+----------------------
+Both succeeded: $S_BS_COUNT (${S_BS_PERCENT}%)
+Both failed: $S_BF_COUNT (${S_BF_PERCENT}%)
+Aptos submission failed: $S_AF_COUNT (${S_AF_PERCENT}%)
+Movement submission failed: $S_MF_COUNT (${S_MF_PERCENT}%)
+
+EOF
+
+# Step 12: Generate statistics for transaction executions
+E_LOGS_STATS=$(get_output_path "E_logs_stats")
+log_creation "$E_LOGS_STATS"
+
+# Get number of executed transactions
+E_LOGS_COUNT=$(wc -l < "$E_LOGS")
+
+# Get counts from individual files
+E_BS_COUNT=$(wc -l < "$E_BS_LOGS")
+E_BS_DIFF_COUNT=$(wc -l < "$E_BS_DIFF_LOGS")
+E_BF_COUNT=$(wc -l < "$E_BF_LOGS")
+E_BF_DIFF_COUNT=$(wc -l < "$E_BF_DIFF_LOGS")
+E_AF_COUNT=$(wc -l < "$E_AF_LOGS")
+E_MF_COUNT=$(wc -l < "$E_MF_LOGS")
+
+# Calculate percentages
+if [ "$E_LOGS_COUNT" -gt 0 ]; then
+    E_BS_PERCENT=$(echo "scale=2; $E_BS_COUNT * 100 / $E_LOGS_COUNT" | bc)
+    E_BF_PERCENT=$(echo "scale=2; $E_BF_COUNT * 100 / $E_LOGS_COUNT" | bc)
+    E_AF_PERCENT=$(echo "scale=2; $E_AF_COUNT * 100 / $E_LOGS_COUNT" | bc)
+    E_MF_PERCENT=$(echo "scale=2; $E_MF_COUNT * 100 / $E_LOGS_COUNT" | bc)
+else
+    E_BS_PERCENT=0.00
+    E_BF_PERCENT=0.00
+    E_AF_PERCENT=0.00
+    E_MF_PERCENT=0.00
+fi
+
+# Write statistics to file
+cat > "$E_LOGS_STATS" << EOF
+Execution Statistics Report
+===========================
+
+Base file: E_logs
+Total executed transactions: $E_LOGS_COUNT
+
+Breakdown by category:
+----------------------
+Both succeeded: $E_BS_COUNT (${E_BS_PERCENT}%). Different outputs (events, changes): $E_BS_DIFF_COUNT.
+Both failed: $E_BF_COUNT (${E_BF_PERCENT}%). Different errors: $E_BF_DIFF_COUNT
+Aptos execution failed: $E_AF_COUNT (${E_AF_PERCENT}%)
+Movement execution failed: $E_MF_COUNT (${E_MF_PERCENT}%)
+
+EOF
+
+echo
+echo "Processing completed successfully!"
+echo "All output files have been created in: $INPUT_DIR"
+echo "Statistics summaries written to:"
+echo "  - $S_LOGS_STATS"
+echo "  - $E_LOGS_STATS"


### PR DESCRIPTION
# Summary
- **RFCs**: $\emptyset$.
- **Categories**: `util`

## Changes
- Add validation of transaction submission against a Movement full-node to the L1-migration replay validation tool.
- Use a formal structure of logs for later processing.
- Add the shell script `process_replay_logs.sh` that cleans the logs, splits them into separate files, and then creates statistics.

## Log structure tokens
```
@R: - Movement-Aptos replay of transactions
  S: - Submission
    AF: - Aptos submission failed, Movement submission succeeded (record error)
    MF: - Movement submission failed, Aptos submission succeeded
    BF: - Submission failed on both, Movement and Aptos (record error)
    BS: - Submission succeeded on both, Movement and Aptos

  E: - Execution
    AF: - Aptos execution failed, Movement execution succeeded (record error)
    MF: - Movement execution failed, Aptos execution succeeded (record error)
    BF: - Execution failed on both, Movement and Aptos (compare errors)
    BS: - Execution succeeded on both, Movement and Aptos (compare events and changes)
```

The transaction hash follows the structure tokens, and for execution, the entry function is also logged.

### Example submission logs
```
@R:S:BS:(0x0ff4e14e24d5bd9646b4a7721fc927db5ad0f2be6d7444dc7f30187ed704c04e): ok
@R:S:BS:(0x365de55a94fe9124eb9b53e3285217b90964d344a670c9bfb2fc26eae611a202): ok
@R:S:AF:(0x6bc774903796b9c133855537523ec68ff7ba231f81124a8baaff09b8e55587ff): Error(VmError): Invalid transaction: Type: Validation Code: SENDING_ACCOUNT_DOES_NOT_EXIST
```

### Example execution logs
```
@R:E:BF:(0xdc2fae9a038c15ab6275901abcf02ff9e91c799bb42d36e1c56d6c5bdf852ec7/entry:5d2b6a8b6478d86f62c9d3378e2a1fa265e85e69046946632d1fecae1940e851::strategy::perform_upkeep_fa): same error
@R:E:AF:(0x3bf692fe68d080bc734c26dd478220fc714a30c8461a07fa9899033119c4d757/entry:ccd2621d2897d407e06d18e6ebe3be0e6d9b61f1e809dd49360522b9105812cf::entry_public::redeem_v2): Unknown error Transaction committed on chain, but failed execution: Move abort in 0xccd2621d2897d407e06d18e6ebe3be0e6d9b61f1e809dd49360522b9105812cf::basic_ticket_v2: ERR_INVALID_TICKET_PORTFOLIO_COLLATERALS(0x4):
@R:E:BS:(0xb02bb02b193ed7e9ba98deb269ec2b76b40678eb512623d344b055226c17e7da/entry:03f7399a0d3d646ce94ee0badf16c4c3f3c656fe3a5e142e83b5ebc011aa8b3d::router::swap): ok
```

## Files generated by the shell script
- `clean_logs`: contains all submission and execution logs produced by the replay tool. Everything up to the `@R:` token (inclusive) has been removed from each line.

### Submission log files
- `S_logs`: extracted submission logs from the `clean_logs` file. The `@S:` prefix has been removed from each line.
- `S_AF_logs`: contains only submission logs where the submission to Aptos failed and on Movement succeeded.
- `S_MF_logs`: contains only submission logs where the submission to Movement failed and on Aptos succeeded.
- `S_BS_logs`: contains only submission logs where the submission to Aptos and Movement succeeded.
- `S_BF_logs`: contains only submission logs where the submission to Aptos and Movement failed.

### Execution log files
- `E_logs`: extracted execution logs from the `clean_logs` file. The `@E:` prefix has been removed from each line.
- `E_AF_logs`: contains only execution logs where the execution on Aptos failed and on Movement succeeded.
- `E_MF_logs`: contains only execution logs where the execution on Movement failed and on Aptos succeeded.
- `E_BS_logs`: contains only execution logs where the execution on Aptos and Movement succeeded.
- `E_BS_diff_logs`: contains logs from `E_BS_logs` filtered for differences in execution outputs (events, changes).
- `E_BF_logs`: contains only execution logs where the execution on Aptos and Movement failed.
- `E_BF_diff_logs`: contains logs from `E_BF_logs` filtered for differences in execution errors.

### Execution failure locations
- `E_AF_entry`: contains a unique sorted list of all transaction entry functions where the execution failed.
- `E_AF_entry_freq`: same as `E_AF_entry` but with failure occurrence frequencies.
- `E_AF_abort`: contains a unique sorted list of all functions where the execution has been aborted.
- `E_AF_abort_freq`: same as `E_AF_abort` but with abort occurrence frequencies.

### Statistics
- `S_logs_stats`: contains a report with submission statistics.
- `E_logs_stats`: contains a report with execution statistics.

**Example submission statistics:**
```
Submission Statistics Report
============================

Base file: S_logs
Total submitted transactions: 998

Breakdown by category:
----------------------
Both succeeded: 975 (97.69%)
Both failed: 0 (0%)
Aptos submission failed: 23 (2.30%)
Movement submission failed: 0 (0%)
```

**Example submission statistics:**
```
Execution Statistics Report
===========================

Base file: E_logs
Total executed transactions: 975

Breakdown by category:
----------------------
Both succeeded: 893 (91.58%). Different outputs (events, changes): 5.
Both failed: 63 (6.46%). Different errors: 15
Aptos execution failed: 19 (1.94%)
Movement execution failed: 0 (0%)
```

# Testing
1. Prepare the testing environment with a Movement full-node and an Aptos node.
2. Run the replay validation tool and redirect the log output to a file.
3. Execute the shell script with the logs from the validation tool.

# Outstanding issues
None.