### PR TITLE
ci: bind workflow inputs via env before shell

### DIFF
--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -61,5 +61,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       
       - name: Build and push container tags
+        env:
+          CONTAINER_NAME: ${{ inputs.container_name }}
         run: |
-          ./scripts/docker/build-push-container -n ${{ inputs.container_name }}
+          ./scripts/docker/build-push-container -n "$CONTAINER_NAME"

--- a/.github/workflows/build-push-manifest.yml
+++ b/.github/workflows/build-push-manifest.yml
@@ -45,5 +45,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       
       - name: Build and push container tags
+        env:
+          CONTAINER_NAME: ${{ inputs.container_name }}
         run: |
-          ./scripts/docker/build-push-manifest -n ${{ inputs.container_name }}
+          ./scripts/docker/build-push-manifest -n "$CONTAINER_NAME"

--- a/.github/workflows/handle-target-comment.yml
+++ b/.github/workflows/handle-target-comment.yml
@@ -24,8 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Output the comment
+        env:
+          COMMENT: ${{ github.event.inputs.comment }}
         run: |
-         echo "Comment was: ${{ github.event.inputs.comment }}"
+         echo "Comment was: $COMMENT"
     
   manage-infra-pr:
     if: startsWith(github.event.inputs.comment, 'gali')
@@ -36,15 +38,19 @@ jobs:
 
       - name: Extract comment ID
         id: extract-comment-id
+        env:
+          HTML_URL: ${{ github.event.inputs.html_url }}
         run: |
-          comment_url="${{ github.event.inputs.html_url }}"
+          comment_url="$HTML_URL"
           comment_id=$(basename "$comment_url")
           echo "::set-output name=comment_id::$comment_id"
 
       - name: Extract repository name
         id: gali-id
+        env:
+          ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
         run: |
-          echo "GALI_ID=${{ github.repository }}/${{ github.event.inputs.issue_number }}/${{ github.ref_name }}" >> $GITHUB_ENV
+          echo "GALI_ID=${{ github.repository }}/$ISSUE_NUMBER/${{ github.ref_name }}" >> $GITHUB_ENV
           echo "GALI_SHA=${{ github.sha }}" >> $GITHUB_ENV
 
       - name: Create PR in Infra Repo if not exist

--- a/.github/workflows/tag-semantic-version.yml
+++ b/.github/workflows/tag-semantic-version.yml
@@ -54,8 +54,11 @@ jobs:
           git fetch --tags
 
       - name: Bump Version
+        env:
+          BUMP_TYPE: ${{ inputs.bump_type }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          ./scripts/devops/tag-semantic-release ${{ inputs.bump_type }} ${{ inputs.dry_run }}
+          ./scripts/devops/tag-semantic-release "$BUMP_TYPE" "$DRY_RUN"
       
       - name: Push commit and tags
         run: |


### PR DESCRIPTION
## Summary
Bind `inputs.*` / `github.event.inputs.*` into step `env:` before shell use in:
- `build-push-container`
- `build-push-manifest`
- `tag-semantic-version`
- `handle-target-comment`

Keeps `${{ }}` expansions out of `run:` scripts. `if:` conditions are unchanged.

## Test plan
- [ ] Confirm workflow YAML still validates
- [ ] Optional: re-run a container/manifest or tag workflow that consumes these inputs

Made with [Cursor](https://cursor.com)